### PR TITLE
divide cache tokens into reading and writing

### DIFF
--- a/src/grasp_agents/litellm/completion_converters.py
+++ b/src/grasp_agents/litellm/completion_converters.py
@@ -9,21 +9,28 @@ from .message_converters import from_api_assistant_message
 
 def from_api_completion_usage(api_usage: LiteLLMUsage) -> Usage:
     reasoning_tokens = None
-    cached_tokens = None
+    cached_reading_tokens = None
+    cached_writing_tokens = None
 
     if api_usage.completion_tokens_details is not None:
         reasoning_tokens = api_usage.completion_tokens_details.reasoning_tokens
     if api_usage.prompt_tokens_details is not None:
-        cached_tokens = api_usage.prompt_tokens_details.cached_tokens
+        cached_reading_tokens = api_usage.prompt_tokens_details.cached_tokens
+        cached_writing_tokens = api_usage.prompt_tokens_details.cache_creation_tokens
 
-    input_tokens = max(api_usage.prompt_tokens - (cached_tokens or 0), 0)
-    output_tokens = max(api_usage.completion_tokens - (reasoning_tokens or 0), 0)
+    input_tokens = max(
+        api_usage.prompt_tokens - (cached_reading_tokens or 0), 0
+    )
+    output_tokens = max(
+        api_usage.completion_tokens - (reasoning_tokens or 0), 0
+    )
 
     return Usage(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         reasoning_tokens=reasoning_tokens,
-        cached_tokens=cached_tokens,
+        cached_reading_tokens=cached_reading_tokens,
+        cached_writing_tokens=cached_writing_tokens,
     )
 
 

--- a/src/grasp_agents/openai/completions/completion_converters.py
+++ b/src/grasp_agents/openai/completions/completion_converters.py
@@ -6,21 +6,21 @@ from .message_converters import from_api_assistant_message
 
 def from_api_completion_usage(api_usage: OpenAIUsage) -> Usage:
     reasoning_tokens = None
-    cached_tokens = None
+    cached_reading_tokens = None
 
     if api_usage.completion_tokens_details is not None:
         reasoning_tokens = api_usage.completion_tokens_details.reasoning_tokens
     if api_usage.prompt_tokens_details is not None:
-        cached_tokens = api_usage.prompt_tokens_details.cached_tokens
+        cached_reading_tokens = api_usage.prompt_tokens_details.cached_tokens
 
-    input_tokens = max(api_usage.prompt_tokens - (cached_tokens or 0), 0)
+    input_tokens = max(api_usage.prompt_tokens - (cached_reading_tokens or 0), 0)
     output_tokens = max(api_usage.completion_tokens - (reasoning_tokens or 0), 0)
 
     return Usage(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         reasoning_tokens=reasoning_tokens,
-        cached_tokens=cached_tokens,
+        cached_reading_tokens=cached_reading_tokens,
     )
 
 

--- a/src/grasp_agents/openai/responses/completion_converters.py
+++ b/src/grasp_agents/openai/responses/completion_converters.py
@@ -9,12 +9,26 @@ from .message_converters import from_api_assistant_message
 
 
 def from_response_usage(raw_usage: ResponseUsage) -> Usage:
+    reasoning_tokens = None
+    cached_reading_tokens = None
+
+    if raw_usage.output_tokens_details is not None:
+        reasoning_tokens = raw_usage.output_tokens_details.reasoning_tokens
+    if raw_usage.input_tokens_details is not None:
+        cached_reading_tokens = raw_usage.input_tokens_details.cached_tokens
+
+    input_tokens = max(
+        raw_usage.input_tokens - (cached_reading_tokens or 0), 0
+    )
+    output_tokens = max(
+        raw_usage.output_tokens - (reasoning_tokens or 0), 0
+    )
+
     return Usage(
-        input_tokens=raw_usage.input_tokens,
-        output_tokens=raw_usage.output_tokens
-        - raw_usage.output_tokens_details.reasoning_tokens,
-        reasoning_tokens=raw_usage.output_tokens_details.reasoning_tokens,
-        cached_tokens=raw_usage.input_tokens_details.cached_tokens,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        reasoning_tokens=reasoning_tokens,
+        cached_reading_tokens=cached_reading_tokens,
     )
 
 

--- a/src/grasp_agents/printer.py
+++ b/src/grasp_agents/printer.py
@@ -187,9 +187,13 @@ class Printer:
 
         # Usage
         if usage is not None:
-            usage_str = f"I/O/R/C tokens: {usage.input_tokens}/{usage.output_tokens}"
+            usage_str = (
+                f"I/O/R/CR/CW tokens: "
+                f"{usage.input_tokens}/{usage.output_tokens}"
+            )
             usage_str += f"/{usage.reasoning_tokens or '-'}"
-            usage_str += f"/{usage.cached_tokens or '-'}"
+            usage_str += f"/{usage.cached_reading_tokens or '-'}"
+            usage_str += f"/{usage.cached_writing_tokens or '-'}"
 
             out += f"\n------------------------------------\n{usage_str}\n"
 

