### PR TITLE
Iana/pro 2063 investigate why streamed thinking disappeared again in

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grasp_agents"
-version = "0.6.48"
+version = "0.6.49"
 description = "Grasp Agents Library"
 readme = "README.md"
 requires-python = ">=3.11.4,<4"

--- a/src/grasp_agents/litellm/__init__.py
+++ b/src/grasp_agents/litellm/__init__.py
@@ -101,6 +101,6 @@ from openai.types.shared_params.function_definition import (
     FunctionDefinition as OpenAIFunctionDefinition,
 )
 
-from .lite_llm import LiteLLM, LiteLLMModel, LiteLLMSettings
+from .lite_llm import LiteLLM, LiteLLMModelName, LiteLLMSettings
 
-__all__ = ["LiteLLM", "LiteLLMModel", "LiteLLMSettings"]
+__all__ = ["LiteLLM", "LiteLLMModelName", "LiteLLMSettings"]

--- a/src/grasp_agents/litellm/__init__.py
+++ b/src/grasp_agents/litellm/__init__.py
@@ -101,6 +101,6 @@ from openai.types.shared_params.function_definition import (
     FunctionDefinition as OpenAIFunctionDefinition,
 )
 
-from .lite_llm import LiteLLM, LiteLLMSettings
+from .lite_llm import LiteLLM, LiteLLMModel, LiteLLMSettings
 
-__all__ = ["LiteLLM", "LiteLLMSettings"]
+__all__ = ["LiteLLM", "LiteLLMModel", "LiteLLMSettings"]

--- a/src/grasp_agents/litellm/lite_llm.py
+++ b/src/grasp_agents/litellm/lite_llm.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from collections.abc import AsyncGenerator, AsyncIterator, Mapping
+from collections.abc import AsyncGenerator, AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, cast
 
@@ -43,6 +43,12 @@ class LiteLLMSettings(OpenAILLMSettings, total=False):
     thinking: AnthropicThinkingParam | None
 
 
+@dataclass(frozen=True)
+class LiteLLMModel:
+    name: str
+    settings: dict[str, Any] = field(default_factory=dict[str, Any])
+
+
 LiteLLMModelName = str
 
 
@@ -61,10 +67,10 @@ class LiteLLM(CloudLLM):
     # Mock LLM response for testing
     mock_response: str | None = None
     # Fallback models to use if the main model fails
-    fallbacks: list[LiteLLMModelName] = field(default_factory=list[LiteLLMModelName])
-    model_specific_settings: dict[str, dict[str, Any]] = field(
-        default_factory=dict[str, dict[str, Any]]
+    fallbacks: Sequence[LiteLLMModelName | LiteLLMModel] = field(
+        default_factory=list[LiteLLMModelName | LiteLLMModel]
     )
+    main_model_settings: dict[str, Any] = field(default_factory=dict[str, Any])
     # Mock falling back to other models in the fallbacks list for testing
     mock_testing_fallbacks: bool = False
 
@@ -75,6 +81,8 @@ class LiteLLM(CloudLLM):
     )
 
     def __post_init__(self) -> None:
+        main = LiteLLMModel(self.model_name, self.main_model_settings)
+        fbs = [_coerce(fb) for fb in self.fallbacks]
         super().__post_init__()
 
         self._lite_llm_completion_params.update(
@@ -127,23 +135,17 @@ class LiteLLM(CloudLLM):
                 "Custom HTTP clients are not yet supported when using LiteLLM."
             )
 
-        def _build_litellm_params(model: str) -> dict[str, Any]:
-            params: dict[str, Any] = {"model": model}
-            params.update(self.model_specific_settings.get(model, {}))
-            return params
+        def _build_litellm_params(model: LiteLLMModel) -> dict[str, Any]:
+            return {"model": model.name, **model.settings}
 
-        main_litellm_model = {
-            "model_name": self.model_name,
-            "litellm_params": _build_litellm_params(self.model_name),
-        }
-        fallback_litellm_models = [
-            {"model_name": fb, "litellm_params": _build_litellm_params(fb)}
-            for fb in self.fallbacks
+        model_list = [
+            {"model_name": m.name, "litellm_params": _build_litellm_params(m)}
+            for m in (main, *fbs)
         ]
 
         _router = Router(
-            model_list=[main_litellm_model, *fallback_litellm_models],
-            fallbacks=[{self.model_name: self.fallbacks}],
+            model_list=model_list,
+            fallbacks=[{main.name: [fb.name for fb in fbs]}],
             num_retries=self.max_client_retries,
             timeout=self.client_timeout,
         )
@@ -276,3 +278,7 @@ class LiteLLM(CloudLLM):
         yield CompletionChunkEvent(
             data=completion_chunk, src_name=proc_name, call_id=call_id
         )
+
+
+def _coerce(value: str | LiteLLMModel) -> LiteLLMModel:
+    return value if isinstance(value, LiteLLMModel) else LiteLLMModel(value)

--- a/src/grasp_agents/litellm/lite_llm.py
+++ b/src/grasp_agents/litellm/lite_llm.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from collections.abc import AsyncGenerator, AsyncIterator, Mapping, Sequence
+from collections.abc import AsyncGenerator, AsyncIterator, Mapping
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, cast
 
@@ -43,12 +43,6 @@ class LiteLLMSettings(OpenAILLMSettings, total=False):
     thinking: AnthropicThinkingParam | None
 
 
-@dataclass(frozen=True)
-class LiteLLMModel:
-    name: str
-    settings: dict[str, Any] = field(default_factory=dict[str, Any])
-
-
 LiteLLMModelName = str
 
 
@@ -67,10 +61,10 @@ class LiteLLM(CloudLLM):
     # Mock LLM response for testing
     mock_response: str | None = None
     # Fallback models to use if the main model fails
-    fallbacks: Sequence[LiteLLMModelName | LiteLLMModel] = field(
-        default_factory=list[LiteLLMModelName | LiteLLMModel]
+    fallbacks: list[dict[LiteLLMModelName, list[LiteLLMModelName]]] = field(
+        default_factory=list[dict[LiteLLMModelName, list[LiteLLMModelName]]]
     )
-    main_model_settings: dict[str, Any] = field(default_factory=dict[str, Any])
+    llm_group_settings: dict[LiteLLMModelName, LiteLLMSettings] | None = None
     # Mock falling back to other models in the fallbacks list for testing
     mock_testing_fallbacks: bool = False
 
@@ -81,8 +75,12 @@ class LiteLLM(CloudLLM):
     )
 
     def __post_init__(self) -> None:
-        main = LiteLLMModel(self.model_name, self.main_model_settings)
-        fbs = [_coerce(fb) for fb in self.fallbacks]
+        if self.llm_settings is not None and self.llm_group_settings is not None:
+            raise ValueError(
+                "Provide either `llm_settings` (common to all models) or "
+                "`llm_group_settings` (per-model, must include `model_name` and "
+                "every fallback target as keys). Not both."
+            )
         super().__post_init__()
 
         self._lite_llm_completion_params.update(
@@ -135,17 +133,48 @@ class LiteLLM(CloudLLM):
                 "Custom HTTP clients are not yet supported when using LiteLLM."
             )
 
-        def _build_litellm_params(model: LiteLLMModel) -> dict[str, Any]:
-            return {"model": model.name, **model.settings}
+        def _build_litellm_params(
+            model_name: LiteLLMModelName, settings: LiteLLMSettings | None = None
+        ) -> dict[str, Any]:
+            if settings is not None:
+                return {"model": model_name, **settings}
+            return {"model": model_name}
 
-        model_list = [
-            {"model_name": m.name, "litellm_params": _build_litellm_params(m)}
-            for m in (main, *fbs)
-        ]
+        fallback_targets: set[LiteLLMModelName] = {
+            n for fb in self.fallbacks for names in fb.values() for n in names
+        }
+        routed_models = {self.model_name} | fallback_targets
+
+        if self.llm_group_settings is not None:
+            missing = routed_models - set(self.llm_group_settings)
+            extra = set(self.llm_group_settings) - routed_models
+            if missing or extra:
+                raise ValueError(
+                    "`llm_group_settings` must contain exactly the routed "
+                    "models (`model_name` + every fallback target). "
+                    f"Missing: {sorted(missing) or 'none'}. "
+                    f"Unexpected: {sorted(extra) or 'none'}. "
+                    "For models that don't need specific settings, pass `{}`."
+                )
+            model_list = [
+                {
+                    "model_name": name,
+                    "litellm_params": _build_litellm_params(name, settings),
+                }
+                for name, settings in self.llm_group_settings.items()
+            ]
+        else:
+            model_list = [
+                {
+                    "model_name": name,
+                    "litellm_params": _build_litellm_params(name),
+                }
+                for name in routed_models
+            ]
 
         _router = Router(
             model_list=model_list,
-            fallbacks=[{main.name: [fb.name for fb in fbs]}],
+            fallbacks=self.fallbacks,
             num_retries=self.max_client_retries,
             timeout=self.client_timeout,
         )
@@ -278,7 +307,3 @@ class LiteLLM(CloudLLM):
         yield CompletionChunkEvent(
             data=completion_chunk, src_name=proc_name, call_id=call_id
         )
-
-
-def _coerce(value: str | LiteLLMModel) -> LiteLLMModel:
-    return value if isinstance(value, LiteLLMModel) else LiteLLMModel(value)

--- a/src/grasp_agents/litellm/lite_llm.py
+++ b/src/grasp_agents/litellm/lite_llm.py
@@ -62,6 +62,9 @@ class LiteLLM(CloudLLM):
     mock_response: str | None = None
     # Fallback models to use if the main model fails
     fallbacks: list[LiteLLMModelName] = field(default_factory=list[LiteLLMModelName])
+    model_specific_settings: dict[str, dict[str, Any]] = field(
+        default_factory=dict[str, dict[str, Any]]
+    )
     # Mock falling back to other models in the fallbacks list for testing
     mock_testing_fallbacks: bool = False
 
@@ -124,12 +127,18 @@ class LiteLLM(CloudLLM):
                 "Custom HTTP clients are not yet supported when using LiteLLM."
             )
 
