### PR TITLE
expand configs of LLM providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,9 @@ uv add grasp_agents          # or: pip install grasp_agents
 | `grasp_agents` | Core: OpenAI + LiteLLM, file/shell/code tools, memory, skills, durability, console |
 | `grasp_agents[anthropic]` | Native Anthropic provider |
 | `grasp_agents[gemini]` | Native Gemini provider |
-| `grasp_agents[all-llm-providers]` | Anthropic + Gemini |
+| `grasp_agents[all-llm-providers]` | Anthropic + Gemini + Bedrock/Vertex auth deps |
+| `grasp_agents[bedrock]` | Claude on AWS Bedrock (adds `boto3` for SigV4) |
+| `grasp_agents[vertex]` | Claude + Gemini on Google Vertex AI (adds `google-auth`) |
 | `grasp_agents[mcp]` | MCP client |
 | `grasp_agents[notebook]` | Local Jupyter kernel for `RunPython` / `RunCell` |
 | `grasp_agents[notebook-edit]` | `NotebookRead` / `NotebookEdit` (no kernel) |
@@ -156,7 +158,9 @@ uv add grasp_agents          # or: pip install grasp_agents
 | `grasp_agents[tui]` | Textual terminal UI |
 | `grasp_agents[phoenix]` | Phoenix / OpenLLMetry tracing |
 
