### PR TITLE
fix converter errors

### DIFF
--- a/src/grasp_agents/llm_providers/openai_responses/response_to_provider_inputs.py
+++ b/src/grasp_agents/llm_providers/openai_responses/response_to_provider_inputs.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 from openai.types.responses.response_function_web_search_param import (
     ActionOpenPage as ActionOpenPageParam,
@@ -23,7 +23,7 @@ from openai.types.responses.response_input_item_param import (
 from grasp_agents.types.items import InputItem, SearchAction, WebSearchCallItem
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterator, Sequence
 
 # Fields added by grasp-agents that are NOT part of the OpenAI Responses API
 _GRASP_EXTENSION_FIELDS = {
@@ -31,6 +31,36 @@ _GRASP_EXTENSION_FIELDS = {
     "provider_specific_fields",
     "is_error",
 }
+
+# Same, on content/output/summary parts and their annotations — the API rejects
+# unknown parameters (e.g. ``mime_type`` on a base64 image part).
+_GRASP_PART_EXTENSION_FIELDS = {
+    "mime_type",
+    "cache_control",
+    "provider_specific_fields",
+}
+
+
+def _iter_part_dicts(dumped: dict[str, Any]) -> Iterator[dict[str, Any]]:
+    for field in ("content", "output", "summary"):
+        parts: object = dumped.get(field)
+        if not isinstance(parts, list):
+            continue
+        for part in cast("list[object]", parts):
+            if isinstance(part, dict):
+                yield cast("dict[str, Any]", part)
+
+
+def _scrub_part_fields(dumped: dict[str, Any]) -> None:
+    for part in _iter_part_dicts(dumped):
+        for key in _GRASP_PART_EXTENSION_FIELDS:
+            part.pop(key, None)
+        annotations: object = part.get("annotations")
+        if not isinstance(annotations, list):
+            continue
+        for annotation in cast("list[object]", annotations):
+            if isinstance(annotation, dict):
+                cast("dict[str, Any]", annotation).pop("provider_specific_fields", None)
 
 
 def items_to_provider_inputs(
@@ -44,6 +74,7 @@ def items_to_provider_inputs(
         dumped = item.model_dump(  # type: ignore[arg-type]
             exclude=_GRASP_EXTENSION_FIELDS, exclude_none=True, mode="json"
         )
+        _scrub_part_fields(dumped)
         # The Responses API reads a client-sent message ``id`` as a reference to a
         # stored item and 404s on it (fatally when the message carries an image);
         # our ``msg_`` ids are internal bookkeeping, so don't echo them back.

--- a/tests/openai_responses/test_converters.py
+++ b/tests/openai_responses/test_converters.py
@@ -307,6 +307,26 @@ class TestMessageIdNotSent:
         # the image content survives the id strip
         assert "input_image" in [p["type"] for p in param["content"]]
 
+    def test_grasp_part_fields_stripped(self) -> None:
+        """Part-level grasp fields (e.g. ``mime_type``) must not reach the API."""
+        image = InputImage.from_base64(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAA=", mime_type="image/png"
+        )
+        assert image.mime_type == "image/png"
+
+        tool_output = FunctionToolOutputItem.from_tool_result(
+            call_id="c1", output=[InputText(text="plot saved"), image]
+        )
+        msg = InputMessageItem(role="user", content=[InputText(text="hi"), image])
+
+        for param in items_to_provider_inputs([tool_output, msg]):
+            parts = param.get("output") or param.get("content")
+            assert isinstance(parts, list)
+            for part in parts:
+                assert "mime_type" not in part
+                assert "cache_control" not in part
+                assert "provider_specific_fields" not in part
+
     def test_message_phase_sent_back(self) -> None:
         """``phase`` must be echoed back to the API to avoid degradation."""
         msg = OutputMessageItem(


### PR DESCRIPTION
This pull request improves how part-level extension fields are handled when converting internal items to OpenAI provider inputs, ensuring that unsupported fields are stripped before sending data to the API. It also adds tests to verify this behavior.

**Provider input sanitization:**

* Added `_GRASP_PART_EXTENSION_FIELDS` to define part-level fields (like `mime_type`, `cache_control`, and `provider_specific_fields`) that should be removed from content/output/summary parts before sending data to the OpenAI Responses API.
* Implemented `_iter_part_dicts` and `_scrub_part_fields` helper functions to iterate through and sanitize these fields in the dumped data.
* Updated `items_to_provider_inputs` to call `_scrub_part_fields` after dumping items, ensuring the API does not receive unsupported part-level fields.

**Testing:**

* Added `test_grasp_part_fields_stripped` to verify that part-level grasp fields are properly removed and do not reach the API.

**Type hints and imports:**

* Added the `Iterator` import to support new helper functions.
* Updated type hints and casting to support the new sanitization logic.