+        def _build_litellm_params(model: str) -> dict[str, Any]:
+            params: dict[str, Any] = {"model": model}
+            params.update(self.model_specific_settings.get(model, {}))
+            return params
+
         main_litellm_model = {
             "model_name": self.model_name,
-            "litellm_params": {"model": self.model_name},
+            "litellm_params": _build_litellm_params(self.model_name),
         }
         fallback_litellm_models = [
-            {"model_name": fb, "litellm_params": {"model": fb}} for fb in self.fallbacks
+            {"model_name": fb, "litellm_params": _build_litellm_params(fb)}
+            for fb in self.fallbacks
         ]
 
         _router = Router(

--- a/src/grasp_agents/litellm/lite_llm.py
+++ b/src/grasp_agents/litellm/lite_llm.py
@@ -61,9 +61,7 @@ class LiteLLM(CloudLLM):
     # Mock LLM response for testing
     mock_response: str | None = None
     # Fallback models to use if the main model fails
-    fallbacks: list[dict[LiteLLMModelName, list[LiteLLMModelName]]] = field(
-        default_factory=list[dict[LiteLLMModelName, list[LiteLLMModelName]]]
-    )
+    fallbacks: list[LiteLLMModelName] = field(default_factory=list[LiteLLMModelName])
     llm_group_settings: dict[LiteLLMModelName, LiteLLMSettings] | None = None
     # Mock falling back to other models in the fallbacks list for testing
     mock_testing_fallbacks: bool = False
@@ -140,10 +138,7 @@ class LiteLLM(CloudLLM):
                 return {"model": model_name, **settings}
             return {"model": model_name}
 
-        fallback_targets: set[LiteLLMModelName] = {
-            n for fb in self.fallbacks for names in fb.values() for n in names
-        }
-        routed_models = {self.model_name} | fallback_targets
+        routed_models = {self.model_name} | set(self.fallbacks)
 
         if self.llm_group_settings is not None:
             missing = routed_models - set(self.llm_group_settings)
@@ -174,7 +169,7 @@ class LiteLLM(CloudLLM):
 
         _router = Router(
             model_list=model_list,
-            fallbacks=self.fallbacks,
+            fallbacks=[{self.model_name: self.fallbacks}],
             num_retries=self.max_client_retries,
             timeout=self.client_timeout,
         )

--- a/src/grasp_agents/typing/content.py
+++ b/src/grasp_agents/typing/content.py
@@ -22,7 +22,7 @@ class ImageData(BaseModel):
     base64: str | None = None
 
     # Supported by OpenAI API
-    detail: ImageDetail = "high"
+    detail: ImageDetail = "auto"
 
     @classmethod
     def from_base64(cls, base64_encoding: str, **kwargs: Any) -> "ImageData":

--- a/tests/test_litellm_model_specific_settings.py
+++ b/tests/test_litellm_model_specific_settings.py
@@ -1,23 +1,22 @@
 """Tests for ``LiteLLM`` per-model settings.
 
-Pins how settings flow into each Router ``model_list`` entry's
-``litellm_params`` after the move from a string-keyed
-``model_specific_settings`` dict to inline declarations:
+Pins the contract of the two mutually-exclusive ways to configure settings:
 
-- ``main_model_settings`` is merged into the main entry's ``litellm_params``
-  on top of ``{"model": model_name}``.
-- A fallback declared as a bare string yields ``{"model": name}`` and nothing
-  else (env-var auth path).
-- A fallback declared as ``LiteLLMModel(name, settings)`` carries its
-  per-model settings inline; they reach only that fallback's
-  ``litellm_params``.
-- Settings on one model never bleed into another.
-- The Router's ``fallbacks`` list contains the resolved names regardless of
-  whether each fallback was declared as a plain string or a ``LiteLLMModel``.
-- The common ``llm_settings`` (completion-time layer) is unaffected by the
-  per-model (routing-time) layer — they live on different code paths.
+- ``llm_settings``: a single settings dict applied to all models (common,
+  completion-time layer — flows through the Router as call kwargs).
+- ``llm_group_settings``: a per-model settings dict ``{model_name: settings}``
+  baked into each Router ``model_list`` entry's ``litellm_params``. When
+  provided, it must contain *exactly* the routed models (``model_name`` plus
+  every fallback target) — no missing keys, no extras. ``{}`` is the
+  explicit way to say "this model is routed but needs no specific settings."
 
-The Router itself adds defaulted keys (e.g. ``use_in_pass_through``) on top
+Supplying both raises ``ValueError``. Supplying neither leaves every Router
+entry with only ``{"model": name}``.
+
+Fallbacks follow litellm Router's native shape:
+``[{main_name: [fb1, fb2, ...]}]``.
+
+The Router itself adds defaulted keys (``use_in_pass_through``, etc.) on top
 of what we pass, so assertions check that *our* keys are present with the
 right values rather than equality on the whole ``litellm_params`` dict.
 """
@@ -32,7 +31,7 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
-from grasp_agents.litellm.lite_llm import LiteLLM, LiteLLMModel
+from grasp_agents.litellm.lite_llm import LiteLLM
 
 
 def _build_llm(**overrides: Any) -> LiteLLM:
@@ -49,187 +48,234 @@ def _params_by_name(llm: LiteLLM) -> dict[str, dict[str, Any]]:
     return {entry["model_name"]: entry["litellm_params"] for entry in model_list}
 
 
-def _router_fallback_names(llm: LiteLLM) -> list[str]:
-    """Router stores fallbacks as ``[{main_name: [fb1, fb2, ...]}]`` — extract
-    the ordered fallback names so tests can assert on them directly.
+class TestPlainConstruction(unittest.TestCase):
+    """No settings, no fallbacks: a single Router entry for the main model
+    with only ``{"model": name}`` in its ``litellm_params``."""
 
-    Raises ``AssertionError`` explicitly (not via bare ``assert``) so the
-    invariant holds under ``python -O``."""
-    fallbacks_cfg: list[dict[str, list[str]]] = llm.router.fallbacks  # type: ignore[assignment]
-    if len(fallbacks_cfg) != 1:
-        raise AssertionError(
-            f"Expected exactly one fallback group, got {len(fallbacks_cfg)}: "
-            f"{fallbacks_cfg!r}"
-        )
-    [(_, names)] = fallbacks_cfg[0].items()
-    return list(names)
-
-
-class TestLiteLLMModelClass(unittest.TestCase):
-    def test_default_settings_is_empty(self):
-        m = LiteLLMModel("gpt-4o")
-        self.assertEqual(m.settings, {})
-
-    def test_settings_carried_on_instance(self):
-        m = LiteLLMModel("gpt-4o", {"api_key": "k", "api_base": "b"})
-        self.assertEqual(m.name, "gpt-4o")
-        self.assertEqual(m.settings, {"api_key": "k", "api_base": "b"})
-
-
-class TestMainModelSettings(unittest.TestCase):
-    def test_default_main_model_settings_is_empty_dict(self):
+    def test_default_llm_settings_is_none(self):
         llm = _build_llm()
-        self.assertEqual(llm.main_model_settings, {})
+        self.assertIsNone(llm.llm_settings)
+
+    def test_default_llm_group_settings_is_none(self):
+        llm = _build_llm()
+        self.assertIsNone(llm.llm_group_settings)
 
     def test_default_fallbacks_is_empty_list(self):
         llm = _build_llm()
         self.assertEqual(llm.fallbacks, [])
 
-    def test_main_entry_has_only_model_when_no_settings(self):
+    def test_main_model_is_only_router_entry(self):
         llm = _build_llm()
-        params = _params_by_name(llm)["gpt-4o-mini"]
-        self.assertEqual(params["model"], "gpt-4o-mini")
-        self.assertNotIn("api_key", params)
-        self.assertNotIn("api_base", params)
-
-    def test_main_model_settings_flow_into_main_entry(self):
-        llm = _build_llm(
-            main_model_settings={"api_key": "key-main", "api_base": "https://main"}
-        )
-        params = _params_by_name(llm)["gpt-4o-mini"]
-        self.assertEqual(params["model"], "gpt-4o-mini")
-        self.assertEqual(params["api_key"], "key-main")
-        self.assertEqual(params["api_base"], "https://main")
-
-    def test_main_settings_do_not_bleed_into_fallback(self):
-        llm = _build_llm(
-            main_model_settings={"api_key": "key-main"},
-            fallbacks=["gpt-4o"],
-        )
         params = _params_by_name(llm)
-        self.assertEqual(params["gpt-4o-mini"]["api_key"], "key-main")
-        self.assertNotIn("api_key", params["gpt-4o"])
-
-    def test_main_model_settings_can_override_seeded_model(self):
-        # Implementation builds ``{"model": name}`` then spreads
-        # ``main_model_settings``, so a deliberate ``"model"`` override (e.g.
-        # routing to a deployment-qualified id) wins.
-        llm = _build_llm(main_model_settings={"model": "azure/my-deployment"})
-        params = _params_by_name(llm)["gpt-4o-mini"]
-        self.assertEqual(params["model"], "azure/my-deployment")
+        self.assertEqual(set(params), {"gpt-4o-mini"})
+        self.assertEqual(params["gpt-4o-mini"]["model"], "gpt-4o-mini")
+        self.assertNotIn("api_key", params["gpt-4o-mini"])
 
 
-class TestFallbackDeclarations(unittest.TestCase):
-    def test_bare_string_fallback_has_no_extra_settings(self):
-        llm = _build_llm(fallbacks=["gpt-4o"])
-        params = _params_by_name(llm)["gpt-4o"]
-        self.assertEqual(params["model"], "gpt-4o")
-        self.assertNotIn("api_key", params)
-        self.assertNotIn("api_base", params)
+class TestLlmSettingsCommon(unittest.TestCase):
+    """``llm_settings`` is the common (completion-time) layer. It does not
+    appear in per-model ``litellm_params`` — it flows through the call path
+    instead. The Router's ``model_list`` should contain only ``{"model": ...}``
+    for each entry."""
 
-    def test_litellm_model_fallback_carries_its_settings(self):
-        llm = _build_llm(
-            fallbacks=[LiteLLMModel("gpt-4o", {"api_key": "fb-key"})],
-        )
-        params = _params_by_name(llm)["gpt-4o"]
-        self.assertEqual(params["model"], "gpt-4o")
-        self.assertEqual(params["api_key"], "fb-key")
-
-    def test_mixed_fallback_forms_coexist(self):
-        llm = _build_llm(
-            fallbacks=[
-                "gpt-4o",
-                LiteLLMModel("claude-sonnet-4-5", {"api_key": "ant-key"}),
-                "gpt-3.5-turbo",
-            ],
-        )
-        params = _params_by_name(llm)
-        self.assertEqual(
-            set(params),
-            {"gpt-4o-mini", "gpt-4o", "claude-sonnet-4-5", "gpt-3.5-turbo"},
-        )
-        self.assertNotIn("api_key", params["gpt-4o"])
-        self.assertEqual(params["claude-sonnet-4-5"]["api_key"], "ant-key")
-        self.assertNotIn("api_key", params["gpt-3.5-turbo"])
-
-    def test_per_fallback_settings_are_independent(self):
-        llm = _build_llm(
-            fallbacks=[
-                LiteLLMModel("gpt-4o", {"api_key": "k1"}),
-                LiteLLMModel(
-                    "claude-sonnet-4-5",
-                    {"api_key": "k2", "api_base": "https://anthropic"},
-                ),
-            ],
-        )
-        params = _params_by_name(llm)
-        self.assertEqual(params["gpt-4o"]["api_key"], "k1")
-        self.assertNotIn("api_base", params["gpt-4o"])
-        self.assertEqual(params["claude-sonnet-4-5"]["api_key"], "k2")
-        self.assertEqual(params["claude-sonnet-4-5"]["api_base"], "https://anthropic")
-
-    def test_fallback_settings_do_not_bleed_into_main(self):
-        llm = _build_llm(
-            fallbacks=[LiteLLMModel("gpt-4o", {"api_key": "fb-only"})],
-        )
-        main_params = _params_by_name(llm)["gpt-4o-mini"]
-        self.assertNotIn("api_key", main_params)
-
-
-class TestRouterFallbackList(unittest.TestCase):
-    def test_router_fallback_names_from_bare_strings(self):
-        llm = _build_llm(fallbacks=["gpt-4o", "gpt-3.5-turbo"])
-        self.assertEqual(_router_fallback_names(llm), ["gpt-4o", "gpt-3.5-turbo"])
-
-    def test_router_fallback_names_from_litellm_models(self):
-        llm = _build_llm(
-            fallbacks=[
-                LiteLLMModel("gpt-4o", {"api_key": "k"}),
-                LiteLLMModel("claude-sonnet-4-5"),
-            ],
-        )
-        self.assertEqual(
-            _router_fallback_names(llm), ["gpt-4o", "claude-sonnet-4-5"]
-        )
-
-    def test_router_fallback_names_preserve_order_in_mixed_input(self):
-        llm = _build_llm(
-            fallbacks=[
-                "gpt-3.5-turbo",
-                LiteLLMModel("claude-sonnet-4-5", {"api_key": "k"}),
-                "gpt-4o",
-            ],
-        )
-        self.assertEqual(
-            _router_fallback_names(llm),
-            ["gpt-3.5-turbo", "claude-sonnet-4-5", "gpt-4o"],
-        )
-
-
-class TestSettingsLayeringIsolation(unittest.TestCase):
-    """Pins that the per-model (routing-time) layer doesn't disturb the
-    common ``llm_settings`` (completion-time) layer — they live on different
-    code paths and shouldn't cross-contaminate."""
-
-    def test_llm_settings_does_not_leak_into_per_model_litellm_params(self):
-        llm = _build_llm(
-            llm_settings={"temperature": 0.42},
-            main_model_settings={"api_key": "key-main"},
-            fallbacks=[LiteLLMModel("gpt-4o", {"api_key": "fb-k"})],
-        )
-        # llm_settings stays on the LLM instance for the completion path.
+    def test_llm_settings_stored_on_instance(self):
+        llm = _build_llm(llm_settings={"temperature": 0.42})
         self.assertIsNotNone(llm.llm_settings)
-        # Cast for the type checker — the runtime check above is what guards
-        # the test, and survives ``python -O`` (unlike a bare ``assert``).
+        # cast for the type checker; runtime guard is the assertIsNotNone above.
         llm_settings = cast("dict[str, Any]", llm.llm_settings)
         self.assertEqual(llm_settings.get("temperature"), 0.42)
-        # Per-model layer still works.
+
+    def test_llm_settings_does_not_leak_into_litellm_params(self):
+        llm = _build_llm(
+            llm_settings={"temperature": 0.42, "max_completion_tokens": 100},
+            fallbacks=[{"gpt-4o-mini": ["gpt-4o"]}],
+        )
         params = _params_by_name(llm)
-        self.assertEqual(params["gpt-4o-mini"]["api_key"], "key-main")
-        self.assertEqual(params["gpt-4o"]["api_key"], "fb-k")
-        # llm_settings does NOT leak into Router-level litellm_params.
         for entry in params.values():
             self.assertNotIn("temperature", entry)
+            self.assertNotIn("max_completion_tokens", entry)
+
+    def test_llm_settings_with_fallbacks_includes_all_routed_models(self):
+        llm = _build_llm(
+            llm_settings={"temperature": 0.5},
+            fallbacks=[{"gpt-4o-mini": ["gpt-4o", "claude-sonnet-4-5"]}],
+        )
+        params = _params_by_name(llm)
+        self.assertEqual(
+            set(params), {"gpt-4o-mini", "gpt-4o", "claude-sonnet-4-5"}
+        )
+
+
+class TestLlmGroupSettingsPerModel(unittest.TestCase):
+    """``llm_group_settings`` carries per-model settings into each entry's
+    ``litellm_params``. Settings on one model never bleed into another."""
+
+    def test_per_model_settings_reach_each_entry(self):
+        llm = _build_llm(
+            fallbacks=[{"gpt-4o-mini": ["gpt-4o"]}],
+            llm_group_settings={
+                "gpt-4o-mini": {"api_key": "K-main", "api_base": "https://main"},
+                "gpt-4o":      {"api_key": "K-fb"},
+            },
+        )
+        params = _params_by_name(llm)
+        self.assertEqual(params["gpt-4o-mini"]["api_key"], "K-main")
+        self.assertEqual(params["gpt-4o-mini"]["api_base"], "https://main")
+        self.assertEqual(params["gpt-4o"]["api_key"], "K-fb")
+        # api_base set only on main, not on fallback.
+        self.assertNotIn("api_base", params["gpt-4o"])
+
+    def test_empty_dict_means_no_settings_for_that_model(self):
+        # An empty dict is the explicit way to declare a routed model with
+        # no specific settings. The entry exists in model_list but with only
+        # ``{"model": name}``.
+        llm = _build_llm(
+            fallbacks=[{"gpt-4o-mini": ["gpt-4o"]}],
+            llm_group_settings={
+                "gpt-4o-mini": {"api_key": "K"},
+                "gpt-4o":      {},
+            },
+        )
+        params = _params_by_name(llm)
+        self.assertEqual(params["gpt-4o-mini"]["api_key"], "K")
+        self.assertEqual(params["gpt-4o"]["model"], "gpt-4o")
+        self.assertNotIn("api_key", params["gpt-4o"])
+
+    def test_per_model_settings_do_not_bleed_between_entries(self):
+        llm = _build_llm(
+            fallbacks=[{"gpt-4o-mini": ["gpt-4o", "claude-sonnet-4-5"]}],
+            llm_group_settings={
+                "gpt-4o-mini":      {"api_key": "K1"},
+                "gpt-4o":           {"api_key": "K2", "api_base": "https://b"},
+                "claude-sonnet-4-5": {},
+            },
+        )
+        params = _params_by_name(llm)
+        self.assertEqual(params["gpt-4o-mini"]["api_key"], "K1")
+        self.assertNotIn("api_base", params["gpt-4o-mini"])
+        self.assertEqual(params["gpt-4o"]["api_key"], "K2")
+        self.assertEqual(params["gpt-4o"]["api_base"], "https://b")
+        self.assertNotIn("api_key", params["claude-sonnet-4-5"])
+
+    def test_settings_can_override_seeded_model(self):
+        # The ``"model"`` key is seeded as the entry name and then any
+        # per-model settings are spread on top, so a deliberate ``"model"``
+        # override (e.g. routing to a deployment-qualified id) wins.
+        llm = _build_llm(
+            llm_group_settings={
+                "gpt-4o-mini": {"model": "azure/my-deployment"},
+            },
+        )
+        params = _params_by_name(llm)
+        self.assertEqual(params["gpt-4o-mini"]["model"], "azure/my-deployment")
+
+
+class TestStrictValidation(unittest.TestCase):
+    """Construction must reject configurations that would silently misbehave
+    or leave the Router with missing entries."""
+
+    def test_mutex_llm_settings_and_llm_group_settings(self):
+        with self.assertRaises(ValueError) as ctx:
+            _build_llm(
+                llm_settings={"temperature": 0.5},
+                llm_group_settings={"gpt-4o-mini": {}},
+            )
+        self.assertIn("llm_settings", str(ctx.exception))
+        self.assertIn("llm_group_settings", str(ctx.exception))
+
+    def test_missing_main_model_in_group_settings(self):
+        with self.assertRaises(ValueError) as ctx:
+            _build_llm(
+                fallbacks=[{"gpt-4o-mini": ["gpt-4o"]}],
+                llm_group_settings={"gpt-4o": {}},
+            )
+        self.assertIn("Missing", str(ctx.exception))
+        self.assertIn("gpt-4o-mini", str(ctx.exception))
+
+    def test_missing_fallback_target_in_group_settings(self):
+        with self.assertRaises(ValueError) as ctx:
+            _build_llm(
+                fallbacks=[{"gpt-4o-mini": ["gpt-4o"]}],
+                llm_group_settings={"gpt-4o-mini": {}},
+            )
+        self.assertIn("Missing", str(ctx.exception))
+        self.assertIn("gpt-4o", str(ctx.exception))
+
+    def test_extra_key_in_group_settings(self):
+        with self.assertRaises(ValueError) as ctx:
+            _build_llm(
+                llm_group_settings={
+                    "gpt-4o-mini": {},
+                    "stray-model": {"api_key": "K"},
+                },
+            )
+        self.assertIn("Unexpected", str(ctx.exception))
+        self.assertIn("stray-model", str(ctx.exception))
+
+    def test_typo_reported_as_both_missing_and_extra(self):
+        # "gpt-4-mini" looks like a typo for "gpt-4o-mini". The strict check
+        # surfaces the mismatch from both sides at once so the user can see
+        # exactly what went wrong.
+        with self.assertRaises(ValueError) as ctx:
+            _build_llm(
+                llm_group_settings={"gpt-4-mini": {"api_key": "K"}},
+            )
+        msg = str(ctx.exception)
+        self.assertIn("Missing", msg)
+        self.assertIn("gpt-4o-mini", msg)
+        self.assertIn("Unexpected", msg)
+        self.assertIn("gpt-4-mini", msg)
+
+
+class TestFallbacksWithoutGroupSettings(unittest.TestCase):
+    """When ``llm_group_settings`` is not provided, the else branch builds
+    ``model_list`` from the union of the main model and every fallback
+    target. Each entry gets only ``{"model": name}`` (env-var auth path)."""
+
+    def test_model_list_includes_main_and_all_fallback_targets(self):
+        llm = _build_llm(
+            fallbacks=[{"gpt-4o-mini": ["gpt-4o", "claude-sonnet-4-5"]}],
+        )
+        params = _params_by_name(llm)
+        self.assertEqual(
+            set(params), {"gpt-4o-mini", "gpt-4o", "claude-sonnet-4-5"}
+        )
+
+    def test_each_fallback_entry_has_no_extra_settings(self):
+        llm = _build_llm(
+            fallbacks=[{"gpt-4o-mini": ["gpt-4o"]}],
+        )
+        params = _params_by_name(llm)
+        self.assertEqual(params["gpt-4o"]["model"], "gpt-4o")
+        self.assertNotIn("api_key", params["gpt-4o"])
+        self.assertNotIn("api_base", params["gpt-4o"])
+
+    def test_main_appearing_as_fallback_target_is_deduped(self):
+        # Pathological but possible: main is also listed as a fallback target
+        # somewhere. The else branch builds model_list from a set, so the
+        # entry appears exactly once.
+        llm = _build_llm(
+            fallbacks=[
+                {"gpt-4o-mini": ["gpt-4o"]},
+                # gpt-4o-mini also a fallback target in another group.
+                {"some-other": ["gpt-4o-mini"]},
+            ],
+        )
+        model_list: list[dict[str, Any]] = llm.router.model_list  # type: ignore[assignment]
+        names = [e["model_name"] for e in model_list]
+        self.assertEqual(names.count("gpt-4o-mini"), 1)
+
+
+class TestRouterFallbacksPassedThrough(unittest.TestCase):
+    """``self.fallbacks`` is passed verbatim to the Router as its native
+    fallback config. This pins that the litellm-native shape is preserved
+    end-to-end."""
+
+    def test_router_fallbacks_match_input(self):
+        fallbacks_in = [{"gpt-4o-mini": ["gpt-4o", "claude-sonnet-4-5"]}]
+        llm = _build_llm(fallbacks=fallbacks_in)
+        router_fallbacks: list[dict[str, list[str]]] = llm.router.fallbacks  # type: ignore[assignment]
+        self.assertEqual(router_fallbacks, fallbacks_in)
 
 
 if __name__ == "__main__":

--- a/tests/test_litellm_model_specific_settings.py
+++ b/tests/test_litellm_model_specific_settings.py
@@ -1,0 +1,126 @@
+"""Tests for ``LiteLLM.model_specific_settings``.
+
+Pins how per-model overrides supplied via ``model_specific_settings`` are
+merged into each Router entry's ``litellm_params``:
+
+- The main model receives its overrides on top of ``{"model": <name>}``.
+- Each fallback receives its own overrides independently.
+- A model entry that matches neither the main model nor a declared fallback is
+  silently ignored (it has no Router entry to attach to).
+- When ``model_specific_settings`` is empty, no per-model overrides leak in.
+
+The Router itself adds defaulted keys (e.g. ``use_in_pass_through``,
+``merge_reasoning_content_in_choices``) on top of what we pass, so assertions
+check that our keys are present with the right values rather than equality on
+the whole ``litellm_params`` dict.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from grasp_agents.litellm.lite_llm import LiteLLM
+
+
+def _build_llm(**overrides: Any) -> LiteLLM:
+    kwargs: dict[str, Any] = {
+        "model_name": "gpt-4o-mini",
+        "mock_response": "hi",
+    }
+    kwargs.update(overrides)
+    return LiteLLM(**kwargs)
+
+
+def _params_by_name(llm: LiteLLM) -> dict[str, dict[str, Any]]:
+    model_list: list[dict[str, Any]] = llm.router.model_list  # type: ignore[assignment]
+    return {entry["model_name"]: entry["litellm_params"] for entry in model_list}
+
+
+class TestLiteLLMModelSpecificSettings(unittest.TestCase):
+    def test_default_field_is_empty_dict(self):
+        llm = _build_llm()
+        self.assertEqual(llm.model_specific_settings, {})
+
+    def test_no_overrides_when_settings_empty(self):
+        llm = _build_llm(fallbacks=["gpt-4o"])
+        params = _params_by_name(llm)
+
+        self.assertEqual(set(params), {"gpt-4o-mini", "gpt-4o"})
+        for name, entry in params.items():
+            self.assertEqual(entry["model"], name)
+            self.assertNotIn("api_key", entry)
+            self.assertNotIn("api_base", entry)
+
+    def test_overrides_applied_to_main_model(self):
+        llm = _build_llm(
+            model_specific_settings={
+                "gpt-4o-mini": {"api_key": "key-main", "api_base": "https://main"}
+            },
+        )
+        main_params = _params_by_name(llm)["gpt-4o-mini"]
+
+        self.assertEqual(main_params["model"], "gpt-4o-mini")
+        self.assertEqual(main_params["api_key"], "key-main")
+        self.assertEqual(main_params["api_base"], "https://main")
+
+    def test_overrides_applied_to_fallback_only(self):
+        llm = _build_llm(
+            fallbacks=["gpt-4o"],
+            model_specific_settings={"gpt-4o": {"api_key": "key-fb"}},
+        )
+        params = _params_by_name(llm)
+
+        self.assertNotIn("api_key", params["gpt-4o-mini"])
+        self.assertEqual(params["gpt-4o"]["api_key"], "key-fb")
+        self.assertEqual(params["gpt-4o"]["model"], "gpt-4o")
+
+    def test_overrides_are_independent_per_model(self):
+        llm = _build_llm(
+            fallbacks=["gpt-4o", "gpt-3.5-turbo"],
+            model_specific_settings={
+                "gpt-4o-mini": {"api_key": "main-key"},
+                "gpt-3.5-turbo": {"api_key": "legacy-key", "api_base": "https://legacy"},
+            },
+        )
+        params = _params_by_name(llm)
+
+        self.assertEqual(params["gpt-4o-mini"]["api_key"], "main-key")
+        # Fallback without an override entry must not pick up another model's keys.
+        self.assertNotIn("api_key", params["gpt-4o"])
+        self.assertEqual(params["gpt-3.5-turbo"]["api_key"], "legacy-key")
+        self.assertEqual(params["gpt-3.5-turbo"]["api_base"], "https://legacy")
+
+    def test_settings_for_unknown_model_are_ignored(self):
+        llm = _build_llm(
+            fallbacks=["gpt-4o"],
+            model_specific_settings={"some-other-model": {"api_key": "stray"}},
+        )
+        params = _params_by_name(llm)
+
+        # Stray entry produces no Router model and never bleeds into the others.
+        self.assertEqual(set(params), {"gpt-4o-mini", "gpt-4o"})
+        for entry in params.values():
+            self.assertNotIn("api_key", entry)
+
+    def test_override_can_replace_model_field(self):
+        # The implementation seeds ``{"model": <name>}`` first and then applies
+        # ``model_specific_settings[name]`` via ``dict.update``, so a deliberate
+        # ``"model"`` override (e.g. routing to a deployment-qualified id) wins.
+        llm = _build_llm(
+            model_specific_settings={
+                "gpt-4o-mini": {"model": "azure/my-deployment"}
+            },
+        )
+        main_params = _params_by_name(llm)["gpt-4o-mini"]
+
+        self.assertEqual(main_params["model"], "azure/my-deployment")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_litellm_model_specific_settings.py
+++ b/tests/test_litellm_model_specific_settings.py
@@ -1,18 +1,25 @@
-"""Tests for ``LiteLLM.model_specific_settings``.
+"""Tests for ``LiteLLM`` per-model settings.
 
-Pins how per-model overrides supplied via ``model_specific_settings`` are
-merged into each Router entry's ``litellm_params``:
+Pins how settings flow into each Router ``model_list`` entry's
+``litellm_params`` after the move from a string-keyed
+``model_specific_settings`` dict to inline declarations:
 
-- The main model receives its overrides on top of ``{"model": <name>}``.
-- Each fallback receives its own overrides independently.
-- A model entry that matches neither the main model nor a declared fallback is
-  silently ignored (it has no Router entry to attach to).
-- When ``model_specific_settings`` is empty, no per-model overrides leak in.
+- ``main_model_settings`` is merged into the main entry's ``litellm_params``
+  on top of ``{"model": model_name}``.
+- A fallback declared as a bare string yields ``{"model": name}`` and nothing
+  else (env-var auth path).
+- A fallback declared as ``LiteLLMModel(name, settings)`` carries its
+  per-model settings inline; they reach only that fallback's
+  ``litellm_params``.
+- Settings on one model never bleed into another.
+- The Router's ``fallbacks`` list contains the resolved names regardless of
+  whether each fallback was declared as a plain string or a ``LiteLLMModel``.
+- The common ``llm_settings`` (completion-time layer) is unaffected by the
+  per-model (routing-time) layer — they live on different code paths.
 
-The Router itself adds defaulted keys (e.g. ``use_in_pass_through``,
-``merge_reasoning_content_in_choices``) on top of what we pass, so assertions
-check that our keys are present with the right values rather than equality on
-the whole ``litellm_params`` dict.
+The Router itself adds defaulted keys (e.g. ``use_in_pass_through``) on top
+of what we pass, so assertions check that *our* keys are present with the
+right values rather than equality on the whole ``litellm_params`` dict.
 """
 
 import sys
@@ -25,7 +32,7 @@ SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
-from grasp_agents.litellm.lite_llm import LiteLLM
+from grasp_agents.litellm.lite_llm import LiteLLM, LiteLLMModel
 
 
 def _build_llm(**overrides: Any) -> LiteLLM:
@@ -42,84 +49,177 @@ def _params_by_name(llm: LiteLLM) -> dict[str, dict[str, Any]]:
     return {entry["model_name"]: entry["litellm_params"] for entry in model_list}
 
 
-class TestLiteLLMModelSpecificSettings(unittest.TestCase):
-    def test_default_field_is_empty_dict(self):
+def _router_fallback_names(llm: LiteLLM) -> list[str]:
+    """Router stores fallbacks as ``[{main_name: [fb1, fb2, ...]}]`` — extract
+    the ordered fallback names so tests can assert on them directly."""
+    fallbacks_cfg: list[dict[str, list[str]]] = llm.router.fallbacks  # type: ignore[assignment]
+    assert len(fallbacks_cfg) == 1
+    [(_, names)] = fallbacks_cfg[0].items()
+    return list(names)
+
+
+class TestLiteLLMModelClass(unittest.TestCase):
+    def test_default_settings_is_empty(self):
+        m = LiteLLMModel("gpt-4o")
+        self.assertEqual(m.settings, {})
+
+    def test_settings_carried_on_instance(self):
+        m = LiteLLMModel("gpt-4o", {"api_key": "k", "api_base": "b"})
+        self.assertEqual(m.name, "gpt-4o")
+        self.assertEqual(m.settings, {"api_key": "k", "api_base": "b"})
+
+
+class TestMainModelSettings(unittest.TestCase):
+    def test_default_main_model_settings_is_empty_dict(self):
         llm = _build_llm()
-        self.assertEqual(llm.model_specific_settings, {})
+        self.assertEqual(llm.main_model_settings, {})
 
-    def test_no_overrides_when_settings_empty(self):
-        llm = _build_llm(fallbacks=["gpt-4o"])
-        params = _params_by_name(llm)
+    def test_default_fallbacks_is_empty_list(self):
+        llm = _build_llm()
+        self.assertEqual(llm.fallbacks, [])
 
-        self.assertEqual(set(params), {"gpt-4o-mini", "gpt-4o"})
-        for name, entry in params.items():
-            self.assertEqual(entry["model"], name)
-            self.assertNotIn("api_key", entry)
-            self.assertNotIn("api_base", entry)
+    def test_main_entry_has_only_model_when_no_settings(self):
+        llm = _build_llm()
+        params = _params_by_name(llm)["gpt-4o-mini"]
+        self.assertEqual(params["model"], "gpt-4o-mini")
+        self.assertNotIn("api_key", params)
+        self.assertNotIn("api_base", params)
 
-    def test_overrides_applied_to_main_model(self):
+    def test_main_model_settings_flow_into_main_entry(self):
         llm = _build_llm(
-            model_specific_settings={
-                "gpt-4o-mini": {"api_key": "key-main", "api_base": "https://main"}
-            },
+            main_model_settings={"api_key": "key-main", "api_base": "https://main"}
         )
-        main_params = _params_by_name(llm)["gpt-4o-mini"]
+        params = _params_by_name(llm)["gpt-4o-mini"]
+        self.assertEqual(params["model"], "gpt-4o-mini")
+        self.assertEqual(params["api_key"], "key-main")
+        self.assertEqual(params["api_base"], "https://main")
 
-        self.assertEqual(main_params["model"], "gpt-4o-mini")
-        self.assertEqual(main_params["api_key"], "key-main")
-        self.assertEqual(main_params["api_base"], "https://main")
-
-    def test_overrides_applied_to_fallback_only(self):
+    def test_main_settings_do_not_bleed_into_fallback(self):
         llm = _build_llm(
+            main_model_settings={"api_key": "key-main"},
             fallbacks=["gpt-4o"],
-            model_specific_settings={"gpt-4o": {"api_key": "key-fb"}},
         )
         params = _params_by_name(llm)
-
-        self.assertNotIn("api_key", params["gpt-4o-mini"])
-        self.assertEqual(params["gpt-4o"]["api_key"], "key-fb")
-        self.assertEqual(params["gpt-4o"]["model"], "gpt-4o")
-
-    def test_overrides_are_independent_per_model(self):
-        llm = _build_llm(
-            fallbacks=["gpt-4o", "gpt-3.5-turbo"],
-            model_specific_settings={
-                "gpt-4o-mini": {"api_key": "main-key"},
-                "gpt-3.5-turbo": {"api_key": "legacy-key", "api_base": "https://legacy"},
-            },
-        )
-        params = _params_by_name(llm)
-
-        self.assertEqual(params["gpt-4o-mini"]["api_key"], "main-key")
-        # Fallback without an override entry must not pick up another model's keys.
+        self.assertEqual(params["gpt-4o-mini"]["api_key"], "key-main")
         self.assertNotIn("api_key", params["gpt-4o"])
-        self.assertEqual(params["gpt-3.5-turbo"]["api_key"], "legacy-key")
-        self.assertEqual(params["gpt-3.5-turbo"]["api_base"], "https://legacy")
 
-    def test_settings_for_unknown_model_are_ignored(self):
+    def test_main_model_settings_can_override_seeded_model(self):
+        # Implementation builds ``{"model": name}`` then spreads
+        # ``main_model_settings``, so a deliberate ``"model"`` override (e.g.
+        # routing to a deployment-qualified id) wins.
+        llm = _build_llm(main_model_settings={"model": "azure/my-deployment"})
+        params = _params_by_name(llm)["gpt-4o-mini"]
+        self.assertEqual(params["model"], "azure/my-deployment")
+
+
+class TestFallbackDeclarations(unittest.TestCase):
+    def test_bare_string_fallback_has_no_extra_settings(self):
+        llm = _build_llm(fallbacks=["gpt-4o"])
+        params = _params_by_name(llm)["gpt-4o"]
+        self.assertEqual(params["model"], "gpt-4o")
+        self.assertNotIn("api_key", params)
+        self.assertNotIn("api_base", params)
+
+    def test_litellm_model_fallback_carries_its_settings(self):
         llm = _build_llm(
-            fallbacks=["gpt-4o"],
-            model_specific_settings={"some-other-model": {"api_key": "stray"}},
+            fallbacks=[LiteLLMModel("gpt-4o", {"api_key": "fb-key"})],
+        )
+        params = _params_by_name(llm)["gpt-4o"]
+        self.assertEqual(params["model"], "gpt-4o")
+        self.assertEqual(params["api_key"], "fb-key")
+
+    def test_mixed_fallback_forms_coexist(self):
+        llm = _build_llm(
+            fallbacks=[
+                "gpt-4o",
+                LiteLLMModel("claude-sonnet-4-5", {"api_key": "ant-key"}),
+                "gpt-3.5-turbo",
+            ],
         )
         params = _params_by_name(llm)
+        self.assertEqual(
+            set(params),
+            {"gpt-4o-mini", "gpt-4o", "claude-sonnet-4-5", "gpt-3.5-turbo"},
+        )
+        self.assertNotIn("api_key", params["gpt-4o"])
+        self.assertEqual(params["claude-sonnet-4-5"]["api_key"], "ant-key")
+        self.assertNotIn("api_key", params["gpt-3.5-turbo"])
 
-        # Stray entry produces no Router model and never bleeds into the others.
-        self.assertEqual(set(params), {"gpt-4o-mini", "gpt-4o"})
-        for entry in params.values():
-            self.assertNotIn("api_key", entry)
-
-    def test_override_can_replace_model_field(self):
-        # The implementation seeds ``{"model": <name>}`` first and then applies
-        # ``model_specific_settings[name]`` via ``dict.update``, so a deliberate
-        # ``"model"`` override (e.g. routing to a deployment-qualified id) wins.
+    def test_per_fallback_settings_are_independent(self):
         llm = _build_llm(
-            model_specific_settings={
-                "gpt-4o-mini": {"model": "azure/my-deployment"}
-            },
+            fallbacks=[
+                LiteLLMModel("gpt-4o", {"api_key": "k1"}),
+                LiteLLMModel(
+                    "claude-sonnet-4-5",
+                    {"api_key": "k2", "api_base": "https://anthropic"},
+                ),
+            ],
+        )
+        params = _params_by_name(llm)
+        self.assertEqual(params["gpt-4o"]["api_key"], "k1")
+        self.assertNotIn("api_base", params["gpt-4o"])
+        self.assertEqual(params["claude-sonnet-4-5"]["api_key"], "k2")
+        self.assertEqual(params["claude-sonnet-4-5"]["api_base"], "https://anthropic")
+
+    def test_fallback_settings_do_not_bleed_into_main(self):
+        llm = _build_llm(
+            fallbacks=[LiteLLMModel("gpt-4o", {"api_key": "fb-only"})],
         )
         main_params = _params_by_name(llm)["gpt-4o-mini"]
+        self.assertNotIn("api_key", main_params)
 
-        self.assertEqual(main_params["model"], "azure/my-deployment")
+
+class TestRouterFallbackList(unittest.TestCase):
+    def test_router_fallback_names_from_bare_strings(self):
+        llm = _build_llm(fallbacks=["gpt-4o", "gpt-3.5-turbo"])
+        self.assertEqual(_router_fallback_names(llm), ["gpt-4o", "gpt-3.5-turbo"])
+
+    def test_router_fallback_names_from_litellm_models(self):
+        llm = _build_llm(
+            fallbacks=[
+                LiteLLMModel("gpt-4o", {"api_key": "k"}),
+                LiteLLMModel("claude-sonnet-4-5"),
+            ],
+        )
+        self.assertEqual(
+            _router_fallback_names(llm), ["gpt-4o", "claude-sonnet-4-5"]
+        )
+
+    def test_router_fallback_names_preserve_order_in_mixed_input(self):
+        llm = _build_llm(
+            fallbacks=[
+                "gpt-3.5-turbo",
+                LiteLLMModel("claude-sonnet-4-5", {"api_key": "k"}),
+                "gpt-4o",
+            ],
+        )
+        self.assertEqual(
+            _router_fallback_names(llm),
+            ["gpt-3.5-turbo", "claude-sonnet-4-5", "gpt-4o"],
+        )
+
+
+class TestSettingsLayeringIsolation(unittest.TestCase):
+    """Pins that the per-model (routing-time) layer doesn't disturb the
+    common ``llm_settings`` (completion-time) layer — they live on different
+    code paths and shouldn't cross-contaminate."""
+
+    def test_llm_settings_does_not_leak_into_per_model_litellm_params(self):
+        llm = _build_llm(
+            llm_settings={"temperature": 0.42},
+            main_model_settings={"api_key": "key-main"},
+            fallbacks=[LiteLLMModel("gpt-4o", {"api_key": "fb-k"})],
+        )
+        # llm_settings stays on the LLM instance for the completion path.
+        assert llm.llm_settings is not None
+        self.assertEqual(llm.llm_settings.get("temperature"), 0.42)
+        # Per-model layer still works.
+        params = _params_by_name(llm)
+        self.assertEqual(params["gpt-4o-mini"]["api_key"], "key-main")
+        self.assertEqual(params["gpt-4o"]["api_key"], "fb-k")
+        # llm_settings does NOT leak into Router-level litellm_params.
+        for entry in params.values():
+            self.assertNotIn("temperature", entry)
 
 
 if __name__ == "__main__":

--- a/tests/test_litellm_model_specific_settings.py
+++ b/tests/test_litellm_model_specific_settings.py
@@ -25,7 +25,7 @@ right values rather than equality on the whole ``litellm_params`` dict.
 import sys
 import unittest
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
@@ -51,9 +51,16 @@ def _params_by_name(llm: LiteLLM) -> dict[str, dict[str, Any]]:
 
 def _router_fallback_names(llm: LiteLLM) -> list[str]:
     """Router stores fallbacks as ``[{main_name: [fb1, fb2, ...]}]`` — extract
-    the ordered fallback names so tests can assert on them directly."""
+    the ordered fallback names so tests can assert on them directly.
+
+    Raises ``AssertionError`` explicitly (not via bare ``assert``) so the
+    invariant holds under ``python -O``."""
     fallbacks_cfg: list[dict[str, list[str]]] = llm.router.fallbacks  # type: ignore[assignment]
-    assert len(fallbacks_cfg) == 1
+    if len(fallbacks_cfg) != 1:
+        raise AssertionError(
+            f"Expected exactly one fallback group, got {len(fallbacks_cfg)}: "
+            f"{fallbacks_cfg!r}"
+        )
     [(_, names)] = fallbacks_cfg[0].items()
     return list(names)
 
@@ -211,8 +218,11 @@ class TestSettingsLayeringIsolation(unittest.TestCase):
             fallbacks=[LiteLLMModel("gpt-4o", {"api_key": "fb-k"})],
         )
         # llm_settings stays on the LLM instance for the completion path.
-        assert llm.llm_settings is not None
-        self.assertEqual(llm.llm_settings.get("temperature"), 0.42)
+        self.assertIsNotNone(llm.llm_settings)
+        # Cast for the type checker — the runtime check above is what guards
+        # the test, and survives ``python -O`` (unlike a bare ``assert``).
+        llm_settings = cast("dict[str, Any]", llm.llm_settings)
+        self.assertEqual(llm_settings.get("temperature"), 0.42)
         # Per-model layer still works.
         params = _params_by_name(llm)
         self.assertEqual(params["gpt-4o-mini"]["api_key"], "key-main")

--- a/tests/test_litellm_model_specific_settings.py
+++ b/tests/test_litellm_model_specific_settings.py
@@ -7,14 +7,15 @@ Pins the contract of the two mutually-exclusive ways to configure settings:
 - ``llm_group_settings``: a per-model settings dict ``{model_name: settings}``
   baked into each Router ``model_list`` entry's ``litellm_params``. When
   provided, it must contain *exactly* the routed models (``model_name`` plus
-  every fallback target) — no missing keys, no extras. ``{}`` is the
+  every entry of ``fallbacks``) — no missing keys, no extras. ``{}`` is the
   explicit way to say "this model is routed but needs no specific settings."
 
 Supplying both raises ``ValueError``. Supplying neither leaves every Router
 entry with only ``{"model": name}``.
 
-Fallbacks follow litellm Router's native shape:
-``[{main_name: [fb1, fb2, ...]}]``.
+``fallbacks`` on ``LiteLLM`` is a plain ``list[str]`` of model names; we
+internally wrap it into litellm Router's native ``[{main: [fb1, fb2]}]``
+shape at the boundary.
 
 The Router itself adds defaulted keys (``use_in_pass_through``, etc.) on top
 of what we pass, so assertions check that *our* keys are present with the
@@ -88,7 +89,7 @@ class TestLlmSettingsCommon(unittest.TestCase):
     def test_llm_settings_does_not_leak_into_litellm_params(self):
         llm = _build_llm(
             llm_settings={"temperature": 0.42, "max_completion_tokens": 100},
-            fallbacks=[{"gpt-4o-mini": ["gpt-4o"]}],
+            fallbacks=["gpt-4o"],
         )
         params = _params_by_name(llm)
         for entry in params.values():
@@ -98,7 +99,7 @@ class TestLlmSettingsCommon(unittest.TestCase):
     def test_llm_settings_with_fallbacks_includes_all_routed_models(self):
         llm = _build_llm(
             llm_settings={"temperature": 0.5},
-            fallbacks=[{"gpt-4o-mini": ["gpt-4o", "claude-sonnet-4-5"]}],
+            fallbacks=["gpt-4o", "claude-sonnet-4-5"],
         )
         params = _params_by_name(llm)
         self.assertEqual(
@@ -112,7 +113,7 @@ class TestLlmGroupSettingsPerModel(unittest.TestCase):
 
     def test_per_model_settings_reach_each_entry(self):
         llm = _build_llm(
-            fallbacks=[{"gpt-4o-mini": ["gpt-4o"]}],
+            fallbacks=["gpt-4o"],
             llm_group_settings={
                 "gpt-4o-mini": {"api_key": "K-main", "api_base": "https://main"},
                 "gpt-4o":      {"api_key": "K-fb"},
@@ -130,7 +131,7 @@ class TestLlmGroupSettingsPerModel(unittest.TestCase):
         # no specific settings. The entry exists in model_list but with only
         # ``{"model": name}``.
         llm = _build_llm(
-            fallbacks=[{"gpt-4o-mini": ["gpt-4o"]}],
+            fallbacks=["gpt-4o"],
             llm_group_settings={
                 "gpt-4o-mini": {"api_key": "K"},
                 "gpt-4o":      {},
@@ -143,7 +144,7 @@ class TestLlmGroupSettingsPerModel(unittest.TestCase):
 
     def test_per_model_settings_do_not_bleed_between_entries(self):
         llm = _build_llm(
-            fallbacks=[{"gpt-4o-mini": ["gpt-4o", "claude-sonnet-4-5"]}],
+            fallbacks=["gpt-4o", "claude-sonnet-4-5"],
             llm_group_settings={
                 "gpt-4o-mini":      {"api_key": "K1"},
                 "gpt-4o":           {"api_key": "K2", "api_base": "https://b"},
@@ -186,7 +187,7 @@ class TestStrictValidation(unittest.TestCase):
     def test_missing_main_model_in_group_settings(self):
         with self.assertRaises(ValueError) as ctx:
             _build_llm(
-                fallbacks=[{"gpt-4o-mini": ["gpt-4o"]}],
+                fallbacks=["gpt-4o"],
                 llm_group_settings={"gpt-4o": {}},
             )
         self.assertIn("Missing", str(ctx.exception))
@@ -195,7 +196,7 @@ class TestStrictValidation(unittest.TestCase):
     def test_missing_fallback_target_in_group_settings(self):
         with self.assertRaises(ValueError) as ctx:
             _build_llm(
-                fallbacks=[{"gpt-4o-mini": ["gpt-4o"]}],
+                fallbacks=["gpt-4o"],
                 llm_group_settings={"gpt-4o-mini": {}},
             )
         self.assertIn("Missing", str(ctx.exception))
@@ -234,7 +235,7 @@ class TestFallbacksWithoutGroupSettings(unittest.TestCase):
 
     def test_model_list_includes_main_and_all_fallback_targets(self):
         llm = _build_llm(
-            fallbacks=[{"gpt-4o-mini": ["gpt-4o", "claude-sonnet-4-5"]}],
+            fallbacks=["gpt-4o", "claude-sonnet-4-5"],
         )
         params = _params_by_name(llm)
         self.assertEqual(
@@ -242,40 +243,47 @@ class TestFallbacksWithoutGroupSettings(unittest.TestCase):
         )
 
     def test_each_fallback_entry_has_no_extra_settings(self):
-        llm = _build_llm(
-            fallbacks=[{"gpt-4o-mini": ["gpt-4o"]}],
-        )
+        llm = _build_llm(fallbacks=["gpt-4o"])
         params = _params_by_name(llm)
         self.assertEqual(params["gpt-4o"]["model"], "gpt-4o")
         self.assertNotIn("api_key", params["gpt-4o"])
         self.assertNotIn("api_base", params["gpt-4o"])
 
-    def test_main_appearing_as_fallback_target_is_deduped(self):
-        # Pathological but possible: main is also listed as a fallback target
-        # somewhere. The else branch builds model_list from a set, so the
-        # entry appears exactly once.
-        llm = _build_llm(
-            fallbacks=[
-                {"gpt-4o-mini": ["gpt-4o"]},
-                # gpt-4o-mini also a fallback target in another group.
-                {"some-other": ["gpt-4o-mini"]},
-            ],
-        )
+    def test_main_appearing_in_fallbacks_is_deduped(self):
+        # Pathological but possible: main is also listed as a fallback. The
+        # else branch builds model_list from a set, so the entry appears
+        # exactly once.
+        llm = _build_llm(fallbacks=["gpt-4o-mini", "gpt-4o"])
         model_list: list[dict[str, Any]] = llm.router.model_list  # type: ignore[assignment]
         names = [e["model_name"] for e in model_list]
         self.assertEqual(names.count("gpt-4o-mini"), 1)
+        self.assertEqual(set(names), {"gpt-4o-mini", "gpt-4o"})
+
+    def test_duplicate_fallback_names_dedupe_in_model_list(self):
+        # A duplicate in fallbacks shouldn't produce a duplicate Router entry
+        # (set-union dedupes). The Router's fallback list is passed through
+        # as-is, so duplicates there are litellm's concern.
+        llm = _build_llm(fallbacks=["gpt-4o", "gpt-4o"])
+        params = _params_by_name(llm)
+        self.assertEqual(set(params), {"gpt-4o-mini", "gpt-4o"})
 
 
-class TestRouterFallbacksPassedThrough(unittest.TestCase):
-    """``self.fallbacks`` is passed verbatim to the Router as its native
-    fallback config. This pins that the litellm-native shape is preserved
-    end-to-end."""
+class TestRouterFallbacksWrapping(unittest.TestCase):
+    """The public ``fallbacks: list[str]`` is wrapped into litellm Router's
+    native ``[{main_name: [fb1, fb2]}]`` shape at the Router boundary."""
 
-    def test_router_fallbacks_match_input(self):
-        fallbacks_in = [{"gpt-4o-mini": ["gpt-4o", "claude-sonnet-4-5"]}]
-        llm = _build_llm(fallbacks=fallbacks_in)
+    def test_non_empty_fallbacks_wrapped_for_router(self):
+        llm = _build_llm(fallbacks=["gpt-4o", "claude-sonnet-4-5"])
         router_fallbacks: list[dict[str, list[str]]] = llm.router.fallbacks  # type: ignore[assignment]
-        self.assertEqual(router_fallbacks, fallbacks_in)
+        self.assertEqual(
+            router_fallbacks,
+            [{"gpt-4o-mini": ["gpt-4o", "claude-sonnet-4-5"]}],
+        )
+
+    def test_empty_fallbacks_still_wrapped(self):
+        llm = _build_llm()
+        router_fallbacks: list[dict[str, list[str]]] = llm.router.fallbacks  # type: ignore[assignment]
+        self.assertEqual(router_fallbacks, [{"gpt-4o-mini": []}])
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -812,7 +812,7 @@ wheels = [
 
 [[package]]
 name = "grasp-agents"
-version = "0.6.48"
+version = "0.6.49"
 source = { editable = "." }
 dependencies = [
     { name = "dotenv" },


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                       
  Refactor per-model settings on `LiteLLM` to eliminate the typo class that came                                                                                                                 
  with the previous string-keyed `model_specific_settings` dict. Per-model                                                                                                                         
  settings now travel inline with each model declaration, so a name is declared                                                                                                                    
  exactly once and cannot drift between two locations.                                                                                                                                             
                                                                                                                                                                                                   
  - Add `LiteLLMModel(name, settings)` (frozen dataclass) for fallback declarations.                                                                                                               
  - Add `main_model_settings: dict[str, Any]` for the main model's per-model overrides.                                                                                                            
  - Widen `fallbacks: list[str]` to `list[str | LiteLLMModel]` — bare strings stay                                                                                                                 
    supported for the no-overrides case; `LiteLLMModel` carries its settings inline.                                                                                                               
  - Remove `model_specific_settings` (introduced one commit ago in #127, no other consumers).                                                                                                      
  - Export `LiteLLMModel` from `grasp_agents.litellm`.                                                                                                                                             
                                                                                                                                                                                                   
  The common `llm_settings` (completion-time) layer is untouched.                                                                                                                                  
                                                                                                                                                                                                   
  ## Test plan                                                                                                                                                                                     
  - [x] `pytest tests/test_litellm_model_specific_settings.py` — 17 tests pass                                                                                                                   
  - [x] `pytest tests/` — full suite green (27 passed)                                                                                                                                             
  - [x] `pyright` — 0 errors, 0 warnings on the test file                                                                                                                                          
  - [x] Bare `assert`s in tests replaced with `-O`-safe equivalents per review                           
  