-API keys are read from the environment.
+API keys are read from the environment. The same models are also reachable
+through AWS Bedrock, Google Vertex AI, and Azure OpenAI — see
+[Cloud-hosted models](#cloud-hosted-models).
 
 ## Minimal example
 
@@ -209,6 +213,79 @@ uv run quickstart.py
 out = await agent.run("What's the weather in Paris?")
 print(out.payloads[0])
 ```
+
+## Cloud-hosted models
+
+The native providers reach the same models through the major cloud platforms,
+selected with a `platform=` argument; platform-specific client args go in a
+typed `platform_config`. The request/response surface is identical, so tools,
+streaming, structured outputs, and `FallbackLLM` all work unchanged.
+
+```python
+from grasp_agents.llm_providers.anthropic import AnthropicLLM
+from grasp_agents.llm_providers.openai_completions import OpenAILLM
+from grasp_agents.llm_providers.gemini import GeminiLLM
+
+# Claude on AWS Bedrock (AWS cred chain / profile / bearer token)
+bedrock = AnthropicLLM(
+    model_name="anthropic.claude-sonnet-4-5-20250929-v1:0",
+    platform="bedrock",                  # or "bedrock_mantle" for newest models
+    platform_config={"aws_region": "us-east-1"},
+)
+
+# Claude on Google Vertex AI
+claude_vertex = AnthropicLLM(
+    model_name="claude-sonnet-4-5@20250929",
+    platform="vertex",
+    platform_config={"project_id": "my-project", "region": "us-east5"},
+)
+
+# Azure OpenAI — model_name is the deployment name (key or Entra ID auth)
+azure = OpenAILLM(
+    model_name="my-gpt-deployment",
+    platform="azure",
+    platform_config={
+        "azure_endpoint": "https://my-resource.openai.azure.com",
+        "api_version": "2024-10-21",
+    },
+)
+
+# Gemini on Google Vertex AI
+gemini_vertex = GeminiLLM(
+    model_name="gemini-2.5-flash",
+    platform="vertex",
+    platform_config={"project": "my-project", "location": "us-central1"},
+)
+```
+
+Anything not set in `platform_config` falls back to each platform's own
+credential chain and environment variables. The shared `http_client` /
+`default_headers` args and a per-provider `extra_*_client_params` escape hatch
+are available on every provider.
+
+### Server-side conversation state (OpenAI Responses)
+
+By default the loop is stateless toward the provider: it sends the full
+transcript each turn. To instead chain turns server-side with the Responses API
+(`previous_response_id`), wire it with the LLM hooks — the framework leaves the
+strategy to you. `OpenAIResponsesLLM` slices the input to only the new items
+whenever `previous_response_id` (or `conversation`) is set.
+
+```python
+last: dict[str, str] = {}  # keyed by exec_id (one run); or use current_run_context().state
+
+@agent.add_after_llm_hook
+async def _capture(response, *, exec_id, turn):
+    last[exec_id] = response.id
+
+@agent.add_before_llm_hook
+async def _chain(*, exec_id, turn, extra_llm_settings):
+    if rid := last.get(exec_id):
+        extra_llm_settings["previous_response_id"] = rid
+```
+
+Pair it with `llm_settings={"store": True}` (the provider-side persistence
+toggle); `store=False` keeps responses unstored.
 
 ## More examples
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,20 @@ dev = [
 [project.optional-dependencies]
 anthropic = ["anthropic>=0.84,<1"]
 gemini = ["google-genai>=1.65,<2"]
-all-llm-providers = ["anthropic>=0.84,<1", "google-genai>=1.65,<2"]
+# Claude via AWS Bedrock: the SDK signs requests with botocore SigV4 (pulled in
+# by anthropic's own `bedrock` extra). Not needed when authenticating with a
+# Bedrock API key / bearer token. The 'bedrock_mantle' endpoint needs a recent
+# anthropic SDK.
+bedrock = ["anthropic[bedrock]>=0.84,<1"]
+# Vertex AI: Claude needs google-auth (anthropic's `vertex` extra) for ADC
+# token minting; google-genai (Gemini on Vertex) already bundles google-auth.
+# Azure OpenAI needs no extra — AsyncAzureOpenAI ships in the base openai SDK
+# (use azure-identity yourself for Entra ID token providers).
+vertex = ["anthropic[vertex]>=0.84,<1", "google-genai>=1.65,<2"]
+all-llm-providers = [
+    "anthropic[bedrock,vertex]>=0.84,<1",
+    "google-genai>=1.65,<2",
+]
 e2b = ["e2b>=2.0,<3", "e2b-code-interpreter>=2.7.0,<3"]
 mcp = ["mcp>=1.8,<2"]
 notebook-edit = ["nbformat>=5.10.4,<6"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grasp_agents"
-version = "1.0.2"
+version = "1.0.3"
 description = "Grasp Agents Library"
 readme = "README.md"
 requires-python = ">=3.12,<4"

--- a/src/grasp_agents/llm/cloud_llm.py
+++ b/src/grasp_agents/llm/cloud_llm.py
@@ -65,6 +65,7 @@ class CloudLLM(LLM):
     apply_output_schema_via_provider: bool = False
     apply_tool_call_schema_via_provider: bool = False
     http_client: httpx.AsyncClient | None = None
+    default_headers: Mapping[str, str] | None = None
 
     def __post_init__(self) -> None:
         if self.rate_limiter is not None:

--- a/src/grasp_agents/llm_providers/anthropic/__init__.py
+++ b/src/grasp_agents/llm_providers/anthropic/__init__.py
@@ -91,4 +91,10 @@ from anthropic.types import (
     WebSearchToolResultBlock as AnthropicWebSearchToolResultBlock,
 )
 
-from .anthropic_llm import AnthropicLLM, AnthropicLLMSettings
+from .anthropic_llm import (
+    AnthropicLLM,
+    AnthropicLLMSettings,
+    AnthropicPlatform,
+    BedrockClientConfig,
+    VertexClientConfig,
+)

--- a/src/grasp_agents/llm_providers/anthropic/anthropic_llm.py
+++ b/src/grasp_agents/llm_providers/anthropic/anthropic_llm.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 from anthropic import AsyncAnthropic
 from anthropic._types import omit  # type: ignore[import]  # noqa: PLC2701
@@ -32,6 +32,12 @@ from .tool_converters import to_api_tool, to_api_tool_choice
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Mapping, Sequence
 
+    from anthropic import (
+        AsyncAnthropicBedrock,  # pyright: ignore[reportPrivateImportUsage]
+        AsyncAnthropicBedrockMantle,  # pyright: ignore[reportPrivateImportUsage]
+        AsyncAnthropicVertex,  # pyright: ignore[reportPrivateImportUsage]
+    )
+    from anthropic.types import MetadataParam, OutputConfigParam
     from pydantic import BaseModel
 
     from grasp_agents.tools.base import BaseTool, ToolChoice
@@ -58,14 +64,70 @@ DEFAULT_MAX_TOKENS = 32768
 WebSearchToolParam = WebSearchTool20260209Param | WebSearchTool20250305Param
 WebFetchToolParam = WebFetchTool20260209Param
 
+AnthropicPlatform = Literal["anthropic", "bedrock", "bedrock_mantle", "vertex"]
+
+_BEDROCK_INSTALL_HINT = (
+    "AWS Bedrock support is unavailable. Install it with "
+    "`pip install 'grasp_agents[bedrock]'` (and use a recent anthropic SDK for "
+    "the 'bedrock_mantle' endpoint)."
+)
+_VERTEX_INSTALL_HINT = (
+    "Google Vertex AI support is unavailable. Install it with "
+    "`pip install 'grasp_agents[vertex]'`."
+)
+
 
 class AnthropicLLMSettings(CloudLLMSettings, total=False):
     max_tokens: int
     thinking: ThinkingConfigParam | None
     stop_sequences: list[str] | None
     top_k: int | None
+
+    # Structured outputs sent directly (the manual escape hatch). When
+    # ``apply_output_schema_via_provider`` is set the schema travels via the
+    # separate ``output_schema`` channel (``messages.parse``) instead.
+    output_config: OutputConfigParam | None
+
     web_search: WebSearchToolParam | None
     web_fetch: WebFetchToolParam | None
+
+    metadata: MetadataParam | None
+    service_tier: Literal["auto", "standard_only"] | None
+    container: str | None
+    inference_geo: str | None
+
+
+class BedrockClientConfig(TypedDict, total=False):
+    """
+    Client args for ``platform="bedrock"`` / ``"bedrock_mantle"``.
+
+    Unset values fall back to the standard AWS credential/region chain (env
+    vars, shared config/credentials files, SSO, IMDS). ``api_key`` is a Bedrock
+    bearer token, mutually exclusive with the ``aws_*`` credential fields.
+    """
+
+    aws_region: str
+    aws_profile: str
+    aws_access_key: str
+    aws_secret_key: str
+    aws_session_token: str
+    api_key: str
+    base_url: str
+
+
+class VertexClientConfig(TypedDict, total=False):
+    """
+    Client args for ``platform="vertex"``.
+
+    Unset values fall back to Application Default Credentials and the SDK env
+    vars (``ANTHROPIC_VERTEX_PROJECT_ID`` / ``CLOUD_ML_REGION``).
+    """
+
+    project_id: str
+    region: str
+    access_token: str
+    credentials: Any
+    base_url: str
 
 
 @dataclass(frozen=True)
@@ -79,30 +141,114 @@ class AnthropicLLM(CloudLLM):
     # SDK-level retries default to 0: ``LLM.retry_policy`` is the retry
     # system, and a non-zero value here would multiply with it.
     anthropic_client_max_retries: int = 0
-    client: AsyncAnthropic = field(init=False)
+    # Escape hatch: forwarded verbatim to the underlying client constructor
+    # (direct / Bedrock / Vertex) for SDK-specific args not in platform_config.
+    extra_anthropic_client_params: dict[str, Any] | None = None
+
+    # Which Anthropic-hosting platform to call. The Messages API surface is
+    # identical across all four; only client construction differs.
+    platform: AnthropicPlatform = "anthropic"
+    # Platform-specific client args: a ``BedrockClientConfig`` for
+    # "bedrock"/"bedrock_mantle" or a ``VertexClientConfig`` for "vertex"
+    # (ignored for the direct API, which uses ``api_provider``). May carry
+    # secrets — kept out of repr.
+    platform_config: BedrockClientConfig | VertexClientConfig | None = field(
+        default=None, repr=False
+    )
+
+    client: (
+        AsyncAnthropic
+        | AsyncAnthropicBedrock
+        | AsyncAnthropicVertex
+        | AsyncAnthropicBedrockMantle
+    ) = field(init=False)
     _default_max_tokens: int = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         super().__post_init__()
 
         _api_provider = self.api_provider or APIProvider(
-            name="anthropic",
+            name=self.platform,
             base_url=None,
-            api_key=os.getenv("ANTHROPIC_API_KEY"),
+            api_key=(
+                os.getenv("ANTHROPIC_API_KEY") if self.platform == "anthropic" else None
+            ),
         )
 
-        _client = AsyncAnthropic(
-            base_url=_api_provider.get("base_url"),
-            api_key=_api_provider.get("api_key"),
-            timeout=self.anthropic_client_timeout,
-            max_retries=self.anthropic_client_max_retries,
-        )
+        _client = self._build_client(_api_provider)
 
-        cap = get_model_capabilities(self.model_name, "anthropic").max_output_tokens
+        # On a cloud platform the model IDs and cost tables differ from the
+        # direct API; resolve the pricing identity used for cost lookups
+        # unless the caller pinned ``litellm_provider`` explicitly.
+        litellm_provider = self.litellm_provider
+        if self.platform != "anthropic" and litellm_provider == "anthropic":
+            litellm_provider = "vertex_ai" if self.platform == "vertex" else "bedrock"
+            object.__setattr__(self, "litellm_provider", litellm_provider)
+
+        cap = get_model_capabilities(
+            self.model_name, litellm_provider
+        ).max_output_tokens
 
         object.__setattr__(self, "api_provider", _api_provider)
         object.__setattr__(self, "client", _client)
         object.__setattr__(self, "_default_max_tokens", cap or DEFAULT_MAX_TOKENS)
+
+    def _build_client(
+        self, api_provider: APIProvider
+    ) -> (
+        AsyncAnthropic
+        | AsyncAnthropicBedrock
+        | AsyncAnthropicVertex
+        | AsyncAnthropicBedrockMantle
+    ):
+        # Client args whose role is identical across the direct / Bedrock /
+        # Vertex clients (so nothing the caller configured is dropped).
+        common: dict[str, Any] = {
+            "timeout": self.anthropic_client_timeout,
+            "max_retries": self.anthropic_client_max_retries,
+        }
+        if api_provider.get("base_url"):
+            common["base_url"] = api_provider["base_url"]
+        if self.http_client is not None:
+            common["http_client"] = self.http_client
+        if self.default_headers is not None:
+            common["default_headers"] = self.default_headers
+
+        config: dict[str, Any] = dict(self.platform_config or {})
+        extra: dict[str, Any] = dict(self.extra_anthropic_client_params or {})
+
+        if self.platform == "anthropic":
+            anthropic_kwargs: dict[str, Any] = {
+                **common,
+                "api_key": api_provider.get("api_key"),
+                **extra,
+            }
+            return AsyncAnthropic(**anthropic_kwargs)
+
+        if self.platform in {"bedrock", "bedrock_mantle"}:
+            try:
+                from anthropic import (  # noqa: PLC0415
+                    AsyncAnthropicBedrock,  # pyright: ignore[reportPrivateImportUsage]
+                    AsyncAnthropicBedrockMantle,  # pyright: ignore[reportPrivateImportUsage]
+                )
+            except ImportError as err:
+                raise ImportError(_BEDROCK_INSTALL_HINT) from err
+
+            bedrock_cls = (
+                AsyncAnthropicBedrockMantle
+                if self.platform == "bedrock_mantle"
+                else AsyncAnthropicBedrock
+            )
+            return bedrock_cls(**{**common, **config, **extra})
+
+        try:
+            from anthropic import (  # noqa: PLC0415
+                AsyncAnthropicVertex,  # pyright: ignore[reportPrivateImportUsage]
+            )
+        except ImportError as err:
+            raise ImportError(_VERTEX_INSTALL_HINT) from err
+
+        return AsyncAnthropicVertex(**{**common, **config, **extra})
 
     # --- Input preparation ---
 

--- a/src/grasp_agents/llm_providers/gemini/__init__.py
+++ b/src/grasp_agents/llm_providers/gemini/__init__.py
@@ -73,4 +73,9 @@ from google.genai.types import (
     ToolConfig as GeminiToolConfig,
 )
 
-from .gemini_llm import GeminiLLM, GeminiLLMSettings
+from .gemini_llm import (
+    GeminiLLM,
+    GeminiLLMSettings,
+    GeminiPlatform,
+    GeminiVertexClientConfig,
+)

--- a/src/grasp_agents/llm_providers/gemini/gemini_llm.py
+++ b/src/grasp_agents/llm_providers/gemini/gemini_llm.py
@@ -130,14 +130,14 @@ class GeminiLLM(CloudLLM):
     def __post_init__(self) -> None:
         super().__post_init__()
 
-        extra = dict(self.extra_gemini_client_params or {})
+        extra: dict[str, Any] = dict(self.extra_gemini_client_params or {})
 
         if self.platform == "vertex":
             _api_provider = self.api_provider or APIProvider(
                 name="vertex", base_url=None, api_key=None
             )
-            config = dict(self.platform_config or {})
-            kwargs = {"vertexai": True, **config, **extra}
+            config: dict[str, Any] = dict(self.platform_config or {})
+            kwargs: dict[str, Any] = {"vertexai": True, **config, **extra}
             kwargs.setdefault("location", "global")
         else:
             _api_provider = self.api_provider or APIProvider(

--- a/src/grasp_agents/llm_providers/gemini/gemini_llm.py
+++ b/src/grasp_agents/llm_providers/gemini/gemini_llm.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 from google.genai import Client
 from google.genai.types import HttpOptions as GeminiHttpOptions
@@ -28,6 +28,14 @@ from .tool_converters import to_api_tool_config, to_api_tools
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Mapping, Sequence
 
+    from google.genai.types import (
+        AutomaticFunctionCallingConfigDict,
+        GenerationConfigRoutingConfigDict,
+        MediaResolution,
+        ModelArmorConfigDict,
+        ModelSelectionConfigDict,
+        ServiceTier,
+    )
     from pydantic import BaseModel
 
     from grasp_agents.tools.base import BaseTool, ToolChoice
@@ -55,10 +63,22 @@ class GeminiLLMSettings(CloudLLMSettings, total=False):
     seed: int | None
     response_logprobs: bool
     logprobs: int
+
     thinking_config: GeminiThinkingConfigDict | dict[str, Any] | None
-    safety_settings: list[GeminiSafetySettingDict] | None
+
     google_search: GeminiGoogleSearchDict | None
+
     url_context: bool | None
+    safety_settings: list[GeminiSafetySettingDict] | None
+    media_resolution: MediaResolution
+    service_tier: ServiceTier
+    cached_content: str
+    labels: dict[str, str]
+    enable_enhanced_civic_answers: bool
+    routing_config: GenerationConfigRoutingConfigDict
+    model_selection_config: ModelSelectionConfigDict
+    model_armor_config: ModelArmorConfigDict
+    automatic_function_calling: AutomaticFunctionCallingConfigDict
 
 
 # Keys with no Gemini equivalent (silently dropped)
@@ -75,48 +95,76 @@ _CONFIG_KEYS = (
 )
 
 
+GeminiPlatform = Literal["gemini", "vertex"]
+
+
+class GeminiVertexClientConfig(TypedDict, total=False):
+    """
+    Client args for ``platform="vertex"``.
+
+    Unset values fall back to ADC and the SDK env vars (GOOGLE_CLOUD_PROJECT,
+    GOOGLE_CLOUD_LOCATION); ``location`` defaults to "us-central1".
+    """
+
+    project: str
+    location: str
+    credentials: Any
+
+
 @dataclass(frozen=True)
 class GeminiLLM(CloudLLM):
     litellm_provider: str | None = "vertex_ai"
     llm_settings: GeminiLLMSettings | None = None
-    vertexai: bool = False
-    project: str | None = None
-    location: str | None = None
-    # Per-request HTTP timeout in seconds (``None`` disables). Without one the
-    # SDK waits forever on a stalled request — the retry layer never engages
-    # and ``run_timeout`` (checked at turn boundaries) cannot interrupt it.
-    gemini_client_timeout: float | None = 120.0
+    # Per-request HTTP timeout in seconds (``None`` disables).
+    gemini_client_timeout: float | None = 600.0
+    # Escape hatch: forwarded verbatim to the ``google.genai.Client``
+    # constructor for SDK-specific args (e.g. ``debug_config``).
+    extra_gemini_client_params: dict[str, Any] | None = None
+
+    # "gemini" = Gemini Developer API (api_key); "vertex" = Google Vertex AI.
+    platform: GeminiPlatform = "gemini"
+    platform_config: GeminiVertexClientConfig | None = field(default=None, repr=False)
+
     client: Client = field(init=False)
 
     def __post_init__(self) -> None:
         super().__post_init__()
 
-        http_options: GeminiHttpOptions | None = None
-        if self.gemini_client_timeout is not None:
-            http_options = GeminiHttpOptions(
-                timeout=int(self.gemini_client_timeout * 1000)  # milliseconds
-            )
+        extra = dict(self.extra_gemini_client_params or {})
 
-        if self.vertexai:
-            _client = Client(
-                vertexai=True,
-                project=self.project,
-                location=self.location or "us-central1",
-                http_options=http_options,
+        if self.platform == "vertex":
+            _api_provider = self.api_provider or APIProvider(
+                name="vertex", base_url=None, api_key=None
             )
+            config = dict(self.platform_config or {})
+            kwargs = {"vertexai": True, **config, **extra}
+            kwargs.setdefault("location", "global")
         else:
             _api_provider = self.api_provider or APIProvider(
-                name="google",
+                name="gemini",
                 base_url=None,
                 api_key=os.getenv("GOOGLE_API_KEY"),
             )
-            _client = Client(
-                api_key=_api_provider.get("api_key"),
-                http_options=http_options,
-            )
-            object.__setattr__(self, "api_provider", _api_provider)
+            kwargs = {"api_key": _api_provider.get("api_key"), **extra}
 
+        kwargs.setdefault("http_options", self._http_options())
+        _client = Client(**kwargs)
+
+        object.__setattr__(self, "api_provider", _api_provider)
         object.__setattr__(self, "client", _client)
+
+    def _http_options(self) -> GeminiHttpOptions:
+        # Client args whose role is identical across providers (timeout,
+        # default headers, a shared httpx client) map onto the genai client's
+        # ``http_options``.
+        opts: dict[str, Any] = {}
+        if self.gemini_client_timeout is not None:
+            opts["timeout"] = int(self.gemini_client_timeout * 1000)  # ms
+        if self.default_headers is not None:
+            opts["headers"] = dict(self.default_headers)
+        if self.http_client is not None:
+            opts["httpx_async_client"] = self.http_client
+        return GeminiHttpOptions(**opts)
 
     # --- Input preparation ---
 
@@ -153,13 +201,17 @@ class GeminiLLM(CloudLLM):
         extra_body = merged.pop("extra_body", None)
         merged.pop("extra_query", None)  # no Gemini equivalent
         if extra_headers or extra_body:
-            # Request-level http_options replace the client-level ones, so
-            # the client timeout must be re-applied here.
+            # Request-level http_options replace the client-level ones, so the
+            # client timeout and default headers must be re-applied here.
             http_options: GeminiHttpOptionsDict = {}
             if self.gemini_client_timeout is not None:
                 http_options["timeout"] = int(self.gemini_client_timeout * 1000)
-            if extra_headers:
-                http_options["headers"] = extra_headers
+            merged_headers: dict[str, str] = {
+                **(self.default_headers or {}),
+                **(extra_headers or {}),
+            }
+            if merged_headers:
+                http_options["headers"] = merged_headers
             if extra_body:
                 http_options["extra_body"] = extra_body
             config_kwargs["http_options"] = http_options

--- a/src/grasp_agents/llm_providers/litellm/__init__.py
+++ b/src/grasp_agents/llm_providers/litellm/__init__.py
@@ -9,7 +9,7 @@ from litellm.types.utils import ModelResponseStream as LiteLLMCompletionChunk
 from litellm.types.utils import StreamingChoices as LiteLLMChunkChoice
 from litellm.types.utils import Usage as LiteLLMUsage
 from openai._streaming import (
-    AsyncStream as OpenAIAsyncStream,  # type: ignore[import] # noqa: PLC2701
+    AsyncStream as OpenAIAsyncStream,  # type: ignore[import]
 )
 from openai.types import CompletionUsage as OpenAIUsage
 from openai.types.chat.chat_completion import ChatCompletion as OpenAICompletion

--- a/src/grasp_agents/llm_providers/openai_completions/__init__.py
+++ b/src/grasp_agents/llm_providers/openai_completions/__init__.py
@@ -65,6 +65,7 @@ from openai.types.chat.chat_completion_tool_param import (
 from openai.types.chat.chat_completion_user_message_param import (
     ChatCompletionUserMessageParam as OpenAIUserMessageParam,
 )
+from openai.types.chat.completion_create_params import Moderation as OpenAIModeration
 from openai.types.chat.completion_create_params import (
     WebSearchOptions as OpenAIWebSearchOptions,
 )
@@ -75,19 +76,23 @@ from openai.types.shared_params import (
     ResponseFormatJSONObject as OpenAIResponseFormatJSONObject,
 )
 from openai.types.shared_params import (
+    ResponseFormatJSONSchema as OpenAIResponseFormatJSONSchema,
+)
+from openai.types.shared_params import (
     ResponseFormatText as OpenAIResponseFormatText,
 )
 from openai.types.shared_params.function_definition import (
     FunctionDefinition as OpenAIFunctionDefinition,
 )
 
-from .completions_llm import OpenAILLM, OpenAILLMSettings
+from .completions_llm import AzureClientConfig, OpenAILLM, OpenAILLMSettings
 from .response_to_provider_inputs import (
     items_to_provider_inputs,
     response_to_provider_input,
 )
 
 __all__ = [
+    "AzureClientConfig",
     "OpenAILLM",
     "OpenAILLMSettings",
     "items_to_provider_inputs",

--- a/src/grasp_agents/llm_providers/openai_completions/completions_llm.py
+++ b/src/grasp_agents/llm_providers/openai_completions/completions_llm.py
@@ -1,11 +1,11 @@
 import logging
 import os
-from collections.abc import AsyncIterator, Mapping, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any, Literal, TypedDict
 
-from openai import AsyncOpenAI, AsyncStream
+from openai import AsyncAzureOpenAI, AsyncOpenAI, AsyncStream
 from openai._types import omit  # type: ignore  # noqa: PLC2701
 from openai.lib.streaming.chat import (
     AsyncChatCompletionStreamManager as OpenAIAsyncChatCompletionStreamManager,
@@ -28,9 +28,11 @@ from grasp_agents.types.response import Response
 from . import (
     OpenAICompletion,
     OpenAICompletionChunk,
+    OpenAIModeration,
     OpenAIParsedCompletion,
     OpenAIPredictionContentParam,
     OpenAIResponseFormatJSONObject,
+    OpenAIResponseFormatJSONSchema,
     OpenAIResponseFormatText,
     OpenAIStreamOptionsParam,
     OpenAIToolChoiceOptionParam,
@@ -78,15 +80,6 @@ _COMPAT_LITELLM_PROVIDERS = {
 class OpenAILLMSettings(CloudLLMSettings, total=False):
     max_completion_tokens: int | None
     seed: int | None
-
-    reasoning_effort: (
-        Literal["none", "disable", "minimal", "low", "medium", "high"] | None
-    )
-
-    parallel_tool_calls: bool
-
-    modalities: list[Literal["text"]] | None
-
     frequency_penalty: float | None
     presence_penalty: float | None
     logit_bias: dict[str, int] | None
@@ -94,38 +87,92 @@ class OpenAILLMSettings(CloudLLMSettings, total=False):
     logprobs: bool | None
     top_logprobs: int | None
 
+    reasoning_effort: (
+        Literal["none", "disable", "minimal", "low", "medium", "high"] | None
+    )
+
+    parallel_tool_calls: bool
+
     stream_options: OpenAIStreamOptionsParam | None
 
-    prediction: OpenAIPredictionContentParam | None
+    # The SDK's full response_format union (text / json_schema / json_object).
+    # Sending a json_schema here is the manual path; the
+    # ``apply_output_schema_via_provider`` gate instead routes the
+    # ``output_schema`` through ``beta.chat.completions.parse``.
+    response_format: (
+        OpenAIResponseFormatText
+        | OpenAIResponseFormatJSONSchema
+        | OpenAIResponseFormatJSONObject
+    )
 
+    modalities: list[Literal["text"]] | None
     metadata: dict[str, str] | None
     store: bool | None
     user: str
-
-    # To support the old JSON mode without respose schemas
-    response_format: OpenAIResponseFormatJSONObject | OpenAIResponseFormatText
+    prediction: OpenAIPredictionContentParam | None
+    moderation: OpenAIModeration | None
+    service_tier: Literal["auto", "default", "flex", "scale", "priority"] | None
+    verbosity: Literal["low", "medium", "high"] | None
+    prompt_cache_key: str
+    prompt_cache_retention: Literal["in_memory", "24h"] | None
+    safety_identifier: str
 
     # TODO: support audio
+
+
+class AzureClientConfig(TypedDict, total=False):
+    """
+    Client args for ``platform="azure"`` (an ``AsyncAzureOpenAI`` client).
+
+    Unset values fall back to the SDK's env vars: AZURE_OPENAI_ENDPOINT,
+    AZURE_OPENAI_API_KEY, OPENAI_API_VERSION. ``api_key`` / ``azure_ad_token``
+    are secrets, so the whole config is kept out of repr.
+    """
+
+    azure_endpoint: str
+    api_version: str
+    azure_deployment: str
+    api_key: str
+    azure_ad_token: str
+    azure_ad_token_provider: Callable[[], str | Awaitable[str]]
+    organization: str
+    base_url: str
 
 
 @dataclass(frozen=True)
 class OpenAILLM(CloudLLM):
     litellm_provider: str | None = "openai"
     llm_settings: OpenAILLMSettings | None = None
-    openai_client_timeout: float = 60.0
+    openai_client_timeout: float = 600.0
     # SDK-level retries default to 0: ``LLM.retry_policy`` is the retry
     # system, and a non-zero value here would multiply with it.
     openai_client_max_retries: int = 0
     extra_openai_client_params: dict[str, Any] | None = None
+
+    # "openai" routes to api.openai.com or any OpenAI-compatible endpoint
+    # (via ``api_provider`` / a ``provider/model`` prefix); "azure" builds an
+    # ``AsyncAzureOpenAI`` client (the Chat Completions surface is identical).
+    platform: Literal["openai", "azure"] = "openai"
+    # Azure client args (see AzureClientConfig). ``model_name`` is the Azure
+    # *deployment* name. May carry secrets — kept out of repr.
+    platform_config: AzureClientConfig | None = field(default=None, repr=False)
+
     client: AsyncOpenAI = field(init=False)
 
     def __post_init__(self):
         super().__post_init__()
 
+        if self.platform == "azure":
+            _client, _api_provider = self._build_azure_client()
+            object.__setattr__(self, "api_provider", _api_provider)
+            object.__setattr__(self, "client", _client)
+            # ``model_name`` is the Azure deployment name — left untouched.
+            if self.litellm_provider == "openai":
+                object.__setattr__(self, "litellm_provider", "azure")
+            return
+
         openai_compatible_providers = get_openai_compatible_providers()
-
         _api_provider = self.api_provider
-
         model_name_parts = self.model_name.split("/", 1)
 
         if _api_provider is not None:
@@ -157,22 +204,37 @@ class OpenAILLM(CloudLLM):
                 "you must provide an 'api_provider' argument."
             )
 
-        _openai_client_params = deepcopy(self.extra_openai_client_params or {})
-        _openai_client_params["timeout"] = self.openai_client_timeout
-        _openai_client_params["max_retries"] = self.openai_client_max_retries
-
-        if self.http_client is not None:
-            _openai_client_params["http_client"] = self.http_client
-
         _client = AsyncOpenAI(
             base_url=_api_provider.get("base_url"),
             api_key=_api_provider.get("api_key"),
-            **_openai_client_params,
+            **self._client_params(),
         )
 
         object.__setattr__(self, "model_name", _model_name)
         object.__setattr__(self, "api_provider", _api_provider)
         object.__setattr__(self, "client", _client)
+
+    def _client_params(self) -> dict[str, Any]:
+        # Client args common to the OpenAI and Azure clients; provider-specific
+        # client args go through ``extra_openai_client_params``.
+        params = deepcopy(self.extra_openai_client_params or {})
+        params["timeout"] = self.openai_client_timeout
+        params["max_retries"] = self.openai_client_max_retries
+        if self.http_client is not None:
+            params["http_client"] = self.http_client
+        if self.default_headers is not None:
+            params.setdefault("default_headers", self.default_headers)
+        return params
+
+    def _build_azure_client(self) -> tuple[AsyncAzureOpenAI, APIProvider]:
+        config: dict[str, Any] = dict(self.platform_config or {})
+        # Anything not supplied here is read from the SDK's Azure env vars.
+        azure_kwargs: dict[str, Any] = {**self._client_params(), **config}
+        client = AsyncAzureOpenAI(**azure_kwargs)
+        api_provider = self.api_provider or APIProvider(
+            name="azure", base_url=config.get("azure_endpoint"), api_key=None
+        )
+        return client, api_provider
 
     # --- Input preparation ---
 

--- a/src/grasp_agents/llm_providers/openai_responses/__init__.py
+++ b/src/grasp_agents/llm_providers/openai_responses/__init__.py
@@ -2,9 +2,14 @@ from openai.types.responses.response_create_params import (
     StreamOptions as OpenAIResponsesStreamOptionsParam,
 )
 
+from grasp_agents.llm_providers.openai_completions.completions_llm import (
+    AzureClientConfig,
+)
+
 from .responses_llm import OpenAIResponsesLLM, OpenAIResponsesLLMSettings
 
 __all__ = [
+    "AzureClientConfig",
     "OpenAIResponsesLLM",
     "OpenAIResponsesLLMSettings",
     "OpenAIResponsesStreamOptionsParam",

--- a/src/grasp_agents/llm_providers/openai_responses/responses_llm.py
+++ b/src/grasp_agents/llm_providers/openai_responses/responses_llm.py
@@ -1,11 +1,11 @@
 import logging
 import os
-from collections.abc import AsyncIterator, Mapping, Sequence
+from collections.abc import AsyncIterator, Iterable, Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import Any, Literal, cast
 
-from openai import AsyncOpenAI
+from openai import AsyncAzureOpenAI, AsyncOpenAI
 from openai._types import omit  # noqa: PLC2701
 from openai.lib.streaming.responses._responses import (
     AsyncResponseStreamManager,
@@ -13,8 +13,18 @@ from openai.lib.streaming.responses._responses import (
 from openai.types.responses import (
     ParsedResponse,
     Response,
+    ResponseIncludable,
     ResponseStreamEvent,
     ResponseTextConfigParam,
+)
+from openai.types.responses.response_create_params import (
+    ContextManagement as ResponsesContextManagement,
+)
+from openai.types.responses.response_create_params import (
+    Conversation as ResponsesConversation,
+)
+from openai.types.responses.response_create_params import (
+    Moderation as ResponsesModeration,
 )
 from openai.types.responses.response_create_params import (
     StreamOptions as ResponsesStreamOptionsParam,
@@ -30,6 +40,7 @@ from openai.types.responses.tool_param import (
 )
 from openai.types.responses.web_search_tool_param import WebSearchToolParam
 from openai.types.shared import Reasoning
+from openai.types.shared_params import Metadata
 from pydantic import BaseModel, TypeAdapter
 
 from grasp_agents.llm.cloud_llm import (
@@ -37,6 +48,9 @@ from grasp_agents.llm.cloud_llm import (
     APIProvider,
     CloudLLM,
     CloudLLMSettings,
+)
+from grasp_agents.llm_providers.openai_completions.completions_llm import (
+    AzureClientConfig,
 )
 from grasp_agents.tools.base import BaseTool, ToolChoice
 from grasp_agents.types.items import InputItem
@@ -92,19 +106,46 @@ class OpenAIResponsesLLMSettings(CloudLLMSettings, total=False):
     reasoning: Reasoning
     parallel_tool_calls: bool
     max_output_tokens: int
+    max_tool_calls: int | None
     top_logprobs: int | None
     web_search: WebSearchToolParam | None
 
+    truncation: Literal["auto", "disabled"] | None
+    service_tier: Literal["auto", "default", "flex", "scale", "priority"] | None
+    include: list[ResponseIncludable] | None
+    context_management: Iterable[ResponsesContextManagement] | None
+    moderation: ResponsesModeration | None
+
+    prompt_cache_key: str
+    prompt_cache_retention: Literal["in_memory", "24h"] | None
+    safety_identifier: str
+
     text: ResponseTextConfigParam
     stream_options: ResponsesStreamOptionsParam | None
+    metadata: Metadata | None
     store: bool | None
     user: str
+
+
+class ResponsesApiCallParams(ApiCallParams, total=False):
+    # Per-call server-side-state pointers, threaded next to api_input/api_tools
+    # (not via the settings bag) — mutually exclusive at the API level.
+    previous_response_id: str | None
+    conversation: ResponsesConversation | None
 
 
 @dataclass(frozen=True)
 class OpenAIResponsesLLM(CloudLLM):
     litellm_provider: str | None = "openai"
     llm_settings: OpenAIResponsesLLMSettings | None = None
+    # "openai" routes to api.openai.com (or an OpenAI-compatible endpoint via
+    # ``api_provider``); "azure" builds an ``AsyncAzureOpenAI`` client. The
+    # Azure Responses API requires ``api_version`` >= "2025-03-01-preview"
+    # (or the version-less v1 surface).
+    platform: Literal["openai", "azure"] = "openai"
+    # Azure client args (see AzureClientConfig). ``model_name`` is the Azure
+    # *deployment* name. May carry secrets — kept out of repr.
+    platform_config: AzureClientConfig | None = field(default=None, repr=False)
     openai_client_timeout: float = 120.0
     # SDK-level retries default to 0: ``LLM.retry_policy`` is the retry
     # system, and a non-zero value here would multiply with it.
@@ -115,26 +156,51 @@ class OpenAIResponsesLLM(CloudLLM):
     def __post_init__(self):
         super().__post_init__()
 
+        if self.platform == "azure":
+            _client, _api_provider = self._build_azure_client()
+            object.__setattr__(self, "api_provider", _api_provider)
+            object.__setattr__(self, "client", _client)
+            # ``model_name`` is the Azure deployment name — left untouched.
+            if self.litellm_provider == "openai":
+                object.__setattr__(self, "litellm_provider", "azure")
+            return
+
         _api_provider = self.api_provider or APIProvider(
             name="openai",
             base_url="https://api.openai.com/v1",
             api_key=os.getenv("OPENAI_API_KEY"),
         )
 
-        _openai_client_params = deepcopy(self.extra_openai_client_params or {})
-        _openai_client_params["timeout"] = self.openai_client_timeout
-        _openai_client_params["max_retries"] = self.openai_client_max_retries
-        if self.http_client is not None:
-            _openai_client_params["http_client"] = self.http_client
-
         _client = AsyncOpenAI(
             base_url=_api_provider.get("base_url"),
             api_key=_api_provider.get("api_key"),
-            **_openai_client_params,
+            **self._client_params(),
         )
 
         object.__setattr__(self, "api_provider", _api_provider)
         object.__setattr__(self, "client", _client)
+
+    def _client_params(self) -> dict[str, Any]:
+        # Client args common to the OpenAI and Azure clients; provider-specific
+        # client args go through ``extra_openai_client_params``.
+        params = deepcopy(self.extra_openai_client_params or {})
+        params["timeout"] = self.openai_client_timeout
+        params["max_retries"] = self.openai_client_max_retries
+        if self.http_client is not None:
+            params["http_client"] = self.http_client
+        if self.default_headers is not None:
+            params.setdefault("default_headers", self.default_headers)
+        return params
+
+    def _build_azure_client(self) -> tuple[AsyncAzureOpenAI, APIProvider]:
+        config: dict[str, Any] = dict(self.platform_config or {})
+        # Anything not supplied here is read from the SDK's Azure env vars.
+        azure_kwargs: dict[str, Any] = {**self._client_params(), **config}
+        client = AsyncAzureOpenAI(**azure_kwargs)
+        api_provider = self.api_provider or APIProvider(
+            name="azure", base_url=config.get("azure_endpoint"), api_key=None
+        )
+        return client, api_provider
 
     # --- Input preparation ---
 
@@ -144,8 +210,10 @@ class OpenAIResponsesLLM(CloudLLM):
         tools: Mapping[str, BaseTool[BaseModel, Any, Any]] | None = None,
         tool_choice: ToolChoice | None = None,
         output_schema: Any | None = None,
+        previous_response_id: str | None = None,
+        conversation: ResponsesConversation | None = None,
         **extra_llm_settings: Any,
-    ) -> ApiCallParams:
+    ) -> ResponsesApiCallParams:
         api_tools: list[ResponsesToolParam] | None = None
         if tools:
             strict = self.apply_tool_call_schema_via_provider
@@ -163,10 +231,15 @@ class OpenAIResponsesLLM(CloudLLM):
             api_tools = api_tools or []
             api_tools.append(web_search_tool_param)
 
-        api_kwargs: ApiCallParams = ApiCallParams(
+        # Server-side-state pointers are per-call request args, not settings:
+        # thread them as first-class params (next to input/tools), so they
+        # reach the API call directly rather than via the settings bag.
+        api_kwargs: ResponsesApiCallParams = ResponsesApiCallParams(
             api_input=items_to_provider_inputs(input),
             api_tools=api_tools,
             api_tool_choice=api_tool_choice,
+            previous_response_id=previous_response_id,
+            conversation=conversation,
         )
         if output_schema is not None:
             api_kwargs["api_output_schema"] = output_schema
@@ -189,15 +262,20 @@ class OpenAIResponsesLLM(CloudLLM):
         api_tools: list[Any] | None = None,
         api_tool_choice: Any | None = None,
         api_output_schema: type | None = None,
+        previous_response_id: str | None = None,
+        conversation: ResponsesConversation | None = None,
         **api_llm_settings: Any,
     ) -> ParsedResponse[Any] | Response:
         tools = api_tools or omit
         tool_choice = api_tool_choice or omit
         text_format = api_output_schema or omit
 
-        response_id = api_llm_settings.get("previous_response_id")
+        # With server-held prior turns (a previous response or a conversation),
+        # only the items postdating the model's last output may be sent.
         input_items = (
-            _items_after_last_response(api_input) if response_id else api_input
+            _items_after_last_response(api_input)
+            if (previous_response_id or conversation)
+            else api_input
         )
 
         if self.apply_output_schema_via_provider:
@@ -207,6 +285,8 @@ class OpenAIResponsesLLM(CloudLLM):
                 input=input_items,
                 tools=tools,
                 tool_choice=tool_choice,
+                previous_response_id=previous_response_id or omit,
+                conversation=conversation or omit,
                 **api_llm_settings,
             )
         return await self.client.responses.create(
@@ -215,6 +295,8 @@ class OpenAIResponsesLLM(CloudLLM):
             stream=False,
             tools=tools,
             tool_choice=tool_choice,
+            previous_response_id=previous_response_id or omit,
+            conversation=conversation or omit,
             **api_llm_settings,
         )
 
@@ -225,11 +307,16 @@ class OpenAIResponsesLLM(CloudLLM):
         api_tools: list[Any] | None = None,
         api_tool_choice: Any | None = None,
         api_output_schema: type | None = None,
+        previous_response_id: str | None = None,
+        conversation: ResponsesConversation | None = None,
         **api_llm_settings: Any,
     ) -> AsyncIterator[ResponseStreamEvent]:
-        response_id = api_llm_settings.get("previous_response_id")
+        # With server-held prior turns (a previous response or a conversation),
+        # only the items postdating the model's last output may be sent.
         input_items = (
-            _items_after_last_response(api_input) if response_id else api_input
+            _items_after_last_response(api_input)
+            if (previous_response_id or conversation)
+            else api_input
         )
 
         _api_llm_settings = dict(api_llm_settings)
@@ -246,6 +333,8 @@ class OpenAIResponsesLLM(CloudLLM):
                     tool_choice=api_tool_choice or omit,
                     tools=api_tools or omit,
                     text_format=api_output_schema or omit,
+                    previous_response_id=previous_response_id or omit,
+                    conversation=conversation or omit,
                     **_api_llm_settings,
                 )
             )

--- a/tests/anthropic/test_cloud_platforms.py
+++ b/tests/anthropic/test_cloud_platforms.py
@@ -1,0 +1,147 @@
+"""AnthropicLLM cloud-platform client construction (Bedrock / Vertex)."""
+
+from typing import Any
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+from grasp_agents.llm_providers.anthropic.anthropic_llm import AnthropicLLM
+
+_BEDROCK_MODEL = "anthropic.claude-sonnet-4-5-20250929-v1:0"
+_VERTEX_MODEL = "claude-sonnet-4-5@20250929"
+
+
+def _capture(monkeypatch: pytest.MonkeyPatch, target: str) -> dict[str, Any]:
+    """Patch a client class with a kwargs-capturing fake; return the kwargs."""
+    captured: dict[str, Any] = {}
+
+    class _Fake:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr(target, _Fake)
+    return captured
+
+
+class TestBedrockConstruction:
+    def test_uses_bedrock_client_with_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = _capture(monkeypatch, "anthropic.AsyncAnthropicBedrock")
+        llm = AnthropicLLM(
+            model_name=_BEDROCK_MODEL,
+            platform="bedrock",
+            platform_config={"aws_region": "us-east-1", "aws_profile": "prod"},
+        )
+        assert captured["aws_region"] == "us-east-1"
+        assert captured["aws_profile"] == "prod"
+        # The framework retry layer is the one retry system → SDK retries off.
+        assert captured["max_retries"] == 0
+        assert captured["timeout"] == llm.anthropic_client_timeout
+
+    def test_litellm_provider_defaults_to_bedrock(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _capture(monkeypatch, "anthropic.AsyncAnthropicBedrock")
+        llm = AnthropicLLM(model_name=_BEDROCK_MODEL, platform="bedrock")
+        assert llm.litellm_provider == "bedrock"
+
+    def test_bearer_token_via_platform_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = _capture(monkeypatch, "anthropic.AsyncAnthropicBedrock")
+        AnthropicLLM(
+            model_name=_BEDROCK_MODEL,
+            platform="bedrock",
+            platform_config={"api_key": "bedrock-bearer-xyz"},
+        )
+        assert captured["api_key"] == "bedrock-bearer-xyz"
+
+    def test_mantle_uses_mantle_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured = _capture(monkeypatch, "anthropic.AsyncAnthropicBedrockMantle")
+        AnthropicLLM(
+            model_name="anthropic.claude-opus-4-8",
+            platform="bedrock_mantle",
+            platform_config={"aws_region": "us-east-1"},
+        )
+        assert captured["aws_region"] == "us-east-1"
+
+    def test_real_bedrock_client_type(self) -> None:
+        from anthropic import AsyncAnthropicBedrock
+
+        llm = AnthropicLLM(
+            model_name=_BEDROCK_MODEL,
+            platform="bedrock",
+            platform_config={"aws_region": "us-east-1"},
+        )
+        assert isinstance(llm.client, AsyncAnthropicBedrock)
+
+
+class TestVertexConstruction:
+    def test_uses_vertex_client_with_config(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = _capture(monkeypatch, "anthropic.AsyncAnthropicVertex")
+        llm = AnthropicLLM(
+            model_name=_VERTEX_MODEL,
+            platform="vertex",
+            platform_config={"project_id": "my-proj", "region": "us-east5"},
+        )
+        assert captured["project_id"] == "my-proj"
+        assert captured["region"] == "us-east5"
+        assert llm.litellm_provider == "vertex_ai"
+
+    def test_real_vertex_client_type(self) -> None:
+        from anthropic import AsyncAnthropicVertex
+
+        llm = AnthropicLLM(
+            model_name=_VERTEX_MODEL,
+            platform="vertex",
+            platform_config={"project_id": "p", "region": "us-east5"},
+        )
+        assert isinstance(llm.client, AsyncAnthropicVertex)
+
+
+class TestClientArgForwarding:
+    def test_http_client_headers_and_extra_forwarded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = _capture(monkeypatch, "anthropic.AsyncAnthropicBedrock")
+        http_client = Mock(spec=httpx.AsyncClient)
+        AnthropicLLM(
+            model_name=_BEDROCK_MODEL,
+            platform="bedrock",
+            platform_config={"aws_region": "us-east-1"},
+            http_client=http_client,
+            default_headers={"X-Test": "1"},
+            extra_anthropic_client_params={"default_query": {"q": "1"}},
+        )
+        assert captured["http_client"] is http_client
+        assert captured["default_headers"] == {"X-Test": "1"}
+        assert captured["default_query"] == {"q": "1"}
+
+    def test_direct_api_forwards_shared_client_args(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = _capture(
+            monkeypatch,
+            "grasp_agents.llm_providers.anthropic.anthropic_llm.AsyncAnthropic",
+        )
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "dummy")
+        http_client = Mock(spec=httpx.AsyncClient)
+        AnthropicLLM(
+            model_name="claude-sonnet-4-5",
+            http_client=http_client,
+            default_headers={"X-Test": "1"},
+        )
+        assert captured["http_client"] is http_client
+        assert captured["default_headers"] == {"X-Test": "1"}
+
+    def test_secrets_kept_out_of_repr(self) -> None:
+        llm = AnthropicLLM(
+            model_name=_BEDROCK_MODEL,
+            platform="bedrock",
+            platform_config={"aws_secret_key": "SECRET", "aws_region": "us-east-1"},
+        )
+        assert "SECRET" not in repr(llm)

--- a/tests/gemini/test_cloud_platforms.py
+++ b/tests/gemini/test_cloud_platforms.py
@@ -1,0 +1,106 @@
+"""GeminiLLM client construction: Developer API (default) and Vertex AI."""
+
+from typing import Any
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+from grasp_agents.llm.cloud_llm import APIProvider
+from grasp_agents.llm_providers.gemini.gemini_llm import GeminiLLM
+
+_CLIENT = "grasp_agents.llm_providers.gemini.gemini_llm.Client"
+
+
+def _capture(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    class _Fake:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr(_CLIENT, _Fake)
+    return captured
+
+
+class TestGeminiDeveloperApi:
+    def test_default_platform_is_developer_api(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = _capture(monkeypatch)
+        GeminiLLM(
+            model_name="gemini-2.5-flash",
+            api_provider=APIProvider(name="google", base_url=None, api_key="dummy"),
+        )
+        assert captured["api_key"] == "dummy"
+        assert "vertexai" not in captured
+
+    def test_shared_client_args_on_http_options(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = _capture(monkeypatch)
+        http_client = Mock(spec=httpx.AsyncClient)
+        llm = GeminiLLM(
+            model_name="gemini-2.5-flash",
+            api_provider=APIProvider(name="google", base_url=None, api_key="d"),
+            http_client=http_client,
+            default_headers={"X-T": "1"},
+        )
+        http_options = captured["http_options"]
+        assert http_options.httpx_async_client is http_client
+        assert http_options.headers == {"X-T": "1"}
+        assert http_options.timeout == int((llm.gemini_client_timeout or 0) * 1000)
+
+    def test_extra_client_params_forwarded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = _capture(monkeypatch)
+        GeminiLLM(
+            model_name="gemini-2.5-flash",
+            api_provider=APIProvider(name="google", base_url=None, api_key="d"),
+            extra_gemini_client_params={"debug_config": "X"},
+        )
+        assert captured["debug_config"] == "X"
+
+
+class TestGeminiVertex:
+    def test_vertex_config_forwarded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured = _capture(monkeypatch)
+        creds = object()
+        GeminiLLM(
+            model_name="gemini-2.5-flash",
+            platform="vertex",
+            platform_config={
+                "project": "p",
+                "location": "us-east5",
+                "credentials": creds,
+            },
+        )
+        assert captured["vertexai"] is True
+        assert captured["project"] == "p"
+        assert captured["location"] == "us-east5"
+        assert captured["credentials"] is creds
+
+    def test_vertex_location_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured = _capture(monkeypatch)
+        GeminiLLM(
+            model_name="gemini-2.5-flash",
+            platform="vertex",
+            platform_config={"project": "p"},
+        )
+        assert captured["location"] == "us-central1"
+
+
+class TestGeminiRequestHeaders:
+    def test_request_headers_merge_client_default_headers(self) -> None:
+        # A per-request extra_headers must not drop the client-level
+        # default_headers — they are merged onto the request http_options.
+        llm = GeminiLLM(
+            model_name="gemini-2.5-flash",
+            api_provider=APIProvider(name="google", base_url=None, api_key="d"),
+            default_headers={"X-Client": "c"},
+            llm_settings={"extra_headers": {"X-Req": "r"}},
+        )
+        params = llm._make_api_input([])
+        config = params["extra_settings"]["config"]  # type: ignore[index]
+        assert config.http_options.headers == {"X-Client": "c", "X-Req": "r"}

--- a/tests/llm/test_settings_forwarding.py
+++ b/tests/llm/test_settings_forwarding.py
@@ -1,0 +1,81 @@
+"""
+Newly-exposed provider settings actually reach the API call kwargs.
+
+Each provider forwards ``llm_settings`` verbatim (no conversion); these assert a
+representative sample of the expanded settings lands in the API request that
+``_make_api_input`` builds — i.e. nothing is silently dropped.
+"""
+
+import pytest
+
+from grasp_agents.llm.cloud_llm import APIProvider
+
+_GOOGLE = APIProvider(name="google", base_url=None, api_key="dummy")
+_OPENAI = APIProvider(name="openai", base_url=None, api_key="sk-x")
+
+
+def test_anthropic_forwards_new_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "dummy")
+    from grasp_agents.llm_providers.anthropic.anthropic_llm import AnthropicLLM
+
+    llm = AnthropicLLM(
+        model_name="claude-sonnet-4-5",
+        llm_settings={
+            "service_tier": "auto",
+            "metadata": {"user_id": "u1"},
+            "inference_geo": "us",
+            "output_config": {"effort": "low"},
+        },
+    )
+    extra = llm._make_api_input([]).get("extra_settings", {})
+    assert extra["service_tier"] == "auto"
+    assert extra["metadata"] == {"user_id": "u1"}
+    assert extra["inference_geo"] == "us"
+    assert extra["output_config"] == {"effort": "low"}
+
+
+def test_openai_completions_forwards_new_settings() -> None:
+    from grasp_agents.llm_providers.openai_completions.completions_llm import OpenAILLM
+
+    llm = OpenAILLM(
+        model_name="gpt-4o",
+        api_provider=_OPENAI,
+        llm_settings={"n": 2, "service_tier": "flex", "verbosity": "low"},
+    )
+    extra = llm._make_api_input([]).get("extra_settings", {})
+    assert extra["n"] == 2
+    assert extra["service_tier"] == "flex"
+    assert extra["verbosity"] == "low"
+
+
+def test_openai_responses_forwards_new_settings() -> None:
+    from grasp_agents.llm_providers.openai_responses.responses_llm import (
+        OpenAIResponsesLLM,
+    )
+
+    llm = OpenAIResponsesLLM(
+        model_name="gpt-4o",
+        api_provider=_OPENAI,
+        llm_settings={
+            "truncation": "auto",
+            "max_tool_calls": 3,
+            "service_tier": "flex",
+        },
+    )
+    extra = llm._make_api_input([]).get("extra_settings", {})
+    assert extra["truncation"] == "auto"
+    assert extra["max_tool_calls"] == 3
+    assert extra["service_tier"] == "flex"
+
+
+def test_gemini_forwards_new_settings() -> None:
+    from grasp_agents.llm_providers.gemini.gemini_llm import GeminiLLM
+
+    llm = GeminiLLM(
+        model_name="gemini-2.5-flash",
+        api_provider=_GOOGLE,
+        llm_settings={"candidate_count": 2, "labels": {"team": "x"}},
+    )
+    config = llm._make_api_input([])["extra_settings"]["config"]  # type: ignore[index]
+    assert config.candidate_count == 2
+    assert config.labels == {"team": "x"}

--- a/tests/llm/test_settings_forwarding.py
+++ b/tests/llm/test_settings_forwarding.py
@@ -74,8 +74,8 @@ def test_gemini_forwards_new_settings() -> None:
     llm = GeminiLLM(
         model_name="gemini-2.5-flash",
         api_provider=_GOOGLE,
-        llm_settings={"candidate_count": 2, "labels": {"team": "x"}},
+        llm_settings={"enable_enhanced_civic_answers": False, "labels": {"team": "x"}},
     )
     config = llm._make_api_input([])["extra_settings"]["config"]  # type: ignore[index]
-    assert config.candidate_count == 2
+    assert config.enable_enhanced_civic_answers is False
     assert config.labels == {"team": "x"}

--- a/tests/openai_completions/test_azure.py
+++ b/tests/openai_completions/test_azure.py
@@ -1,0 +1,113 @@
+"""Azure OpenAI client construction for OpenAILLM (Chat Completions)."""
+
+from typing import Any
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+from grasp_agents.llm.cloud_llm import APIProvider
+from grasp_agents.llm_providers.openai_completions.completions_llm import OpenAILLM
+
+_AZURE = (
+    "grasp_agents.llm_providers.openai_completions.completions_llm.AsyncAzureOpenAI"
+)
+
+
+def _capture(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    class _Fake:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr(_AZURE, _Fake)
+    return captured
+
+
+class TestAzureCompletions:
+    def test_builds_azure_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured = _capture(monkeypatch)
+        llm = OpenAILLM(
+            model_name="my-deployment",
+            platform="azure",
+            platform_config={
+                "azure_endpoint": "https://x.openai.azure.com",
+                "api_version": "2024-10-21",
+            },
+        )
+        assert captured["azure_endpoint"] == "https://x.openai.azure.com"
+        assert captured["api_version"] == "2024-10-21"
+        # The Azure deployment name must be preserved (NOT prefix-split).
+        assert llm.model_name == "my-deployment"
+        assert llm.litellm_provider == "azure"
+
+    def test_ad_token_provider_forwarded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured = _capture(monkeypatch)
+
+        def provider() -> str:
+            return "token"
+
+        OpenAILLM(
+            model_name="dep",
+            platform="azure",
+            platform_config={
+                "azure_endpoint": "https://x",
+                "api_version": "2024-10-21",
+                "azure_ad_token_provider": provider,
+            },
+        )
+        assert captured["azure_ad_token_provider"] is provider
+
+    def test_shared_client_args_forwarded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = _capture(monkeypatch)
+        http_client = Mock(spec=httpx.AsyncClient)
+        OpenAILLM(
+            model_name="dep",
+            platform="azure",
+            platform_config={"azure_endpoint": "https://x", "api_version": "v"},
+            http_client=http_client,
+            default_headers={"X-T": "1"},
+            extra_openai_client_params={"organization": "org"},
+        )
+        assert captured["http_client"] is http_client
+        assert captured["default_headers"] == {"X-T": "1"}
+        assert captured["organization"] == "org"
+
+    def test_real_azure_client_type(self) -> None:
+        from openai import AsyncAzureOpenAI
+
+        llm = OpenAILLM(
+            model_name="dep",
+            platform="azure",
+            platform_config={
+                "azure_endpoint": "https://x.openai.azure.com",
+                "api_version": "2024-10-21",
+                "api_key": "sk-azure",
+            },
+        )
+        assert isinstance(llm.client, AsyncAzureOpenAI)
+
+    def test_secrets_kept_out_of_repr(self) -> None:
+        llm = OpenAILLM(
+            model_name="dep",
+            platform="azure",
+            platform_config={
+                "azure_endpoint": "https://x",
+                "api_version": "v",
+                "api_key": "SECRET",
+            },
+        )
+        assert "SECRET" not in repr(llm)
+
+    def test_non_azure_path_unaffected(self) -> None:
+        from openai import AsyncAzureOpenAI, AsyncOpenAI
+
+        llm = OpenAILLM(
+            model_name="gpt-4o",
+            api_provider=APIProvider(name="openai", base_url=None, api_key="sk-x"),
+        )
+        assert isinstance(llm.client, AsyncOpenAI)
+        assert not isinstance(llm.client, AsyncAzureOpenAI)

--- a/tests/openai_responses/test_azure.py
+++ b/tests/openai_responses/test_azure.py
@@ -1,0 +1,82 @@
+"""Azure OpenAI client construction for OpenAIResponsesLLM (Responses API)."""
+
+from typing import Any
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+from grasp_agents.llm.cloud_llm import APIProvider
+from grasp_agents.llm_providers.openai_responses.responses_llm import (
+    OpenAIResponsesLLM,
+)
+
+_AZURE = "grasp_agents.llm_providers.openai_responses.responses_llm.AsyncAzureOpenAI"
+
+
+def _capture(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    class _Fake:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr(_AZURE, _Fake)
+    return captured
+
+
+class TestAzureResponses:
+    def test_builds_azure_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured = _capture(monkeypatch)
+        # The Responses API on Azure needs a preview/v1 api_version.
+        llm = OpenAIResponsesLLM(
+            model_name="my-deployment",
+            platform="azure",
+            platform_config={
+                "azure_endpoint": "https://x.openai.azure.com",
+                "api_version": "2025-03-01-preview",
+            },
+        )
+        assert captured["azure_endpoint"] == "https://x.openai.azure.com"
+        assert captured["api_version"] == "2025-03-01-preview"
+        assert llm.model_name == "my-deployment"
+        assert llm.litellm_provider == "azure"
+
+    def test_shared_client_args_forwarded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        captured = _capture(monkeypatch)
+        http_client = Mock(spec=httpx.AsyncClient)
+        OpenAIResponsesLLM(
+            model_name="dep",
+            platform="azure",
+            platform_config={"azure_endpoint": "https://x", "api_version": "v"},
+            http_client=http_client,
+            default_headers={"X-T": "1"},
+        )
+        assert captured["http_client"] is http_client
+        assert captured["default_headers"] == {"X-T": "1"}
+
+    def test_real_azure_client_type(self) -> None:
+        from openai import AsyncAzureOpenAI
+
+        llm = OpenAIResponsesLLM(
+            model_name="dep",
+            platform="azure",
+            platform_config={
+                "azure_endpoint": "https://x.openai.azure.com",
+                "api_version": "2025-03-01-preview",
+                "api_key": "sk-azure",
+            },
+        )
+        assert isinstance(llm.client, AsyncAzureOpenAI)
+
+    def test_non_azure_path_unaffected(self) -> None:
+        from openai import AsyncAzureOpenAI, AsyncOpenAI
+
+        llm = OpenAIResponsesLLM(
+            model_name="gpt-4o",
+            api_provider=APIProvider(name="openai", base_url=None, api_key="sk-x"),
+        )
+        assert isinstance(llm.client, AsyncOpenAI)
+        assert not isinstance(llm.client, AsyncAzureOpenAI)

--- a/tests/openai_responses/test_server_state.py
+++ b/tests/openai_responses/test_server_state.py
@@ -1,0 +1,103 @@
+"""
+previous_response_id / conversation are explicit per-call params, not settings.
+
+Both are server-side multi-turn-state pointers (not stable model config), so
+they are passed straight to ``responses.create`` next to ``input``/``tools`` and
+gate the "send only items after the last model output" slicing.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from grasp_agents.llm.cloud_llm import APIProvider
+from grasp_agents.llm_providers.openai_responses.responses_llm import (
+    OpenAIResponsesLLM,
+    OpenAIResponsesLLMSettings,
+)
+
+_OPENAI = APIProvider(name="openai", base_url=None, api_key="sk-x")
+
+# A user turn, a model reply, then a new user turn — slicing keeps only the
+# trailing item(s) that postdate the model's last output.
+_API_INPUT: list[Any] = [
+    {"role": "user", "content": "hi"},
+    {"type": "message", "role": "assistant", "content": "hello"},
+    {"role": "user", "content": "next"},
+]
+
+
+def test_server_state_params_are_not_settings() -> None:
+    keys = OpenAIResponsesLLMSettings.__optional_keys__
+    assert "previous_response_id" not in keys
+    assert "conversation" not in keys
+    # ``instructions`` is the system prompt (built from input); not a setting.
+    assert "instructions" not in keys
+
+
+def test_make_api_input_extracts_server_state() -> None:
+    # Passed as per-call kwargs, they are extracted into the api-call params
+    # (next to input/tools), NOT left in the settings bag.
+    llm = OpenAIResponsesLLM(model_name="gpt-4o", api_provider=_OPENAI)
+    params = llm._make_api_input(
+        [], previous_response_id="resp_1", conversation="conv_1"
+    )
+    assert params["previous_response_id"] == "resp_1"
+    assert params["conversation"] == "conv_1"
+    extra = params.get("extra_settings", {})
+    assert "previous_response_id" not in extra
+    assert "conversation" not in extra
+
+
+@pytest.mark.asyncio
+async def test_previous_response_id_threaded_and_slices(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    llm = OpenAIResponsesLLM(model_name="gpt-4o", api_provider=_OPENAI)
+    captured: dict[str, Any] = {}
+
+    async def fake_create(**kwargs: Any) -> MagicMock:
+        captured.update(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr(llm.client.responses, "create", fake_create)
+    await llm._get_api_response(_API_INPUT, previous_response_id="resp_1")
+
+    assert captured["previous_response_id"] == "resp_1"
+    assert captured["input"] == _API_INPUT[2:]  # sliced to the new user turn
+
+
+@pytest.mark.asyncio
+async def test_conversation_threaded_and_slices(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    llm = OpenAIResponsesLLM(model_name="gpt-4o", api_provider=_OPENAI)
+    captured: dict[str, Any] = {}
+
+    async def fake_create(**kwargs: Any) -> MagicMock:
+        captured.update(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr(llm.client.responses, "create", fake_create)
+    await llm._get_api_response(_API_INPUT, conversation="conv_1")
+
+    assert captured["conversation"] == "conv_1"
+    assert captured["input"] == _API_INPUT[2:]
+
+
+@pytest.mark.asyncio
+async def test_no_server_state_sends_full_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    llm = OpenAIResponsesLLM(model_name="gpt-4o", api_provider=_OPENAI)
+    captured: dict[str, Any] = {}
+
+    async def fake_create(**kwargs: Any) -> MagicMock:
+        captured.update(kwargs)
+        return MagicMock()
+
+    monkeypatch.setattr(llm.client.responses, "create", fake_create)
+    await llm._get_api_response(_API_INPUT)
+
+    assert captured["input"] == _API_INPUT  # no slicing without server state

--- a/uv.lock
+++ b/uv.lock
@@ -169,6 +169,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/f2/bee5de8a2699fc8a3cce34d61c7a2626a2c310ddde7ea5611327eb0ddbe9/anthropic-0.109.2-py3-none-any.whl", hash = "sha256:e0fb4ca5df0ed983248c9c6c3242adc81d9cfddb8725902da53698554117abac", size = 923800, upload-time = "2026-06-15T17:30:23.124Z" },
 ]
 
+[package.optional-dependencies]
+bedrock = [
+    { name = "boto3" },
+    { name = "botocore" },
+]
+vertex = [
+    { name = "google-auth", extra = ["requests"] },
+]
+
 [[package]]
 name = "anyio"
 version = "4.14.0"
@@ -330,6 +339,34 @@ wheels = [
 [package.optional-dependencies]
 css = [
     { name = "tinycss2" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.43.34"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/ac/178eb7f96bb6d5771105fe998b8b34512ef3f7ce9e2f1ab8d018df935bee/boto3-1.43.34.tar.gz", hash = "sha256:444207c6c883d4df3ea3b2c36df43ad492b86e0b889eebd2fc1d5ea8db0a8a1a", size = 112656, upload-time = "2026-06-19T19:33:39.366Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/5f/ac0872df61c3cea3539252f867cf8d76c226e4952f52a981b3fa54381060/boto3-1.43.34-py3-none-any.whl", hash = "sha256:42595057324606928c6e2432b3093978e4d722e0d432bce942f2a385702c0a43", size = 140029, upload-time = "2026-06-19T19:33:37.807Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.34"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/0d/559cdceb9f6acea6b91404970b7973e28a4434fa8a70eb1416b0af478d86/botocore-1.43.34.tar.gz", hash = "sha256:ccc973cf30c6445b30afe5760f6dc949a80f1f862cb23d9c45747f2c814ece77", size = 15591382, upload-time = "2026-06-19T19:33:28.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d5/ea/dc5aab38e2b3f63380810465fab92c836e9e8bce458eba4a8a896f25e1d2/botocore-1.43.34-py3-none-any.whl", hash = "sha256:238a0269f33c5914b9343900b44767e783b3e8b6dcb6e065eac8b4495601c5df", size = 15277590, upload-time = "2026-06-19T19:33:24.562Z" },
 ]
 
 [[package]]
@@ -1159,11 +1196,14 @@ dependencies = [
 
 [package.optional-dependencies]
 all-llm-providers = [
-    { name = "anthropic" },
+    { name = "anthropic", extra = ["bedrock", "vertex"] },
     { name = "google-genai" },
 ]
 anthropic = [
     { name = "anthropic" },
+]
+bedrock = [
+    { name = "anthropic", extra = ["bedrock"] },
 ]
 e2b = [
     { name = "e2b" },
@@ -1197,6 +1237,10 @@ tui = [
     { name = "textual" },
     { name = "textual-image" },
 ]
+vertex = [
+    { name = "anthropic", extra = ["vertex"] },
+    { name = "google-genai" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1220,8 +1264,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", marker = "extra == 'all-llm-providers'", specifier = ">=0.84,<1" },
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.84,<1" },
+    { name = "anthropic", extras = ["bedrock"], marker = "extra == 'bedrock'", specifier = ">=0.84,<1" },
+    { name = "anthropic", extras = ["bedrock", "vertex"], marker = "extra == 'all-llm-providers'", specifier = ">=0.84,<1" },
+    { name = "anthropic", extras = ["vertex"], marker = "extra == 'vertex'", specifier = ">=0.84,<1" },
     { name = "arize-phoenix-otel", marker = "extra == 'phoenix'", specifier = ">=0.13.1,<1" },
     { name = "catppuccin", marker = "extra == 'tui'", specifier = ">=2.5.0,<3" },
     { name = "chafa-py", marker = "extra == 'tui'", specifier = ">=1.2,<2" },
@@ -1229,6 +1275,7 @@ requires-dist = [
     { name = "e2b-code-interpreter", marker = "extra == 'e2b'", specifier = ">=2.7.0,<3" },
     { name = "google-genai", marker = "extra == 'all-llm-providers'", specifier = ">=1.65,<2" },
     { name = "google-genai", marker = "extra == 'gemini'", specifier = ">=1.65,<2" },
+    { name = "google-genai", marker = "extra == 'vertex'", specifier = ">=1.65,<2" },
     { name = "httpx", specifier = ">=0.27.0,<1" },
     { name = "ipykernel", marker = "extra == 'notebook'", specifier = ">=6.19.1,<7" },
     { name = "ipython", marker = "extra == 'notebook'", specifier = ">=8.3.0,<9" },
@@ -1250,7 +1297,7 @@ requires-dist = [
     { name = "textual", marker = "extra == 'tui'", specifier = ">=8.0,<9" },
     { name = "textual-image", marker = "extra == 'tui'", specifier = ">=0.13,<1" },
 ]
-provides-extras = ["anthropic", "gemini", "all-llm-providers", "e2b", "mcp", "notebook-edit", "notebook", "phoenix", "tui"]
+provides-extras = ["anthropic", "gemini", "bedrock", "vertex", "all-llm-providers", "e2b", "mcp", "notebook-edit", "notebook", "phoenix", "tui"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1690,6 +1737,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/95/a06692b29e77473f286e1ec1f426d3ca44d7b5843be8ad21d7a5f3fcdcc0/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:b6c0ffae686c39bf3737be60793783267628783ea42545632c10b291105aee45", size = 305128, upload-time = "2026-05-19T10:09:43.657Z" },
     { url = "https://files.pythonhosted.org/packages/23/85/7270d7ad41d6061a25b950c6bf91d638bd9aacb113200a8c8d57a055fd67/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d54fb5b31dea401a41af3f8a7d2512e9b6a6a005491e6166c7e4ffab9639a9c", size = 340459, upload-time = "2026-05-19T10:09:45.452Z" },
     { url = "https://files.pythonhosted.org/packages/c8/8d/302cb2057b7513327b4d575cff6b1d066ee6431a5357fc3f8867cd684406/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d5d6090cdc1b7c9e780dfb04949a990adb1e301a2fc0bbcee7de4638d33f9a", size = 344469, upload-time = "2026-05-19T10:09:46.864Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -3968,6 +4024,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/71/9b29d6b87cef468d697f43c6a91e3fae4a80185779d7d5a4ef27d173439f/ruff-0.15.17-py3-none-win32.whl", hash = "sha256:596065960ab1ff593f744220c9fe6580eda00a95003cffa9f4048bb5b1bf0392", size = 10925574, upload-time = "2026-06-11T17:54:55.723Z" },
     { url = "https://files.pythonhosted.org/packages/3d/b2/8fc77f3723228836fa5d12497eb71c808f83782e10d058d2b15cfa14640b/ruff-0.15.17-py3-none-win_amd64.whl", hash = "sha256:6769e5fa1710b179b92e0bfa5a51735b35baea9013dadb06d5f44cbcf9547084", size = 12058788, upload-time = "2026-06-11T17:54:41.042Z" },
     { url = "https://files.pythonhosted.org/packages/2d/c7/c53e8dbff9c9dc4b7928773421ae294a5d28fcb8dcda1a089579d3a7e510/ruff-0.15.17-py3-none-win_arm64.whl", hash = "sha256:f3be1fbb34bcdfd146240d8fb92a709d4c2c8191348580a3c044ec60fa0b4456", size = 11355275, upload-time = "2026-06-11T17:54:43.635Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/94/dcdaeb1713cab9c84def276cfac7388b17c7d9855bbcfe88d77e4dbafd44/s3transfer-0.19.0.tar.gz", hash = "sha256:ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685", size = 165171, upload-time = "2026-06-16T19:44:51.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/5f/4c174edad94f82de888ac00a5ddd8d07b35609b6c94f0bdf4d74af57703e/s3transfer-0.19.0-py3-none-any.whl", hash = "sha256:777cc2415536f1debadb5c2ef7779275d0fc0fe0e042411cdd6caebeb2685262", size = 90101, upload-time = "2026-06-16T19:44:50.439Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1181,7 +1181,7 @@ wheels = [
 
 [[package]]
 name = "grasp-agents"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
# Cloud LLM providers + full settings coverage

Adds support for the major cloud platforms and rounds out each provider's
settings, folded into the existing native providers (the cloud SDK clients
expose the same request surface, so only client construction differs).

## Cloud-hosted models

- **`platform=` discriminator + typed `platform_config`** on each provider:
  - `AnthropicLLM`: `bedrock` / `bedrock_mantle` / `vertex`
    (`BedrockClientConfig` / `VertexClientConfig`)
  - `OpenAILLM` & `OpenAIResponsesLLM`: `azure` → `AsyncAzureOpenAI`
    (`AzureClientConfig`)
  - `GeminiLLM`: `vertex` (`GeminiVertexClientConfig`)
- New optional extras `[bedrock]` (boto3) and `[vertex]` (google-auth);
  Azure needs none (ships in the base `openai` SDK).

## ⚠️ Breaking

- `GeminiLLM` drops flat `vertexai=` / `project=` / `location=` in favor of
  `platform="vertex"` + `platform_config`. (Developer-API usage via
  `api_provider=` is unchanged.)

## No dropped client args

- Shared `http_client` + `default_headers` are now forwarded by **all**
  providers (Anthropic & Gemini previously ignored `http_client`); each
  provider keeps an `extra_*_client_params` escape hatch.

## Complete, native LLM settings

- Each `*LLMSettings` now exposes every generation/behavior param its SDK
  accepts, forwarded verbatim (no implicit conversion); `LiteLLMSettings`
  inherits the OpenAI set. Framework-managed / incompatible params are
  deliberately excluded (system prompt, output modalities, `background`/`n`,
  deprecated reusable prompts).
- Responses `previous_response_id` / `conversation` are explicit per-call
  params (not settings), passed straight to the API with automatic
  input-slicing; cross-turn chaining is left to LLM hooks (recipe in README).

## Tests / docs

- New construction, arg-forwarding, and server-state tests across all
  providers; README "Cloud-hosted models" section. Version → 1.0.3.
- Suite green (2245 passed); pyright / ruff at baseline.

