### PR TITLE
Group agent spans

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grasp_agents"
-version = "1.0.3"
+version = "1.0.4"
 description = "Grasp Agents Library"
 readme = "README.md"
 requires-python = ">=3.12,<4"

--- a/src/grasp_agents/processors/processor.py
+++ b/src/grasp_agents/processors/processor.py
@@ -20,7 +20,11 @@ from grasp_agents import grasp_logging
 from grasp_agents.durability.checkpoint_mixin import CheckpointPersistMixin
 from grasp_agents.durability.checkpoints import CheckpointKind
 from grasp_agents.hooks import RecipientSelector
-from grasp_agents.run_context import RunContext, current_run_context
+from grasp_agents.run_context import (
+    DEFAULT_SESSION_KEY,
+    RunContext,
+    current_run_context,
+)
 from grasp_agents.telemetry import traced
 from grasp_agents.types.errors import (
     PacketRoutingError,
@@ -190,6 +194,21 @@ class Processor[InT, OutT, CtxT](
     def ctx(self) -> RunContext[CtxT]:
         """Session bound at construction. Immutable after init."""
         return self._ctx
+
+    def _trace_session_info(self) -> tuple[str, bool] | None:
+        """
+        Session identity for tracing: ``(session_id, group)`` or ``None``.
+
+        Read by the tracing layer (only when this run span would be a trace
+        root). ``None`` for the default (unnamed) session. Otherwise the session
+        id is stamped on the run's spans as the session attribute, and ``group``
+        (``ctx.session_trace_grouping``) decides whether every run of the session
+        is also parented into one shared trace.
+        """
+        ctx = self._ctx
+        if ctx.session_key == DEFAULT_SESSION_KEY:
+            return None
+        return ctx.session_key, ctx.session_trace_grouping
 
     # --- Session persistence ---
 

--- a/src/grasp_agents/run_context.py
+++ b/src/grasp_agents/run_context.py
@@ -17,6 +17,14 @@ from .types.io import ProcName
 from .types.response import Response
 from .usage_tracker import UsageTracker
 
+DEFAULT_SESSION_KEY = "default"
+"""Sentinel ``session_key`` for an unnamed session.
+
+Session-scoped stores route lookups by ``session_key``; trace grouping treats
+this value as "no session" (each run is its own trace root). Set a real
+``session_key`` to opt a session into single-trace grouping across runs.
+"""
+
 
 class RunContext[CtxT](BaseModel):
     state: CtxT = None  # type: ignore
@@ -41,7 +49,15 @@ class RunContext[CtxT](BaseModel):
     # currently serving. Used by every session-scoped store attached
     # below (``approval_store``, ``file_backend``, etc.) to route
     # lookups.
-    session_key: str = Field(default="default", exclude=True)
+    session_key: str = Field(default=DEFAULT_SESSION_KEY, exclude=True)
+
+    # When True (default), every run sharing this ``session_key`` is parented
+    # to a common session root derived from the key, so all runs of the session
+    # form ONE OTel trace in any backend. Set False to make each run its own
+    # trace root — e.g. when the backend groups runs itself (Phoenix Sessions
+    # via a ``session.id`` span attribute, which expects one trace per turn).
+    # No effect while ``session_key`` is the default sentinel.
+    session_trace_grouping: bool = Field(default=True, exclude=True)
 
     # Set ``approval_store`` to enable the approval gate built via
     # ``build_store_approval``; it scopes its session allowlist by

--- a/src/grasp_agents/runner/runner.py
+++ b/src/grasp_agents/runner/runner.py
@@ -11,7 +11,11 @@ from pydantic import ValidationError as PydanticValidationError
 from grasp_agents.durability.checkpoint_mixin import CheckpointPersistMixin
 from grasp_agents.durability.checkpoints import CheckpointKind, RunnerCheckpoint
 from grasp_agents.processors.processor import Processor
-from grasp_agents.run_context import RunContext, current_run_context
+from grasp_agents.run_context import (
+    DEFAULT_SESSION_KEY,
+    RunContext,
+    current_run_context,
+)
 from grasp_agents.telemetry import SpanKind, traced
 from grasp_agents.types.errors import RunnerError
 from grasp_agents.types.events import Event, ProcPacketOutEvent, RunPacketOutEvent
@@ -146,6 +150,20 @@ class Runner[OutT, CtxT](AutoInstanceAttributesMixin, CheckpointPersistMixin):
     @property
     def ctx(self) -> RunContext[CtxT]:
         return self._ctx
+
+    def _trace_session_info(self) -> tuple[str, bool] | None:
+        """
+        Session identity for tracing: ``(session_id, group)`` or ``None``.
+
+        ``None`` for the default session; otherwise the session id (stamped as
+        the session attribute on the run's spans) and whether to group every run
+        into one trace (``ctx.session_trace_grouping``). See
+        :class:`grasp_agents.processors.processor.Processor`.
+        """
+        ctx = self._ctx
+        if ctx.session_key == DEFAULT_SESSION_KEY:
+            return None
+        return ctx.session_key, ctx.session_trace_grouping
 
     # --- Session persistence ---
 

--- a/src/grasp_agents/telemetry/__init__.py
+++ b/src/grasp_agents/telemetry/__init__.py
@@ -1,11 +1,25 @@
-from .decorators import SpanKind, set_run_span_attributes, traced
-from .setup import add_exporter, add_otlp_http_exporter, init_tracing
+from .decorators import (
+    SpanKind,
+    derive_session_span_context,
+    set_run_span_attributes,
+    stamp_session_attributes,
+    traced,
+)
+from .setup import (
+    SessionSpanProcessor,
+    add_exporter,
+    add_otlp_http_exporter,
+    init_tracing,
+)
 
 __all__ = [
+    "SessionSpanProcessor",
     "SpanKind",
     "add_exporter",
     "add_otlp_http_exporter",
+    "derive_session_span_context",
     "init_tracing",
     "set_run_span_attributes",
+    "stamp_session_attributes",
     "traced",
 ]

--- a/src/grasp_agents/telemetry/decorators.py
+++ b/src/grasp_agents/telemetry/decorators.py
@@ -5,18 +5,23 @@ Follows the OTel library instrumentation pattern: depends only on opentelemetry-
 If no TracerProvider is configured by the application, all spans are no-ops.
 """
 
+import hashlib
 import inspect
 import json
 import os
 import re
 import traceback
-from collections.abc import Callable
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
 from enum import StrEnum
 from functools import wraps
 from logging import getLogger
 from typing import Any, cast, overload
 
+from opentelemetry import context as otel_context
 from opentelemetry import trace
+from opentelemetry.context import Context
+from opentelemetry.trace.propagation import set_span_in_context
 from pydantic import BaseModel
 
 logger = getLogger(__name__)
@@ -58,7 +63,7 @@ _GRASP_TO_OI_KIND: dict[str, str] = {
 # Constants
 # ---------------------------------------------------------------------------
 
-DEFAULT_EXCLUDE_FIELDS = {"_hidden_params", "completions"}
+DEFAULT_EXCLUDE_FIELDS = {"_hidden_params", "responses"}
 _TRACER_NAME = "grasp_agents"
 
 # ---------------------------------------------------------------------------
@@ -89,14 +94,29 @@ def _to_plain(obj: Any, exclude_fields: set[str] | None = None) -> Any:
 
 def _truncate_if_needed(json_str: str) -> str:
     limit_str = os.getenv("OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT")
-    if limit_str:
-        try:
-            limit = int(limit_str)
-            if limit > 0 and len(json_str) > limit:
-                return json_str[:limit]
-        except ValueError:
-            pass
-    return json_str
+    if not limit_str:
+        return json_str
+    try:
+        limit = int(limit_str)
+    except ValueError:
+        return json_str
+    if limit <= 0 or len(json_str) <= limit:
+        return json_str
+    # Keep the head AND tail, dropping the middle: the start and end of a
+    # prompt/response carry the most signal (the bulk is usually repetitive
+    # context). Fitted within `limit` so the SDK's own head-only cap never fires.
+    marker = f" …[{len(json_str) - limit} chars]… "
+    keep = limit - len(marker)
+    if keep <= 0:
+        # Limit too small to fit a head…tail marker — fall back to a head clip.
+        return json_str[:limit]
+    head, tail = keep // 2, keep - keep // 2
+    # Removing head+tail (not just the over-limit slice) raises the true omitted
+    # count; recompute the marker so the result still fits within `limit`.
+    marker = f" …[{len(json_str) - head - tail} chars]… "
+    keep = max(0, limit - len(marker))
+    head, tail = keep // 2, keep - keep // 2
+    return (json_str[:head] + marker + json_str[len(json_str) - tail :])[:limit]
 
 
 def _should_send_prompts() -> bool:
@@ -187,6 +207,152 @@ def set_run_span_attributes(**attributes: str | float | bool) -> None:
     if span.is_recording():
         for key, value in attributes.items():
             span.set_attribute(key, value)
+
+
+# ---------------------------------------------------------------------------
+# Session trace grouping + session attributes
+# ---------------------------------------------------------------------------
+
+
+def derive_session_span_context(session_key: str) -> Context:
+    """
+    Deterministic remote-parent context for a session.
+
+    Hashes ``session_key`` into a stable ``trace_id`` + root ``span_id`` so
+    every run of one session — across turns and across processes, with or
+    without a checkpoint store — lands in a single trace, parented to a common
+    session root. The root span itself is never emitted (it is a remote parent),
+    so the grouping is expressed purely in OTel primitives and renders in any
+    backend. Pass the result as a span's ``context=`` to correlate your own
+    work with a grasp-agents session.
+    """
+    digest = hashlib.sha256(session_key.encode("utf-8")).digest()
+    # trace_id is 128-bit, span_id 64-bit; both must be non-zero (OTel treats a
+    # zero id as invalid). A SHA-256 slice is non-zero in practice — guard anyway.
+    trace_id = int.from_bytes(digest[:16], "big") or 1
+    span_id = int.from_bytes(digest[16:24], "big") or 1
+    span_context = trace.SpanContext(
+        trace_id=trace_id,
+        span_id=span_id,
+        is_remote=True,
+        trace_flags=trace.TraceFlags(trace.TraceFlags.SAMPLED),
+    )
+    return set_span_in_context(trace.NonRecordingSpan(span_context))
+
+
+_DEFAULT_SESSION_ID_ATTRIBUTES = ("gen_ai.conversation.id",)
+
+
+def _session_id_attribute_keys() -> tuple[str, ...]:
+    """
+    Span-attribute keys to stamp with the session id.
+
+    Defaults to ``gen_ai.conversation.id`` (the OpenTelemetry GenAI convention).
+    Override via the ``GRASP_SESSION_ID_ATTRIBUTES`` env var — comma-separated,
+    e.g. ``gen_ai.conversation.id,session.id`` (set it empty to stamp none).
+    Which keys a backend reads is a deployment concern, so it is configured at
+    the deployment level (env) rather than per session.
+    """
+    raw = os.getenv("GRASP_SESSION_ID_ATTRIBUTES")
+    if raw is None:
+        return _DEFAULT_SESSION_ID_ATTRIBUTES
+    return tuple(k.strip() for k in raw.split(",") if k.strip())
+
+
+# Carries the active session id down the OTel context so SessionSpanProcessor
+# can stamp it onto every descendant span. A context value, NOT baggage: it
+# never rides outbound request headers, so a possibly-identifying session id is
+# not leaked to LLM providers / downstream services.
+_SESSION_ID_CTX_KEY = otel_context.create_key("grasp.session_id")
+
+
+def _resolve_run_span_context(instance: Any | None) -> Context | None:
+    """
+    Resolve the context for a run-ROOT span: session parent + session id.
+
+    A run root (``Processor`` / ``Runner``) exposes ``_trace_session_info`` — its
+    session id plus whether to group every run of the session into one trace.
+    Both apply only when this span would actually *be* a trace root (no span is
+    already recording); a nested run (a sub-agent under a runner, an
+    agent-as-tool, a generate/tool span) inherits the enclosing run's context
+    and is left untouched. The returned context carries:
+
+    * a derived session-root parent — so every run of the session shares one
+      trace — when grouping is on; otherwise no parent override;
+    * the session id as a context value, which :class:`SessionSpanProcessor`
+      reads to stamp the configured attribute(s) onto this span and every
+      descendant, attributing the whole run tree (incl. provider spans) to the
+      session.
+
+    ``None`` when nested or there is no named session. Telemetry must never fail
+    the call: any error falls back to ambient parenting.
+    """
+    if instance is None:
+        return None
+    get_info = getattr(instance, "_trace_session_info", None)
+    if get_info is None:
+        return None
+    try:
+        # Only the outermost run span adopts the session; a recording ancestor
+        # means we are nested and must inherit the enclosing run's context.
+        if trace.get_current_span().is_recording():
+            return None
+        info = get_info()
+        if info is None:
+            return None
+        session_id, group = info
+        ctx = derive_session_span_context(session_id) if group else None
+        return otel_context.set_value(_SESSION_ID_CTX_KEY, session_id, ctx)
+    except Exception:
+        logger.debug("session span resolution failed", exc_info=True)
+        return None
+
+
+def stamp_session_attributes(
+    span: trace.Span, parent_context: Context | None = None
+) -> None:
+    """
+    Stamp the active session id onto ``span`` as the configured attribute(s).
+
+    Reads the session id a run root placed on the OTel context (resolved from
+    ``parent_context``, else the current context) and writes it to each key in
+    ``GRASP_SESSION_ID_ATTRIBUTES`` (default ``gen_ai.conversation.id``). Called
+    by :class:`grasp_agents.telemetry.SessionSpanProcessor` for every span — so
+    the whole run tree, including provider-instrumentation spans, is attributed
+    to the session. No-op when no session is active or the span is not recording.
+    """
+    if not span.is_recording():
+        return
+    session_id = otel_context.get_value(_SESSION_ID_CTX_KEY, parent_context)
+    if not session_id:
+        return
+    for key in _session_id_attribute_keys():
+        span.set_attribute(key, str(session_id))
+
+
+@contextmanager
+def _run_span(
+    span_name: str, instance: Any | None
+) -> Generator[trace.Span, None, None]:
+    """
+    Open a span, attaching the run-root's session context for its duration.
+
+    At a run root the attached context carries the session parent + id, so the
+    span parents into the shared session trace (when grouping is on) and
+    :class:`SessionSpanProcessor` stamps the session attribute(s) on this span
+    AND every descendant — the attach (not just ``context=``) is what lets the
+    id reach child spans, since ``start_as_current_span`` re-bases the active
+    context on the current one. A nested span attaches nothing and inherits the
+    enclosing run's context.
+    """
+    parent_context = _resolve_run_span_context(instance)
+    token = otel_context.attach(parent_context) if parent_context is not None else None
+    try:
+        with trace.get_tracer(_TRACER_NAME).start_as_current_span(span_name) as span:
+            yield span
+    finally:
+        if token is not None:
+            otel_context.detach(token)
 
 
 def _handle_span_input(
@@ -293,9 +459,7 @@ def _entity_method[F: Callable[..., Any]](
                     span_name = _get_span_name(
                         entity_name, resolved_kind, instance=instance, kwargs=kwargs
                     )
-                    tracer = trace.get_tracer(_TRACER_NAME)
-
-                    with tracer.start_as_current_span(span_name) as span:
+                    with _run_span(span_name, instance) as span:
                         _set_span_attributes(span, entity_name, resolved_kind, version)
                         _apply_caller_span_overrides(span, kwargs)
                         _handle_span_input(span, input_args, kwargs, exclude_fields)
@@ -337,9 +501,7 @@ def _entity_method[F: Callable[..., Any]](
                 span_name = _get_span_name(
                     entity_name, resolved_kind, instance=instance, kwargs=kwargs
                 )
-                tracer = trace.get_tracer(_TRACER_NAME)
-
-                with tracer.start_as_current_span(span_name) as span:
+                with _run_span(span_name, instance) as span:
                     _set_span_attributes(span, entity_name, resolved_kind, version)
                     _apply_caller_span_overrides(span, kwargs)
                     _handle_span_input(span, input_args, kwargs, exclude_fields)
@@ -375,9 +537,7 @@ def _entity_method[F: Callable[..., Any]](
                 span_name = _get_span_name(
                     entity_name, resolved_kind, instance=instance, kwargs=kwargs
                 )
-                tracer = trace.get_tracer(_TRACER_NAME)
-
-                with tracer.start_as_current_span(span_name) as span:
+                with _run_span(span_name, instance) as span:
                     _set_span_attributes(span, entity_name, resolved_kind, version)
                     _apply_caller_span_overrides(span, kwargs)
                     _handle_span_input(span, input_args, kwargs, exclude_fields)
@@ -416,9 +576,7 @@ def _entity_method[F: Callable[..., Any]](
             span_name = _get_span_name(
                 entity_name, resolved_kind, instance=instance, kwargs=kwargs
             )
-            tracer = trace.get_tracer(_TRACER_NAME)
-
-            with tracer.start_as_current_span(span_name) as span:
+            with _run_span(span_name, instance) as span:
                 _set_span_attributes(span, entity_name, resolved_kind, version)
                 _apply_caller_span_overrides(span, kwargs)
                 _handle_span_input(span, input_args, kwargs, exclude_fields)

--- a/src/grasp_agents/telemetry/setup.py
+++ b/src/grasp_agents/telemetry/setup.py
@@ -10,18 +10,38 @@ from logging import getLogger
 from typing import Any
 
 from opentelemetry import trace
+from opentelemetry.context import Context
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
-from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace import SpanProcessor, TracerProvider
 from opentelemetry.sdk.trace.export import (
     BatchSpanProcessor,
     SimpleSpanProcessor,
     SpanExporter,
 )
+from opentelemetry.trace import Span
+
+from .decorators import stamp_session_attributes
 
 logger = getLogger(__name__)
 
 _init_lock = threading.Lock()
 _initialized = False
+
+
+class SessionSpanProcessor(SpanProcessor):
+    """
+    Stamp the active session id onto every span as configured attribute(s).
+
+    Reads the session id a run root placed on the OTel context and writes it to
+    each key in ``GRASP_SESSION_ID_ATTRIBUTES`` (default ``gen_ai.conversation.id``).
+    :func:`init_tracing` installs it automatically; add it to a hand-built
+    ``TracerProvider`` to propagate the session id to ALL spans — including
+    provider-instrumentation spans — for backends that group or filter by it per
+    span (Langfuse, Datadog, …). No-op when no session is active.
+    """
+
+    def on_start(self, span: Span, parent_context: Context | None = None) -> None:
+        stamp_session_attributes(span, parent_context)
 
 
 def init_tracing(project_name: str = "grasp-agents") -> TracerProvider:
@@ -47,6 +67,8 @@ def init_tracing(project_name: str = "grasp-agents") -> TracerProvider:
                 }
             ),
         )
+        # Propagates the run's session id onto every span (see the processor).
+        provider.add_span_processor(SessionSpanProcessor())
         trace.set_tracer_provider(provider)
         _initialized = True
         logger.info("Initialized TracerProvider for %s", project_name)

--- a/tests/gemini/test_cloud_platforms.py
+++ b/tests/gemini/test_cloud_platforms.py
@@ -88,7 +88,7 @@ class TestGeminiVertex:
             platform="vertex",
             platform_config={"project": "p"},
         )
-        assert captured["location"] == "us-central1"
+        assert captured["location"] == "global"
 
 
 class TestGeminiRequestHeaders:

--- a/tests/telemetry/test_tracing.py
+++ b/tests/telemetry/test_tracing.py
@@ -16,7 +16,15 @@ from opentelemetry.sdk.trace.export import (
     SpanExportResult,
 )
 
-from grasp_agents.telemetry import SpanKind, set_run_span_attributes, traced
+from grasp_agents.agent.llm_agent import LLMAgent
+from grasp_agents.run_context import RunContext
+from grasp_agents.telemetry import (
+    SessionSpanProcessor,
+    SpanKind,
+    derive_session_span_context,
+    set_run_span_attributes,
+    traced,
+)
 from grasp_agents.telemetry.decorators import (
     ATTR_ENTITY_INPUT,
     ATTR_ENTITY_NAME,
@@ -24,11 +32,14 @@ from grasp_agents.telemetry.decorators import (
     ATTR_OI_SPAN_KIND,
     ATTR_SPAN_KIND,
     ATTR_WORKFLOW_NAME,
+    _resolve_run_span_context,
     _resolve_span_kind,
     _should_send_prompts,
     _to_plain,
     _truncate_if_needed,
 )
+from grasp_agents.tools.agent_tool import AgentTool
+from tests._helpers import MockLLM, _text_response, _tool_call_response
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -62,6 +73,7 @@ class MemoryExporter(SpanExporter):
 
 _exporter = MemoryExporter()
 _provider = TracerProvider()
+_provider.add_span_processor(SessionSpanProcessor())  # stamps session attrs
 _provider.add_span_processor(SimpleSpanProcessor(_exporter))
 
 # Reset the set-once guard so we can install our test provider.
@@ -507,10 +519,21 @@ class TestHelpers:
         result = _to_plain({"items": [{"a": 1}, {"b": 2}]})
         assert result == {"items": [{"a": 1}, {"b": 2}]}
 
-    def test_truncate_if_needed(self) -> None:
+    def test_truncate_tiny_limit_falls_back_to_head_clip(self) -> None:
+        # Limit too small to fit a head…tail marker → plain head clip.
         with patch.dict(os.environ, {"OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT": "5"}):
             assert _truncate_if_needed("hello world") == "hello"
             assert _truncate_if_needed("hi") == "hi"
+
+    def test_truncate_keeps_head_and_tail(self) -> None:
+        with patch.dict(os.environ, {"OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT": "60"}):
+            text = "H" * 40 + "X" * 200 + "T" * 40
+            out = _truncate_if_needed(text)
+            assert len(out) <= 60  # never exceeds the limit
+            assert out.startswith("H")  # head kept
+            assert out.endswith("T")  # tail kept
+            assert "chars]" in out  # head…tail marker present
+            assert "X" * 20 not in out  # middle dropped
 
     def test_truncate_no_limit(self) -> None:
         with patch.dict(os.environ, {}, clear=False):
@@ -699,3 +722,207 @@ class TestCallerSpanOverrides:
         attrs = _exporter.get_finished_spans()[0].attributes or {}
         assert attrs["discovered"] == "mid-run"
         assert attrs["count"] == 2
+
+
+# ========================================================================= #
+#  Session trace grouping (deterministic, backend-agnostic)                  #
+# ========================================================================= #
+
+
+def _processor_spans() -> list[ReadableSpan]:
+    """Run-root spans (one per run_stream), selected by entity name."""
+    return [
+        s
+        for s in _exporter.get_finished_spans()
+        if (s.attributes or {}).get(ATTR_ENTITY_NAME) == "processor"
+    ]
+
+
+def _session_trace_id(session_key: str) -> int:
+    parent = derive_session_span_context(session_key)
+    return trace.get_current_span(parent).get_span_context().trace_id
+
+
+class TestSessionTraceDerivation:
+    def test_deterministic_and_distinct(self) -> None:
+        assert _session_trace_id("sess-A") == _session_trace_id("sess-A") != 0
+        assert _session_trace_id("sess-A") != _session_trace_id("sess-B")
+
+    def test_resolver_skips_default_and_missing_session(self) -> None:
+        class Named:
+            def _trace_session_info(self) -> tuple[str, bool] | None:
+                return ("sess-A", True)
+
+        class DefaultSession:
+            def _trace_session_info(self) -> tuple[str, bool] | None:
+                return None
+
+        assert _resolve_run_span_context(object()) is None  # no hook
+        assert _resolve_run_span_context(DefaultSession()) is None  # unnamed
+        assert _resolve_run_span_context(Named()) is not None  # at a run root
+
+    def test_resolver_skips_when_nested_under_recording_span(self) -> None:
+        class Named:
+            def _trace_session_info(self) -> tuple[str, bool] | None:
+                return ("sess-A", True)
+
+        # A live ancestor span means we are nested — inherit the enclosing run's
+        # context instead of starting a fresh session root.
+        with trace.get_tracer("test").start_as_current_span("outer"):
+            assert _resolve_run_span_context(Named()) is None
+
+
+class TestSessionTraceGrouping:
+    @pytest.mark.asyncio(loop_scope="function")
+    async def test_named_session_runs_share_one_trace_without_a_store(self) -> None:
+        # No checkpoint_store wired — grouping is purely from the session_key.
+        with RunContext[None](session_key="sess-multi-turn"):
+            agent = LLMAgent[str, str, None](
+                name="chat",
+                llm=MockLLM(
+                    responses_queue=[_text_response("a1"), _text_response("a2")]
+                ),
+            )
+            await agent.run(chat_inputs="turn 1")
+            await agent.run(chat_inputs="turn 2")
+
+        roots = _processor_spans()
+        assert len(roots) == 2
+        assert {s.context.trace_id for s in roots} == {
+            _session_trace_id("sess-multi-turn")
+        }
+
+    @pytest.mark.asyncio(loop_scope="function")
+    async def test_opt_out_makes_named_session_runs_independent(self) -> None:
+        with RunContext[None](
+            session_key="sess-optout", session_trace_grouping=False
+        ):
+            agent = LLMAgent[str, str, None](
+                name="chat",
+                llm=MockLLM(
+                    responses_queue=[_text_response("a1"), _text_response("a2")]
+                ),
+            )
+            await agent.run(chat_inputs="turn 1")
+            await agent.run(chat_inputs="turn 2")
+
+        roots = _processor_spans()
+        assert len(roots) == 2
+        # Opted out → each run is its own trace root despite the session_key.
+        assert roots[0].context.trace_id != roots[1].context.trace_id
+
+    @pytest.mark.asyncio(loop_scope="function")
+    async def test_default_session_runs_are_independent_traces(self) -> None:
+        agent = LLMAgent[str, str, None](
+            name="chat",
+            llm=MockLLM(responses_queue=[_text_response("a1"), _text_response("a2")]),
+        )
+        await agent.run(chat_inputs="turn 1")
+        await agent.run(chat_inputs="turn 2")
+
+        roots = _processor_spans()
+        assert len(roots) == 2
+        # Unnamed session → each run is its own trace root (prior behavior).
+        assert roots[0].context.trace_id != roots[1].context.trace_id
+
+    @pytest.mark.asyncio(loop_scope="function")
+    async def test_nested_run_stays_in_parent_session_trace(self) -> None:
+        # Construct inside the block: the session binds at construction time.
+        with RunContext[None](session_key="sess-nested"):
+            child = AgentTool[None](
+                name="research",
+                description="Research a topic",
+                llm=MockLLM(responses_queue=[_text_response("child answer")]),
+            )
+            parent = LLMAgent[str, str, None](
+                name="parent",
+                llm=MockLLM(
+                    responses_queue=[
+                        _tool_call_response("research", '{"prompt": "x"}', "tc1"),
+                        _text_response("done"),
+                    ]
+                ),
+                tools=[child],
+            )
+            await parent.run(chat_inputs="go")
+
+        roots = _processor_spans()
+        # Parent (run root) + spawned child both emit a processor span, and ALL
+        # live in the one session trace: the child nested under the parent's
+        # tool span instead of detaching to its own session root.
+        assert len(roots) >= 2
+        assert {s.context.trace_id for s in roots} == {_session_trace_id("sess-nested")}
+
+
+# ========================================================================= #
+#  Session attributes (SessionSpanProcessor — propagated to every span)      #
+# ========================================================================= #
+
+
+def _session_attr(span: ReadableSpan, key: str = "gen_ai.conversation.id") -> Any:
+    return (span.attributes or {}).get(key)
+
+
+async def _run_chat(session_key: str | None = None, **ctx_kwargs: Any) -> None:
+    llm = MockLLM(responses_queue=[_text_response("ok")])
+    if session_key is None:
+        agent = LLMAgent[str, str, None](name="chat", llm=llm)
+        await agent.run(chat_inputs="hi")
+        return
+    with RunContext[None](session_key=session_key, **ctx_kwargs):
+        agent = LLMAgent[str, str, None](name="chat", llm=llm)
+        await agent.run(chat_inputs="hi")
+
+
+class TestSessionAttributes:
+    @pytest.mark.asyncio(loop_scope="function")
+    async def test_stamped_on_run_and_child_spans(self) -> None:
+        await _run_chat("sess-attr")
+        spans = _exporter.get_finished_spans()
+        by_entity = {(s.attributes or {}).get(ATTR_ENTITY_NAME): s for s in spans}
+        # The run root (processor) AND a child it created (generate) both carry
+        # the session id — the processor propagates it down the whole run tree.
+        assert "processor" in by_entity
+        assert "generate" in by_entity
+        assert _session_attr(by_entity["processor"]) == "sess-attr"
+        assert _session_attr(by_entity["generate"]) == "sess-attr"
+
+    @pytest.mark.asyncio(loop_scope="function")
+    async def test_emitted_even_when_grouping_off(self) -> None:
+        # Session attributes are independent of headless trace grouping.
+        await _run_chat("sess-nogroup", session_trace_grouping=False)
+        spans = _exporter.get_finished_spans()
+        assert spans
+        assert all(_session_attr(s) == "sess-nogroup" for s in spans)
+
+    @pytest.mark.asyncio(loop_scope="function")
+    async def test_absent_for_default_session(self) -> None:
+        await _run_chat(session_key=None)
+        spans = _exporter.get_finished_spans()
+        assert spans
+        assert all(_session_attr(s) is None for s in spans)
+
+    @pytest.mark.asyncio(loop_scope="function")
+    async def test_keys_configurable_via_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GRASP_SESSION_ID_ATTRIBUTES", "session.id, custom.session")
+        await _run_chat("sess-cfg")
+        spans = _exporter.get_finished_spans()
+        root = next(
+            s for s in spans if _session_attr(s, ATTR_ENTITY_NAME) == "processor"
+        )
+        attrs = root.attributes or {}
+        assert attrs.get("session.id") == "sess-cfg"
+        assert attrs.get("custom.session") == "sess-cfg"
+        assert "gen_ai.conversation.id" not in attrs  # default replaced
+
+    @pytest.mark.asyncio(loop_scope="function")
+    async def test_opt_out_with_empty_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GRASP_SESSION_ID_ATTRIBUTES", "")
+        await _run_chat("sess-empty")
+        spans = _exporter.get_finished_spans()
+        assert spans
+        assert all(_session_attr(s) is None for s in spans)

--- a/uv.lock
+++ b/uv.lock
@@ -1181,7 +1181,7 @@ wheels = [
 
 [[package]]
 name = "grasp-agents"
-version = "1.0.3"
+version = "1.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
# Session-scoped OTel tracing: trace continuity + session attributes

Group all runs of a conversational session in observability tooling — in a
**backend-agnostic** way — and keep traced prompts/responses readable when
truncated.

## What changed

### 1. One trace per session (deterministic, any backend)

Multiple `run` / `run_stream` calls that share a `session_key` — across turns
and across processes — now form a **single OTel trace** instead of N
disconnected root traces. The session root is derived by hashing `session_key`
into a stable `trace_id` + root `span_id`; each run is parented to it as a
sibling. This is pure OTel (shared `trace_id` + remote parent), so it renders in
any backend (Phoenix, Jaeger, Tempo, Grafana, Datadog, …) with no
vendor-specific primitive. Active only for a named `session_key`; opt out per
session with `RunContext(session_trace_grouping=False)`.

### 2. Session id stamped on every span

A new `SessionSpanProcessor` stamps the session id onto the run-root span **and
every descendant** — LLM, tool, sub-agent, and provider-instrumentation spans —
so backends with a native Sessions/Threads feature can group by it.

- **Default key `gen_ai.conversation.id`** (the OpenTelemetry GenAI convention).
  Configure via `GRASP_SESSION_ID_ATTRIBUTES` (comma-separated — e.g.
  `session.id` for Phoenix/Arize, `langfuse.session.id` for Langfuse; empty
  string disables). *Which* key a backend reads is a deployment concern, so it
  is an env var; the per-session *value* is `RunContext.session_key`.
- The id rides an **in-process OTel context value** (attached for the run's
  duration), not baggage — so it never travels in outbound request headers and a
  possibly-identifying `session_key` is not leaked to LLM providers.
- **Independent of the grouping toggle** — works whether or not runs share one
  trace (so "each run its own trace + native Sessions" is supported).
- **Auto-installed** by `init_tracing` / `init_phoenix`; exported as
  `SessionSpanProcessor` for hand-built `TracerProvider`s.

### 3. Head + tail truncation for traced payloads

Traced input/output exceeding `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT` now keeps
the **start and end** and elides the middle (`head …[N chars]… tail`) instead of
a head-only clip — the informative ends survive. Sized to fit the limit; falls
back to a head clip when the limit is too small for a marker.

## Configuration

| Goal | Setting |
|---|---|
| One trace per session (any backend) | default |
| Each run its own trace | `RunContext(session_trace_grouping=False)` |
| Datadog sessions | default (`gen_ai.conversation.id`) |
| Phoenix / Langfuse sessions | `GRASP_SESSION_ID_ATTRIBUTES=session.id` (or `langfuse.session.id`) |
| Disable session attributes | `GRASP_SESSION_ID_ATTRIBUTES=` |
| Truncation budget | `OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT=<chars>` |

Both mechanisms are no-ops when no named session is set or tracing is off.

## Tests

Added to `tests/telemetry/test_tracing.py`: deterministic grouping (with and
without a checkpoint store), the opt-out, nested runs staying in the parent
trace, session-id propagation to child spans, env-configurable keys + opt-out,
and head/tail truncation. Full suite green; pyright clean; no new lint findings.