--- a/src/grasp_agents/typing/completion.py
+++ b/src/grasp_agents/typing/completion.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, Literal, TypeAlias
+from typing import Any, Literal, TypeAlias, overload
 from uuid import uuid4
 
 from litellm.types.utils import ChoiceLogprobs as LiteLLMChoiceLogprobs
@@ -17,36 +17,42 @@ class Usage(BaseModel):
     input_tokens: NonNegativeInt = 0
     output_tokens: NonNegativeInt = 0
     reasoning_tokens: NonNegativeInt | None = None
-    cached_tokens: NonNegativeInt | None = None
+    cached_reading_tokens: NonNegativeInt | None = None
+    cached_writing_tokens: NonNegativeInt | None = None
     cost: NonNegativeFloat | None = None
 
-    def __add__(self, add_usage: "Usage") -> "Usage":
-        input_tokens = self.input_tokens + add_usage.input_tokens
-        output_tokens = self.output_tokens + add_usage.output_tokens
+    @overload
+    @staticmethod
+    def _add_opt(
+        a: NonNegativeInt | None, b: NonNegativeInt | None
+    ) -> NonNegativeInt | None: ...
 
-        if self.reasoning_tokens is not None or add_usage.reasoning_tokens is not None:
-            reasoning_tokens = (self.reasoning_tokens or 0) + (
-                add_usage.reasoning_tokens or 0
-            )
-        else:
-            reasoning_tokens = None
+    @overload
+    @staticmethod
+    def _add_opt(
+        a: NonNegativeFloat | None, b: NonNegativeFloat | None
+    ) -> NonNegativeFloat | None: ...
 
-        if self.cached_tokens is not None or add_usage.cached_tokens is not None:
-            cached_tokens = (self.cached_tokens or 0) + (add_usage.cached_tokens or 0)
-        else:
-            cached_tokens = None
+    @staticmethod
+    def _add_opt(a: float | None, b: float | None) -> int | float | None:
+        if a is not None or b is not None:
+            return (a or 0) + (b or 0)
+        return None
 
-        if self.cost is not None or add_usage.cost is not None:
-            cost = (self.cost or 0.0) + (add_usage.cost or 0.0)
-        else:
-            cost = None
-
+    def __add__(self, other: "Usage") -> "Usage":
         return Usage(
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            reasoning_tokens=reasoning_tokens,
-            cached_tokens=cached_tokens,
-            cost=cost,
+            input_tokens=self.input_tokens + other.input_tokens,
+            output_tokens=self.output_tokens + other.output_tokens,
+            reasoning_tokens=self._add_opt(
+                self.reasoning_tokens, other.reasoning_tokens
+            ),
+            cached_reading_tokens=self._add_opt(
+                self.cached_reading_tokens, other.cached_reading_tokens
+            ),
+            cached_writing_tokens=self._add_opt(
+                self.cached_writing_tokens, other.cached_writing_tokens
+            ),
+            cost=self._add_opt(self.cost, other.cost),
         )
 
 

--- a/src/grasp_agents/usage_tracker.py
+++ b/src/grasp_agents/usage_tracker.py
@@ -62,12 +62,15 @@ class UsageTracker(BaseModel):
         logger.debug("\n-------------------")
 
         token_usage_str = (
-            f"Total I/O/(R)/(C) tokens: {usage.input_tokens}/{usage.output_tokens}"
+            f"Total I/O/(R)/(CR)/(CW) tokens: "
+            f"{usage.input_tokens}/{usage.output_tokens}"
         )
         if usage.reasoning_tokens is not None:
             token_usage_str += f"/{usage.reasoning_tokens}"
-        if usage.cached_tokens is not None:
-            token_usage_str += f"/{usage.cached_tokens}"
+        if usage.cached_reading_tokens is not None:
+            token_usage_str += f"/{usage.cached_reading_tokens}"
+        if usage.cached_writing_tokens is not None:
+            token_usage_str += f"/{usage.cached_writing_tokens}"
         logger.debug(colored(token_usage_str, "light_grey"))
 
         if usage.cost is not None:
@@ -95,8 +98,9 @@ class UsageTracker(BaseModel):
             else 0.0
         )
         cached_cost: float = (
-            cached_discount * in_rate * usage.cached_tokens
-            if (usage.cached_tokens is not None) and (cached_discount is not None)
+            cached_discount * in_rate * usage.cached_reading_tokens
+            if (usage.cached_reading_tokens is not None)
+            and (cached_discount is not None)
             else 0.0
         )
         usage.cost = (input_cost + output_cost + reasoning_cost + cached_cost) / 1e6


### PR DESCRIPTION
  Replaces Usage.cached_tokens with separate cached_reading_tokens and cached_writing_tokens (cache hits vs cache creation) across LiteLLM, OpenAI Completions, OpenAI
  Responses converters, plus printer/usage tracker/summation logic. Also adds None-safety to the Responses converter and refactors Usage.__add__ via a _add_opt helper.
