### PR TITLE
Llm cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grasp_agents"
-version = "1.0.14"
+version = "1.0.15"
 description = "Grasp Agents Library"
 readme = "README.md"
 requires-python = ">=3.12,<4"

--- a/ruff.toml
+++ b/ruff.toml
@@ -130,7 +130,9 @@ unfixable = ["F401"]
 ban-relative-imports = "parents"
 
 [lint.per-file-ignores]
-"__init__.py" = ["F401"]
+# RUF067: lazy provider re-exports (module __getattr__ + name tables) and
+# optional-extra import guards are legitimate __init__ machinery.
+"__init__.py" = ["F401", "RUF067"]
 "*.ipynb" = ["I"]
 # Tests may white-box internals — private-member access (SLF001) and private
 # imports (PLC2701) — where that is the clearest assertion. Test-idiomatic

--- a/src/grasp_agents/__init__.py
+++ b/src/grasp_agents/__init__.py
@@ -9,6 +9,7 @@ their own subpackages and are imported from there, e.g.::
 
     from grasp_agents.agent import NextStep, ToolCallDecision
     from grasp_agents.context import make_env_info_section, SystemPromptSection
+    from grasp_agents.llm_providers import OpenAIResponsesLLM
     from grasp_agents.types.llm_errors import LlmRateLimitError
     from grasp_agents.types.events import TurnStartEvent
     from grasp_agents.memory import scan_memdir

--- a/src/grasp_agents/agent/llm_agent.py
+++ b/src/grasp_agents/agent/llm_agent.py
@@ -977,41 +977,6 @@ class LLMAgent[InT, OutT, CtxT](
         # that delivery rather than starting a fresh one.
         self._retry_continuation = True
 
-    def _mint_step(self) -> int:
-        """
-        The next auto-minted step. A current step with no recorded boundary is
-        a rollback's parked step (its boundary was just dropped, and every
-        remaining boundary sits below it) — re-mint it, whatever its number.
-        Otherwise mint one past every recorded boundary: a fresh mint never
-        equals a completed head's step (every stepped delivery archives its
-        boundary before it first persists), so it cannot read as an
-        orchestrator redelivery.
-        """
-        recorded = {wm.step for wm in self._step_watermarks if wm.step is not None}
-        if self._step is not None and self._step not in recorded:
-            return self._step
-        return max(recorded, default=0) + 1
-
-    def _anchor_human_turn(self, message: "TeamMessage") -> None:
-        """
-        A resident's rollback anchor: a human message about to be taken from
-        the inbox starts a new step. Runs before the message's consumption seq
-        is minted and before it is appended, so the boundary's high-waters
-        exclude the message — a rollback to it voids the message itself.
-        Peer messages are not anchors.
-        """
-        if message.sender != USER_SENDER:
-            return
-
-        if message.message_id != self._anchored_message_id:
-            self._step = self._mint_step()
-            self._anchored_message_id = message.message_id
-
-        # A re-delivery (a settled turn's re-take) keeps its step and
-        # re-archives at the settled position — one anchor per human message,
-        # not per delivery attempt.
-        self._archive_step_boundary()
-
     def _archive_step_boundary(self) -> None:
         """
         Record the rewind point for the step about to start: the transcript
@@ -1390,6 +1355,97 @@ class LLMAgent[InT, OutT, CtxT](
             )
         return result
 
+    def _mint_step(self) -> int:
+        """
+        The next auto-minted step. A current step with no recorded boundary is
+        a rollback's parked step (its boundary was just dropped, and every
+        remaining boundary sits below it) — re-mint it, whatever its number.
+        Otherwise mint one past every recorded boundary: a fresh mint never
+        equals a completed head's step (every stepped delivery archives its
+        boundary before it first persists), so it cannot read as an
+        orchestrator redelivery.
+        """
+        recorded = {wm.step for wm in self._step_watermarks if wm.step is not None}
+        if self._step is not None and self._step not in recorded:
+            return self._step
+        return max(recorded, default=0) + 1
+
+    def _anchor_human_turn(self, message: "TeamMessage") -> None:
+        """
+        A resident's rollback anchor: a human message about to be taken from
+        the inbox starts a new step. Runs before the message's consumption seq
+        is minted and before it is appended, so the boundary's high-waters
+        exclude the message — a rollback to it voids the message itself.
+        Peer messages are not anchors.
+        """
+        if message.sender != USER_SENDER:
+            return
+
+        if message.message_id != self._anchored_message_id:
+            self._step = self._mint_step()
+            self._anchored_message_id = message.message_id
+
+        # A re-delivery (a settled turn's re-take) keeps its step and
+        # re-archives at the settled position — one anchor per human message,
+        # not per delivery attempt.
+        self._archive_step_boundary()
+
+    async def _start_step(
+        self,
+        chat_inputs: LLMPrompt | Sequence[str | InputImage] | None,
+        *,
+        inp: InT | None,
+        exec_id: str,
+    ) -> list[InputItem]:
+        """
+        Open a delivered step: optionally reset to a fresh conversation,
+        record the step's rollback boundary, and append its input message.
+
+        The boundary is archived before the input lands, so a rewind returns
+        to the prior steps' conversation with no input yet (the header, being
+        ephemeral, is never lost with it). Returns the appended input (as a
+        one-item list, empty when the entry carries none) for the run to
+        surface as an event.
+
+        Runs outside the run's settle guard: everything fallible (input
+        rendering, attachments) happens before the first mutation, so a
+        failure here leaves the session exactly as entered.
+        """
+        input_message = self._prompt_builder.build_input_message(
+            chat_inputs=chat_inputs, in_args=inp, exec_id=exec_id
+        )
+        if input_message:
+            # Attachments see the conversation the input will join — none
+            # when this run resets it.
+            context: list[InputItem] = (
+                [] if self.reset_transcript_on_run else list(self.transcript.messages)
+            )
+            input_message = await self._prompt_builder.apply_input_attachments(
+                input_message,
+                ctx=self._ctx,
+                exec_id=exec_id,
+                messages=context,
+                agent_ctx=self._agent_ctx,
+                source=self._current_input_source,
+            )
+
+        # No mutations above this line.
+        if self.reset_transcript_on_run:
+            # A reset run starts a new conversation: drop the log (the system
+            # prompt lives in the ephemeral header, not here).
+            self.transcript.clear()
+            self._cw.reset_anchor()
+
+        self._archive_step_boundary()
+        self._loop.turn = 0
+
+        exposed: list[InputItem] = []
+        if input_message:
+            self.transcript.update([input_message])
+            exposed.append(input_message)
+
+        return exposed
+
     async def _process_stream(
         self,
         chat_inputs: LLMPrompt | Sequence[str | InputImage] | None = None,
@@ -1425,20 +1481,22 @@ class LLMAgent[InT, OutT, CtxT](
         checkpoint = await self.load_checkpoint(exec_id=exec_id)
 
         # Surface messages resume injected into the transcript (re-delivered
-        # background-task notices) — no hidden transcript messages.
-        if self._resume_notifications:
-            self._print_messages(self._resume_notifications, exec_id=exec_id)
-            for message in self._resume_notifications:
-                yield UserMessageEvent(data=message, source=self.name, exec_id=exec_id)
-            self._resume_notifications = []
+        # background-task notices) — no hidden transcript messages, on every
+        # path incl. the cached-output replay below.
+        for event in self._expose_messages(self._resume_notifications, exec_id=exec_id):
+            yield event
+        self._resume_notifications = []
 
-        # A direct run with no inputs at all resumes the session — continue
-        # the loop on the restored (or live) transcript instead of rendering
-        # an input prompt from nothing.
+        # A resident (attached inbox) is driven by its mailbox, not by
+        # delivered inputs; a direct run with no inputs at all resumes the
+        # session
+        resident = self._agent_ctx.inbox is not None
+
+        # --- Validate entry path ---
+
         pure_resume = step is None and chat_inputs is None and inp is None
-        if pure_resume and self.transcript.is_empty and self._agent_ctx.inbox is None:
-            # A resident legitimately starts parked with an empty transcript
-            # (its turns come from the inbox); a non-resident has nothing to do.
+
+        if not resident and pure_resume and self.transcript.is_empty:
             raise ProcInputValidationError(
                 proc_name=self.name,
                 exec_id=exec_id,
@@ -1458,37 +1516,42 @@ class LLMAgent[InT, OutT, CtxT](
             # The retry continues the settled delivery under its original step
             # (possibly auto-minted by the failed attempt).
             step = self._step
+
         elif step is None and chat_inputs is not None:
             # A chat delivery with no explicit step: every human turn is a
             # rollback anchor, so mint the next step. Typed-args deliveries
             # (orchestrators, agents-as-tools) stay unstepped unless the
             # caller steps them.
             step = self._mint_step()
+
+        # A resident gets its step minted via the callback
+        # on_take=self._anchor_human_turn in the inbox
+
         self._step = step
 
-        # A ``step`` matching the persisted head *resumes* it (an
-        # orchestrator's at-least-once redelivery): completed → replay the
+        # A ``step`` matching the persisted head is an orchestrator's
+        # at-least-once *redelivery* of that step: completed → replay the
         # cached output below; interrupted → continue on the restored
-        # transcript. A no-input run resumes the session as a whole (also how
-        # a resident always enters). Everything else starts a new step; a
-        # rolled-back head is parked at its step's start and delivers fresh.
-        resumes_step = (
-            retry_continuation
-            or pure_resume
-            or (
-                step is not None
-                and checkpoint is not None
-                and checkpoint.current.step == step
-                and checkpoint.location is not AgentCheckpointLocation.ROLLED_BACK
-            )
+        # transcript. A rolled-back head doesn't count — it is parked at its
+        # step's start and delivers fresh.
+        redelivers_head_step = (
+            step is not None
+            and checkpoint is not None
+            and checkpoint.current.step == step
+            and checkpoint.location is not AgentCheckpointLocation.ROLLED_BACK
         )
-        starts_step = not resumes_step
+        # Resumes continue the existing conversation (a no-input run resumes
+        # the session as a whole — also how a resident always enters);
+        # everything else starts a new step.
+        resumes_step = retry_continuation or pure_resume or redelivers_head_step
 
         # Resuming an already-completed step: replay the cached output.
         if resumes_step and checkpoint is not None and checkpoint.output is not None:
             output = self.parse_output(checkpoint.output, in_args=inp, exec_id=exec_id)
             yield ProcPayloadOutEvent(data=output, source=self.name, exec_id=exec_id)
             return
+
+        # --- Compose initial context ---
 
         # Compose the ephemeral initial context (system prompt + leading
         # messages) on every entry path. It is never persisted: the loop
@@ -1498,73 +1561,47 @@ class LLMAgent[InT, OutT, CtxT](
             ctx=self._ctx, exec_id=exec_id, agent_ctx=self._agent_ctx
         )
 
-        try:
-            # Step entry for anything that *starts or (re-)parks* a
-            # conversation: new steps and every resident entry. A resumed step
-            # skips this — re-archiving would replace its rollback boundary
-            # with a mid-step one. A retry continuation skips it for residents
-            # too: the boundary was archived at the human-message take, and
-            # re-archiving here would move it past the settled input.
-            messages_to_expose: list[InputItem] = []
-            resident = self._agent_ctx.inbox is not None
+        messages_to_expose: list[InputItem] = []
 
-            if (starts_step or resident) and not retry_continuation:
-                if self.reset_transcript_on_run:
-                    # A reset run starts a new conversation: drop the log (the
-                    # system prompt lives in the ephemeral header, not here).
-                    self.transcript.clear()
-                    self._cw.reset_anchor()
-                # Record the rollback point before the step's input, so a
-                # rewind lands on the prior steps' conversation with no input
-                # yet (the header, being ephemeral, is never lost with it).
-                self._archive_step_boundary()
-                if self.transcript.is_empty:
-                    # Surface the fresh header once, for UI / event parity.
-                    messages_to_expose.extend(self._cw.initial_context)
+        if self.transcript.is_empty or (
+            not resumes_step and self.reset_transcript_on_run
+        ):
+            # Entering an empty conversation — a first delivery (or one about
+            # to reset to fresh), or a resident's first park — surfaces the
+            # header once, for UI / event parity (the model gets it via the
+            # view either way). Resumes never reset, so a reset agent's
+            # retry/resume entry does not re-expose it mid-conversation.
+            messages_to_expose.extend(self._cw.initial_context)
 
-            # New step: reset the turn and memorize the input (a resident's
-            # turns arrive from the inbox instead).
-            if starts_step:
-                self._loop.turn = 0
-                input_message = self._prompt_builder.build_input_message(
-                    chat_inputs=chat_inputs, in_args=inp, exec_id=exec_id
-                )
-                if input_message:
-                    input_message = await self._prompt_builder.apply_input_attachments(
-                        input_message,
-                        ctx=self._ctx,
-                        exec_id=exec_id,
-                        messages=list(self.transcript.messages),
-                        agent_ctx=self._agent_ctx,
-                        source=self._current_input_source,
-                    )
-                    self.transcript.update([input_message])
-                    messages_to_expose.append(input_message)
-
-            self._print_messages(messages_to_expose, exec_id=exec_id)
-            for message in messages_to_expose:
-                if isinstance(message, InputMessageItem):
-                    if message.role == "system":
-                        yield SystemMessageEvent(
-                            data=message, source=self.name, exec_id=exec_id
-                        )
-                    # TODO: set source
-                    elif message.role == "user":
-                        yield UserMessageEvent(
-                            data=message,
-                            source=None,
-                            destination=self.name,
-                            exec_id=exec_id,
-                        )
-
-            logger.info(
-                "agent '%s' run started (model=%s, max_turns=%s)",
-                self.name,
-                self._loop.llm.model_name,
-                self._loop.max_turns,
+        if not resumes_step:
+            # Start a fresh step: append the input message to the transcript
+            messages_to_expose.extend(
+                await self._start_step(chat_inputs, inp=inp, exec_id=exec_id)
             )
-            run_t0 = time.monotonic()
 
+        # Surface initial context + input message for a fresh delivery
+        for event in self._expose_messages(
+            messages_to_expose, exec_id=exec_id, source=self._current_input_source
+        ):
+            yield event
+
+        # ---- Run the loop ----
+
+        logger.info(
+            "agent '%s' run started (model=%s, max_turns=%s)",
+            self.name,
+            self._loop.llm.model_name,
+            self._loop.max_turns,
+        )
+        run_t0 = time.monotonic()
+
+        # The settle guard scopes exactly the work that can leave the
+        # transcript and its paired state disagreeing: the loop's generations
+        # and tool rounds, and the final-answer parse. Entry work above needs
+        # no settling — ``_start_step`` mutates only after its fallible steps
+        # — and settling a pre-mutation failure would misread the *previous*
+        # delivery's trailing answer as this run's failed output and prune it.
+        try:
             async for event in self._loop.execute_stream(exec_id=exec_id):
                 yield event
 
@@ -1605,6 +1642,31 @@ class LLMAgent[InT, OutT, CtxT](
             self._ctx.printer.print_messages(
                 messages, agent_name=self.name, exec_id=exec_id
             )
+
+    def _expose_messages(
+        self, messages: Sequence[InputItem], *, exec_id: str, source: str | None = None
+    ) -> list[Event[Any]]:
+        self._print_messages(messages, exec_id=exec_id)
+        events: list[Event[Any]] = []
+        for message in messages:
+            if isinstance(message, InputMessageItem):
+                if message.role == "system":
+                    events.append(
+                        SystemMessageEvent(
+                            data=message, source=self.name, exec_id=exec_id
+                        )
+                    )
+                elif message.role == "user":
+                    events.append(
+                        UserMessageEvent(
+                            data=message,
+                            source=source,
+                            destination=self.name,
+                            exec_id=exec_id,
+                        )
+                    )
+
+        return events
 
     # --- Decorator API ---
     #

--- a/src/grasp_agents/llm/fallback_llm.py
+++ b/src/grasp_agents/llm/fallback_llm.py
@@ -23,11 +23,16 @@ class FallbackLLM(LLM):
     """
     Tries LLMs in order until one succeeds.
 
-    The primary LLM's model_name is used for logging/cost tracking
-    unless overridden.
+    The public ``generate_response(_stream)`` entrypoints validate and retry
+    (per this instance's ``retry_policy``) around the whole cascade; member
+    retry policies are bypassed — the cascade itself is the API-retry layer.
+    ``model_name`` defaults to the primary's and is used for logging, cost
+    attribution and context-budget resolution. ``llm_settings`` is inert
+    here: settings live on the member LLMs.
     """
 
-    primary: LLM = field(default=None)  # type: ignore[assignment]
+    model_name: str = ""
+    primary: LLM = field(kw_only=True)
     fallbacks: tuple[LLM, ...] = ()
 
     def __post_init__(self) -> None:

--- a/src/grasp_agents/llm/llm.py
+++ b/src/grasp_agents/llm/llm.py
@@ -13,10 +13,10 @@ from uuid import uuid4
 
 from pydantic import BaseModel
 
+from grasp_agents import grasp_logging
 from grasp_agents.tools.base import BaseTool, ToolChoice
 from grasp_agents.types.errors import (
     JSONSchemaValidationError,
-    LLMResponseRefusalError,
     LLMResponseValidationError,
     LLMToolCallValidationError,
 )
@@ -288,8 +288,8 @@ class LLM(ABC):
                     if isinstance(event, (ResponseCompleted, ResponseIncomplete)):
                         # Incomplete responses validate exactly like the
                         # non-streaming path (which returns them as response
-                        # objects): a content filter raises a typed refusal
-                        # error; a truncated response reaches the caller.
+                        # objects): a refusal / content filter logs a warning;
+                        # a truncated response reaches the caller.
                         self._validate_response(
                             event.response, tools=tools, output_schema=output_schema
                         )
@@ -314,16 +314,19 @@ class LLM(ABC):
 
     # --- Validation ---
 
-    def _check_refusal(self, response: Response) -> None:
+    def _warn_refusal(self, response: Response) -> None:
         """
-        Raise :class:`LLMResponseRefusalError` when the response is a
-        refusal or was blocked by the provider's content filter.
+        Log a warning when the response is a refusal or was blocked by the
+        provider's content filter.
 
         Reads the normalized signal both providers populate: an explicit
         ``refusal`` content part (OpenAI / LiteLLM) or
         ``incomplete_details.reason == "content_filter"`` (Anthropic maps
-        its ``stop_reason == "refusal"`` to this). Not retried — re-sampling
-        the same prompt won't clear a filter.
+        its ``stop_reason == "refusal"`` to this). Deliberately not an
+        error: the refusal flows into the transcript, so the agent — and
+        the caller — can see it and correct course. Structured-output
+        calls still fail schema validation on the refusal text and
+        re-sample via ``validation_retries``.
         """
         refusal = response.refusal
         reason = (
@@ -332,8 +335,14 @@ class LLM(ABC):
             else None
         )
         if refusal or reason == "content_filter":
-            raise LLMResponseRefusalError(
-                status=response.status, reason=reason, refusal=refusal
+            logger.warning(
+                "llm %s: response is a refusal (status=%s, reason=%s): %s",
+                self.model_name,
+                response.status,
+                reason,
+                grasp_logging.body_for_log(
+                    refusal or "", full=grasp_logging.LOG_LLM_OUTPUT
+                ),
             )
 
     def _validate_response(
@@ -343,11 +352,7 @@ class LLM(ABC):
         tools: Mapping[str, BaseTool[BaseModel, Any, Any]] | None = None,
         output_schema: Any | None = None,
     ) -> None:
-        # A refusal / content filter means there is no usable content to
-        # validate — surface it as a dedicated, non-retryable error before
-        # the tool / schema checks (which would otherwise misfire on the
-        # empty or refusal text).
-        self._check_refusal(response)
+        self._warn_refusal(response)
 
         if tools is not None:
             self._validate_tool_calls(response, tools)

--- a/src/grasp_agents/llm_providers/__init__.py
+++ b/src/grasp_agents/llm_providers/__init__.py
@@ -1,6 +1,11 @@
 """
-Concrete LLM providers, one subpackage each. Import from the specific provider
-you need — several require optional extras:
+Concrete LLM providers, one subpackage each. The headline classes are
+re-exported here lazily, so::
+
+    from grasp_agents.llm_providers import AnthropicLLM, GeminiLLM, OpenAILLM
+
+works without eagerly importing providers whose optional extras aren't
+installed — a provider's dependencies load only when its class is accessed.
 
 * :mod:`.openai_responses` — ``OpenAIResponsesLLM`` (OpenAI Responses API)
 * :mod:`.openai_completions` — ``OpenAILLM`` (Chat Completions; also Gemini /
@@ -8,7 +13,90 @@ you need — several require optional extras:
 * :mod:`.anthropic` — ``AnthropicLLM`` (needs the ``anthropic`` extra)
 * :mod:`.gemini` — ``GeminiLLM`` (needs the ``gemini`` extra)
 * :mod:`.litellm` — ``LiteLLM`` (long-tail providers via ``litellm``)
-
-Kept import-free so this package never eagerly pulls a provider whose extra
-isn't installed.
 """
+
+from importlib import import_module
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .anthropic import (
+        AnthropicLLM,
+        AnthropicLLMSettings,
+        AnthropicPlatform,
+        BedrockClientConfig,
+        VertexClientConfig,
+    )
+    from .gemini import (
+        GeminiLLM,
+        GeminiLLMSettings,
+        GeminiPlatform,
+        GeminiVertexClientConfig,
+    )
+    from .litellm import LiteLLM, LiteLLMSettings
+    from .openai_completions import AzureClientConfig, OpenAILLM, OpenAILLMSettings
+    from .openai_responses import OpenAIResponsesLLM, OpenAIResponsesLLMSettings
+
+_SUBMODULE_BY_NAME: dict[str, str] = {
+    "AnthropicLLM": "anthropic",
+    "AnthropicLLMSettings": "anthropic",
+    "AnthropicPlatform": "anthropic",
+    "BedrockClientConfig": "anthropic",
+    "VertexClientConfig": "anthropic",
+    "GeminiLLM": "gemini",
+    "GeminiLLMSettings": "gemini",
+    "GeminiPlatform": "gemini",
+    "GeminiVertexClientConfig": "gemini",
+    "LiteLLM": "litellm",
+    "LiteLLMSettings": "litellm",
+    "AzureClientConfig": "openai_completions",
+    "OpenAILLM": "openai_completions",
+    "OpenAILLMSettings": "openai_completions",
+    "OpenAIResponsesLLM": "openai_responses",
+    "OpenAIResponsesLLMSettings": "openai_responses",
+}
+
+_EXTRA_BY_SUBMODULE: dict[str, str] = {
+    "anthropic": "anthropic",
+    "gemini": "gemini",
+}
+
+
+def __getattr__(name: str) -> Any:
+    submodule = _SUBMODULE_BY_NAME.get(name)
+    if submodule is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    try:
+        module = import_module(f".{submodule}", __name__)
+    except ModuleNotFoundError as err:
+        extra = _EXTRA_BY_SUBMODULE.get(submodule)
+        if extra is not None:
+            raise ImportError(
+                f"{name} requires the '{extra}' extra: "
+                f'pip install "grasp_agents[{extra}]"'
+            ) from err
+        raise
+    return getattr(module, name)
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals()) | set(_SUBMODULE_BY_NAME))
+
+
+__all__ = [
+    "AnthropicLLM",
+    "AnthropicLLMSettings",
+    "AnthropicPlatform",
+    "AzureClientConfig",
+    "BedrockClientConfig",
+    "GeminiLLM",
+    "GeminiLLMSettings",
+    "GeminiPlatform",
+    "GeminiVertexClientConfig",
+    "LiteLLM",
+    "LiteLLMSettings",
+    "OpenAILLM",
+    "OpenAILLMSettings",
+    "OpenAIResponsesLLM",
+    "OpenAIResponsesLLMSettings",
+    "VertexClientConfig",
+]

--- a/src/grasp_agents/llm_providers/anthropic/anthropic_llm.py
+++ b/src/grasp_agents/llm_providers/anthropic/anthropic_llm.py
@@ -264,7 +264,8 @@ class AnthropicLLM(CloudLLM):
 
         api_tools: list[ToolParam | Any] | None = None
         if tools:
-            api_tools = [to_api_tool(tool) for tool in tools.values()]
+            strict = self.apply_tool_call_schema_via_provider
+            api_tools = [to_api_tool(tool, strict=strict) for tool in tools.values()]
 
         api_tool_choice: ToolChoiceParam | None = None
         if tool_choice is not None:

--- a/src/grasp_agents/llm_providers/anthropic/response_to_provider_inputs.py
+++ b/src/grasp_agents/llm_providers/anthropic/response_to_provider_inputs.py
@@ -294,7 +294,7 @@ def _output_group_to_message_param(output_items: Sequence[OutputItem]) -> Messag
             content.append(_reasoning_to_block(item))
 
         elif isinstance(item, OutputMessageItem):
-            if item.text:
+            if item.text or item.refusal:
                 content.extend(_output_message_to_blocks(item))
 
         elif isinstance(item, WebSearchCallItem):
@@ -325,6 +325,11 @@ def _output_message_to_blocks(item: OutputMessageItem) -> list[TextBlockParam]:
 
     for part in item.content:
         if isinstance(part, OutputMessageRefusal):
+            # Anthropic has no refusal input block — round-trip the refusal
+            # as text so the model sees it on the next turn and can correct
+            # course.
+            if part.refusal:
+                blocks.append(TextBlockParam(type="text", text=part.refusal))
             continue
 
         # Each text block carries its own citations — using the item-level

--- a/src/grasp_agents/llm_providers/anthropic/tool_converters.py
+++ b/src/grasp_agents/llm_providers/anthropic/tool_converters.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from anthropic import transform_schema
 from anthropic.types import (
     ToolChoiceAnyParam,
     ToolChoiceAutoParam,
@@ -17,7 +18,20 @@ from pydantic import BaseModel
 from grasp_agents.tools.base import BaseTool, NamedToolChoice, ToolChoice
 
 
-def to_api_tool(tool: BaseTool[BaseModel, Any, Any]) -> ToolParam:
+def to_api_tool(
+    tool: BaseTool[BaseModel, Any, Any], strict: bool | None = None
+) -> ToolParam:
+    if strict:
+        # ``transform_schema`` rewrites the schema into the strict-compatible
+        # subset (``additionalProperties: false`` everywhere; unsupported
+        # keywords folded into descriptions) — only apply it when strict
+        # mode is actually requested.
+        return ToolParam(
+            name=tool.name,
+            description=tool.description,
+            input_schema=transform_schema(tool.llm_in_type),
+            strict=True,
+        )
     return ToolParam(
         name=tool.name,
         description=tool.description,

--- a/src/grasp_agents/llm_providers/gemini/gemini_llm.py
+++ b/src/grasp_agents/llm_providers/gemini/gemini_llm.py
@@ -188,10 +188,17 @@ class GeminiLLM(CloudLLM):
         if system_instruction is not None:
             config_kwargs["system_instruction"] = system_instruction
 
+        strict_tools = self.apply_tool_call_schema_via_provider
         if tools:
             config_kwargs["tools"] = [to_api_tools(tools)]
         if tool_choice is not None:
-            config_kwargs["tool_config"] = to_api_tool_config(tool_choice)
+            config_kwargs["tool_config"] = to_api_tool_config(
+                tool_choice, strict=strict_tools
+            )
+        elif tools and strict_tools:
+            # Schema enforcement is a function-calling *mode* on Gemini, so
+            # opting in must set a tool_config even without a tool_choice.
+            config_kwargs["tool_config"] = to_api_tool_config("auto", strict=True)
 
         # Forward settings to GenerateContentConfig
         config_kwargs.update({k: merged.pop(k) for k in _CONFIG_KEYS if k in merged})

--- a/src/grasp_agents/llm_providers/gemini/response_to_provider_inputs.py
+++ b/src/grasp_agents/llm_providers/gemini/response_to_provider_inputs.py
@@ -211,7 +211,7 @@ def _output_group_to_content(
             parts.append(_reasoning_to_part(item))
 
         elif isinstance(item, OutputMessageItem):
-            if item.text:
+            if item.text or item.refusal:
                 text_part = _message_to_part(item)
                 parts.append(text_part)
 
@@ -233,7 +233,10 @@ def _reasoning_to_part(item: ReasoningItem) -> GeminiPart:
 
 
 def _message_to_part(item: OutputMessageItem) -> GeminiPart:
-    part = GeminiPart(text=item.text)
+    # Gemini has no refusal part — round-trip refusals as text so the model
+    # sees them on the next turn and can correct course.
+    text = "\n".join(t for t in (item.text, item.refusal) if t)
+    part = GeminiPart(text=text)
     psf = item.provider_specific_fields
     if psf and "thought_signature" in psf:
         part.thought_signature = base64.b64decode(psf["thought_signature"])

--- a/src/grasp_agents/llm_providers/gemini/tool_converters.py
+++ b/src/grasp_agents/llm_providers/gemini/tool_converters.py
@@ -47,7 +47,8 @@ def to_api_tool_config(
     for function-call arguments is a *mode*. ``ANY`` (used for ``"required"``
     and named tools) already constrains argument decoding; with ``strict``,
     the free-choice ``"auto"`` mode uses ``VALIDATED`` instead of ``AUTO``
-    (Preview; Gemini 3+ models only — older models reject it).
+    (Preview; documented for Gemini 3+ — older models accept the request
+    but enforcement there is not documented).
     """
     if isinstance(tool_choice, NamedToolChoice):
         return GeminiToolConfig(

--- a/src/grasp_agents/llm_providers/gemini/tool_converters.py
+++ b/src/grasp_agents/llm_providers/gemini/tool_converters.py
@@ -37,18 +37,23 @@ def to_api_tools(
     return GeminiTool(function_declarations=declarations)
 
 
-def to_api_tool_config(tool_choice: ToolChoice) -> GeminiToolConfig:
+def to_api_tool_config(
+    tool_choice: ToolChoice, strict: bool | None = None
+) -> GeminiToolConfig:
+    """
+    Map a :class:`ToolChoice` to a Gemini function-calling config.
+
+    Gemini has no per-tool ``strict`` flag; provider-side schema enforcement
+    for function-call arguments is a *mode*. ``ANY`` (used for ``"required"``
+    and named tools) already constrains argument decoding; with ``strict``,
+    the free-choice ``"auto"`` mode uses ``VALIDATED`` instead of ``AUTO``
+    (Preview; Gemini 3+ models only — older models reject it).
+    """
     if isinstance(tool_choice, NamedToolChoice):
         return GeminiToolConfig(
             function_calling_config=GeminiFunctionCallingConfig(
                 mode=FunctionCallingConfigMode.ANY,
                 allowed_function_names=[tool_choice.name],
-            )
-        )
-    if tool_choice == "auto":
-        return GeminiToolConfig(
-            function_calling_config=GeminiFunctionCallingConfig(
-                mode=FunctionCallingConfigMode.AUTO,
             )
         )
     if tool_choice == "required":
@@ -63,8 +68,13 @@ def to_api_tool_config(tool_choice: ToolChoice) -> GeminiToolConfig:
                 mode=FunctionCallingConfigMode.NONE,
             )
         )
+    # "auto" and any unrecognized value
     return GeminiToolConfig(
         function_calling_config=GeminiFunctionCallingConfig(
-            mode=FunctionCallingConfigMode.AUTO,
+            mode=(
+                FunctionCallingConfigMode.VALIDATED
+                if strict
+                else FunctionCallingConfigMode.AUTO
+            ),
         )
     )

--- a/src/grasp_agents/llm_providers/openai_completions/response_to_provider_inputs.py
+++ b/src/grasp_agents/llm_providers/openai_completions/response_to_provider_inputs.py
@@ -253,10 +253,15 @@ def _add_output_message_items(
 ) -> list[str]:
     thought_sigs: list[str] = []
     text_parts: list[str] = []
+    refusals: list[str] = []
 
     for item in output_message_items:
         if item.text:
             text_parts.append(item.text)
+
+        refusal = item.refusal
+        if refusal:
+            refusals.append(refusal)
 
         if item.provider_specific_fields:
             msg["provider_specific_fields"] = item.provider_specific_fields
@@ -266,6 +271,10 @@ def _add_output_message_items(
 
     # NOTE: Empty content may not be allowed by some providers
     msg["content"] = "\n".join(text_parts)
+    # Round-trip refusals so the model sees them on the next turn and can
+    # correct course.
+    if refusals:
+        msg["refusal"] = "\n".join(refusals)
 
     return thought_sigs
 

--- a/src/grasp_agents/types/errors.py
+++ b/src/grasp_agents/types/errors.py
@@ -181,33 +181,3 @@ class LLMResponseValidationError(JSONSchemaValidationError):
             message
             or f"Failed to validate LLM response:\n{s}\nExpected type: {schema}",
         )
-
-
-class LLMResponseRefusalError(Exception):
-    """
-    Raised when an LLM response carries no usable content for a *semantic*
-    reason — the model refused, or the provider's content filter blocked
-    the output.
-
-    Distinct from the validation errors above: bad JSON / tool arguments are
-    re-sampled (the model can self-correct), but a refusal or content filter
-    recurs on the same prompt, so this is **not** retried. Catch it to choose
-    an application-level fallback (reroute, soften the request, abort).
-
-    Carries the normalized completion signal read off :class:`Response`:
-    ``status``, ``reason`` (from ``incomplete_details``), and ``refusal`` text.
-    """
-
-    def __init__(
-        self,
-        *,
-        status: str | None = None,
-        reason: str | None = None,
-        refusal: str | None = None,
-        message: str | None = None,
-    ) -> None:
-        detail = refusal or reason or status or "unknown"
-        super().__init__(message or f"LLM declined to produce content: {detail}")
-        self.status = status
-        self.reason = reason
-        self.refusal = refusal

--- a/src/grasp_agents/ui/_event_render.py
+++ b/src/grasp_agents/ui/_event_render.py
@@ -238,8 +238,8 @@ def render_event(
     if isinstance(event, UserMessageEvent):
         text = extract_input_text(event.data)
         # Framework notices get a specialized render (shared by every surface).
-        # The owning agent is the recipient: drain delivers with
-        # destination=agent, resume injects with source=agent.
+        # The owning agent is the recipient (``destination``); ``source`` is
+        # kept as a fallback for emitters that only name the agent there.
         if "<task_notification>" in text:
             return render_task_notification(
                 text, agent=event.destination or event.source

--- a/tests/agent/test_initial_context.py
+++ b/tests/agent/test_initial_context.py
@@ -16,8 +16,10 @@ from typing import Any
 import pytest
 
 from grasp_agents.agent.llm_agent import LLMAgent
-from grasp_agents.context.prompt_builder import SystemPromptSection
+from grasp_agents.context.prompt_builder import InputAttachment, SystemPromptSection
 from grasp_agents.types.content import CacheControl, InputText
+from grasp_agents.types.errors import ProcRunError
+from grasp_agents.types.events import SystemMessageEvent
 from grasp_agents.types.items import InputItem, InputMessageItem
 
 # Reuse the hand-rolled MockLLM / text-response helpers.
@@ -176,3 +178,49 @@ class TestPreviewInitialContext:
         assert isinstance(preview[1], InputMessageItem)
         assert preview[1].role == "user"
         assert preview[1].text == "Leading note."
+
+
+class TestResetRunHeaderExposure:
+    @pytest.mark.asyncio
+    async def test_each_reset_conversation_re_exposes_the_header(self) -> None:
+        # A reset run starts a new conversation, so its header surfaces again
+        # even though the transcript is non-empty at entry (the reset clears
+        # it as the step opens).
+        agent = LLMAgent[str, str, None](
+            name="a",
+            llm=MockLLM(responses_queue=[_text_response("one"), _text_response("two")]),
+            env_info=False,
+            sys_prompt="Base.",
+            reset_transcript_on_run=True,
+        )
+        await agent.run("first")
+
+        events = [e async for e in agent.run_stream("second")]
+
+        headers = [e for e in events if isinstance(e, SystemMessageEvent)]
+        assert len(headers) == 1
+        assert headers[0].data.text == "Base."
+
+
+class TestEntryFailure:
+    @pytest.mark.asyncio
+    async def test_entry_failure_leaves_prior_turns_intact(self) -> None:
+        # A failure before this run's input lands (e.g. an attachment) must
+        # propagate with the transcript and rollback anchors untouched —
+        # never settled as if the previous delivery's trailing answer were
+        # the failing run's own output.
+        agent = _agent(sys_prompt="Base.")
+        await agent.run("first")
+        messages_before = list(agent.transcript.messages)
+        steps_before = list(agent.rollback_steps)
+
+        def boom(**_: Any) -> str:
+            raise RuntimeError("attachment exploded")
+
+        agent.add_input_attachment(InputAttachment(name="boom", compute=boom))
+        with pytest.raises(ProcRunError) as err:
+            await agent.run("second")
+        assert isinstance(err.value.__cause__, RuntimeError)
+
+        assert agent.transcript.messages == messages_before
+        assert agent.rollback_steps == steps_before

--- a/tests/agent_team/test_agent_team.py
+++ b/tests/agent_team/test_agent_team.py
@@ -27,6 +27,7 @@ from grasp_agents.processors.processor import Processor
 from grasp_agents.session_context import SessionContext
 from grasp_agents.tools.function_tool import function_tool
 from grasp_agents.types.content import InputRenderableModel
+from grasp_agents.types.items import InputMessageItem, OutputMessageItem
 from grasp_agents.types.message import CONTROL_PRIORITY, TeamMessage
 from tests._helpers import (
     FailFirstLLM,
@@ -377,6 +378,61 @@ async def test_interrupted_run_resumes_without_reseeding() -> None:
     await team2.aclose()
     assert alice2.llm.call_count == 0  # no duplicate kickoff
     assert result2.activations == 2  # restored, not reset
+
+
+@pytest.mark.asyncio
+async def test_reset_transcript_member_keeps_history_across_interrupt() -> None:
+    # ``reset_transcript_on_run`` means "each *delivered* run starts a new
+    # conversation". A resident's daemon entry delivers nothing — it resumes
+    # the ongoing conversation — so interrupting a team run and re-entering
+    # with a new message must keep the earlier turns.
+    solo = LLMAgent[Any, Any, None](
+        name="solo",
+        llm=MockLLM(
+            responses_queue=[
+                _text_response("first answer"),
+                _text_response("second answer"),
+            ]
+        ),
+        reset_transcript_on_run=True,
+    )
+    team = AgentTeam([solo], entry="solo", ctx=SessionContext[None](state=None))
+
+    async def consume(seed: str | None) -> None:
+        async for _ in team.run_stream(seed, daemon=True, poll_interval=0.01):
+            pass
+
+    run = asyncio.create_task(consume("first question"))
+    try:
+        await _until(lambda: len(solo.transcript.messages) >= 2)  # Q1 answered
+    finally:
+        run.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await run
+
+    # New human message while no run is live: queues durably in the mailbox.
+    await team.submit_message("solo", "second question")
+
+    run = asyncio.create_task(consume(None))
+    try:
+        await _until(lambda: len(solo.transcript.messages) >= 4)  # Q2 answered
+    finally:
+        run.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await run
+    await team.aclose()
+
+    texts = [
+        m.text
+        for m in solo.transcript.messages
+        if isinstance(m, (InputMessageItem, OutputMessageItem))
+    ]
+    assert texts == [
+        "first question",
+        "first answer",
+        "second question",
+        "second answer",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/anthropic/test_converters.py
+++ b/tests/anthropic/test_converters.py
@@ -60,7 +60,11 @@ from grasp_agents.llm_providers.anthropic.tool_converters import (
     to_api_tool_choice,
 )
 from grasp_agents.tools.base import BaseTool, NamedToolChoice
-from grasp_agents.types.content import InputText, OutputMessageText
+from grasp_agents.types.content import (
+    InputText,
+    OutputMessageRefusal,
+    OutputMessageText,
+)
 from grasp_agents.types.items import (
     FunctionToolCallItem,
     FunctionToolOutputItem,
@@ -300,6 +304,24 @@ class TestResponseToMessage:
         assert system == "You are helpful"
         assert len(messages) == 1
         assert messages[0]["role"] == "user"
+
+    def test_refusal_round_trips_as_text_block(self):
+        """A refusal-only assistant message rides back as a text block."""
+        items = [
+            InputMessageItem.from_text("Hi"),
+            OutputMessageItem(
+                status="completed",
+                content=[OutputMessageRefusal(refusal="I can't help with that.")],
+            ),
+        ]
+        _system, messages = items_to_anthropic_messages(items)
+
+        assert len(messages) == 2
+        assert messages[1]["role"] == "assistant"
+        blocks = messages[1]["content"]
+        assert isinstance(blocks, list)
+        assert blocks[0]["type"] == "text"  # type: ignore[index]
+        assert blocks[0]["text"] == "I can't help with that."  # type: ignore[index]
 
     def test_multiple_system_messages_emit_blocks(self):
         """
@@ -623,6 +645,33 @@ class TestToolConverters:
         schema = api_tool["input_schema"]
         assert "city" in schema["properties"]
         assert "units" in schema["properties"]
+
+    def test_to_api_tool_strict(self):
+        tool = _WeatherTool()
+        api_tool = to_api_tool(tool, strict=True)
+
+        assert api_tool["strict"] is True
+        schema = api_tool["input_schema"]
+        assert schema["additionalProperties"] is False
+        assert "city" in schema["properties"]  # type: ignore[index]
+
+    def test_to_api_tool_not_strict_by_default(self):
+        api_tool = to_api_tool(_WeatherTool())
+        assert "strict" not in api_tool
+
+    def test_llm_strict_gate_wires_into_api_tools(self):
+        from grasp_agents.llm_providers.anthropic.anthropic_llm import AnthropicLLM
+
+        llm = AnthropicLLM(
+            model_name="claude-sonnet-4-5",
+            api_provider={"name": "anthropic", "base_url": None, "api_key": "dummy"},
+            apply_tool_call_schema_via_provider=True,
+        )
+        params = llm._make_api_input([], tools={"get_weather": _WeatherTool()})
+        api_tools = params["api_tools"]
+        assert api_tools is not None
+        assert api_tools[0]["strict"] is True
+        assert api_tools[0]["input_schema"]["additionalProperties"] is False
 
     def test_to_api_tool_choice_auto(self):
         result = to_api_tool_choice("auto")

--- a/tests/anthropic/test_integration.py
+++ b/tests/anthropic/test_integration.py
@@ -108,6 +108,60 @@ class TestAnthropicIntegration:
 
 
 @pytest.mark.integration
+class TestAnthropicStrictTools:
+    @pytest.fixture
+    def llm(self, anthropic_api_key: str) -> CloudLLM:
+        from grasp_agents.llm_providers.anthropic.anthropic_llm import AnthropicLLM
+
+        return AnthropicLLM(
+            model_name="claude-haiku-4-5-20251001",
+            api_provider=APIProvider(
+                name="anthropic",
+                base_url=None,
+                api_key=anthropic_api_key,
+            ),
+            llm_settings={"max_tokens": 200},
+            apply_tool_call_schema_via_provider=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_strict_tool_call_args_conform(
+        self, llm: CloudLLM, tools: dict[str, BaseTool[Any, Any, Any]]
+    ) -> None:
+        user_msg = InputMessageItem.from_text("What is 17 + 25? Use the add tool.")
+        response = await llm.generate_response(
+            [user_msg], tools=tools, tool_choice="required"
+        )
+
+        assert response.tool_call_items
+        args = json.loads(response.tool_call_items[0].arguments)
+        assert set(args) == {"a", "b"}
+        assert isinstance(args["a"], int)
+        assert isinstance(args["b"], int)
+
+    @pytest.mark.asyncio
+    async def test_stream_strict_tool_call_args_conform(
+        self, llm: CloudLLM, tools: dict[str, BaseTool[Any, Any, Any]]
+    ) -> None:
+        user_msg = InputMessageItem.from_text("What is 17 + 25? Use the add tool.")
+        events = [
+            e
+            async for e in llm.generate_response_stream(
+                [user_msg], tools=tools, tool_choice="required"
+            )
+        ]
+        completed = [e for e in events if isinstance(e, ResponseCompleted)]
+
+        assert len(completed) == 1
+        tool_calls = completed[0].response.tool_call_items
+        assert tool_calls
+        args = json.loads(tool_calls[0].arguments)
+        assert set(args) == {"a", "b"}
+        assert isinstance(args["a"], int)
+        assert isinstance(args["b"], int)
+
+
+@pytest.mark.integration
 class TestAnthropicReasoningContinuity:
     """
     Reasoning traces (thinking blocks) must survive tool-call round-trips.

--- a/tests/anthropic/test_integration.py
+++ b/tests/anthropic/test_integration.py
@@ -160,6 +160,46 @@ class TestAnthropicStrictTools:
         assert isinstance(args["a"], int)
         assert isinstance(args["b"], int)
 
+    @pytest.mark.asyncio
+    async def test_strict_is_validated_server_side(
+        self, anthropic_api_key: str
+    ) -> None:
+        """
+        Negative control pinning the contract our converter relies on:
+        ``strict: true`` with an *untransformed* pydantic schema (no
+        ``additionalProperties: false``) is rejected with a 400, while the
+        identical schema without ``strict`` is accepted — i.e. the flag is
+        processed server-side, and ``transform_schema`` is what makes strict
+        tools work.
+        """
+        import anthropic
+
+        client = anthropic.AsyncAnthropic(api_key=anthropic_api_key)
+
+        class _AddInput(BaseModel):
+            a: int
+            b: int
+
+        raw_schema = _AddInput.model_json_schema()
+        assert "additionalProperties" not in raw_schema
+        tool: dict[str, Any] = {
+            "name": "add",
+            "description": "Add two numbers",
+            "input_schema": raw_schema,
+        }
+        common: dict[str, Any] = {
+            "model": "claude-haiku-4-5-20251001",
+            "max_tokens": 100,
+            "messages": [{"role": "user", "content": "What is 17 + 25? Use add."}],
+            "tool_choice": {"type": "any"},
+        }
+
+        with pytest.raises(anthropic.BadRequestError, match="additionalProperties"):
+            await client.messages.create(tools=[{**tool, "strict": True}], **common)
+
+        resp = await client.messages.create(tools=[tool], **common)
+        assert resp.stop_reason == "tool_use"
+
 
 @pytest.mark.integration
 class TestAnthropicReasoningContinuity:

--- a/tests/gemini/test_converters.py
+++ b/tests/gemini/test_converters.py
@@ -51,7 +51,7 @@ from grasp_agents.llm_providers.gemini.tool_converters import (
     to_api_tools,
 )
 from grasp_agents.tools.base import BaseTool, NamedToolChoice
-from grasp_agents.types.content import OutputMessageText
+from grasp_agents.types.content import OutputMessageRefusal, OutputMessageText
 from grasp_agents.types.items import (
     FunctionToolCallItem,
     FunctionToolOutputItem,
@@ -603,6 +603,22 @@ class TestResponseToProviderInputs:
         assert contents[1].parts is not None
         assert contents[1].parts[0].text == "Hello!"
 
+    def test_refusal_round_trips_as_text(self):
+        """A refusal-only assistant message rides back as model text."""
+        items = [
+            InputMessageItem.from_text("Hi"),
+            OutputMessageItem(
+                status="completed",
+                content=[OutputMessageRefusal(refusal="I can't help with that.")],
+            ),
+        ]
+        _system, contents = items_to_provider_inputs(items)
+
+        assert len(contents) == 2
+        assert contents[1].role == "model"
+        assert contents[1].parts is not None
+        assert contents[1].parts[0].text == "I can't help with that."
+
     def test_tool_roundtrip(self):
         """Tool call + tool output → model + user contents."""
         items = [
@@ -736,6 +752,16 @@ class TestToolConverters:
         config = to_api_tool_config("auto")
         assert config.function_calling_config is not None
         assert config.function_calling_config.mode == "AUTO"
+
+    def test_auto_choice_strict_uses_validated_mode(self):
+        config = to_api_tool_config("auto", strict=True)
+        assert config.function_calling_config is not None
+        assert config.function_calling_config.mode == "VALIDATED"
+
+    def test_required_choice_strict_stays_any(self):
+        config = to_api_tool_config("required", strict=True)
+        assert config.function_calling_config is not None
+        assert config.function_calling_config.mode == "ANY"
 
     def test_required_choice(self):
         config = to_api_tool_config("required")

--- a/tests/gemini/test_integration.py
+++ b/tests/gemini/test_integration.py
@@ -106,6 +106,55 @@ class TestGeminiIntegration:
 
 
 @pytest.mark.integration
+class TestGeminiStrictTools:
+    @pytest.fixture
+    def llm(self, google_api_key: str) -> CloudLLM:
+        from grasp_agents.llm_providers.gemini.gemini_llm import GeminiLLM
+
+        # VALIDATED function calling is Gemini 3+ only.
+        return GeminiLLM(
+            model_name="gemini-3.1-pro-preview",
+            api_provider=APIProvider(
+                name="google",
+                base_url=None,
+                api_key=google_api_key,
+            ),
+            apply_tool_call_schema_via_provider=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_validated_tool_call_args_conform(
+        self, llm: CloudLLM, tools: dict[str, BaseTool[Any, Any, Any]]
+    ) -> None:
+        user_msg = InputMessageItem.from_text("What is 17 + 25? Use the add tool.")
+        response = await llm.generate_response([user_msg], tools=tools)
+
+        assert response.tool_call_items
+        args = json.loads(response.tool_call_items[0].arguments)
+        assert set(args) == {"a", "b"}
+        assert isinstance(args["a"], int)
+        assert isinstance(args["b"], int)
+
+    @pytest.mark.asyncio
+    async def test_stream_validated_tool_call_args_conform(
+        self, llm: CloudLLM, tools: dict[str, BaseTool[Any, Any, Any]]
+    ) -> None:
+        user_msg = InputMessageItem.from_text("What is 17 + 25? Use the add tool.")
+        events = [
+            e async for e in llm.generate_response_stream([user_msg], tools=tools)
+        ]
+        completed = [e for e in events if isinstance(e, ResponseCompleted)]
+
+        assert len(completed) == 1
+        tool_calls = completed[0].response.tool_call_items
+        assert tool_calls
+        args = json.loads(tool_calls[0].arguments)
+        assert set(args) == {"a", "b"}
+        assert isinstance(args["a"], int)
+        assert isinstance(args["b"], int)
+
+
+@pytest.mark.integration
 class TestGeminiReasoningContinuity:
     """
     Reasoning traces (thought parts with signatures) must survive

--- a/tests/gemini/test_integration.py
+++ b/tests/gemini/test_integration.py
@@ -8,12 +8,13 @@ Skipped by default. Run with:
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import pytest
 from pydantic import BaseModel, Field
 
 from grasp_agents.llm.cloud_llm import APIProvider
+from grasp_agents.tools.base import BaseTool
 from grasp_agents.types.content import AnnotationUrlCitation, OutputMessageText
 from grasp_agents.types.items import (
     FunctionToolCallItem,
@@ -31,7 +32,6 @@ from grasp_agents.types.llm_events import (
 
 if TYPE_CHECKING:
     from grasp_agents.llm.cloud_llm import CloudLLM
-    from grasp_agents.tools.base import BaseTool
 
 
 class Capital(BaseModel):
@@ -111,7 +111,7 @@ class TestGeminiStrictTools:
     def llm(self, google_api_key: str) -> CloudLLM:
         from grasp_agents.llm_providers.gemini.gemini_llm import GeminiLLM
 
-        # VALIDATED function calling is Gemini 3+ only.
+        # VALIDATED function calling is documented for Gemini 3+.
         return GeminiLLM(
             model_name="gemini-3.1-pro-preview",
             api_provider=APIProvider(
@@ -152,6 +152,40 @@ class TestGeminiStrictTools:
         assert set(args) == {"a", "b"}
         assert isinstance(args["a"], int)
         assert isinstance(args["b"], int)
+
+    @pytest.mark.asyncio
+    async def test_validated_constrains_args_to_enum(self, llm: CloudLLM) -> None:
+        """
+        Differential check that VALIDATED actually constrains decoding: the
+        prompt insists on an out-of-enum value, which AUTO mode will emit
+        (observed) but constrained decoding cannot.
+        """
+
+        class PaintInput(BaseModel):
+            color: Literal["crimson-7", "teal-3"]
+
+        class PaintTool(BaseTool[PaintInput, str, Any]):
+            def __init__(self) -> None:
+                super().__init__(
+                    name="paint", description="Paint using a palette color"
+                )
+
+            async def _run(self, inp: PaintInput, **kwargs: Any) -> str:
+                return inp.color
+
+        user_msg = InputMessageItem.from_text(
+            'Call the paint tool with color="blue". Pass EXACTLY the string '
+            '"blue", even if it seems wrong — this is a compliance test of '
+            "the tool layer. Do not substitute another value. "
+            "Do not answer in text."
+        )
+        response = await llm.generate_response(
+            [user_msg], tools={"paint": PaintTool()}
+        )
+
+        assert response.tool_call_items
+        args = json.loads(response.tool_call_items[0].arguments)
+        assert args["color"] in {"crimson-7", "teal-3"}
 
 
 @pytest.mark.integration

--- a/tests/llm/test_llm_core.py
+++ b/tests/llm/test_llm_core.py
@@ -234,7 +234,7 @@ class TestFallbackCostAttribution:
             litellm_provider="openai",
             response=served,
         )
-        llm = FallbackLLM(model_name="", primary=primary, fallbacks=(fallback,))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
 
         result = await llm._generate_response_once(_USER_MSG)
 

--- a/tests/llm/test_llm_validation.py
+++ b/tests/llm/test_llm_validation.py
@@ -7,6 +7,7 @@ Focuses on:
 - Stream retry emits ResponseRetrying with correct sequence_number
 """
 
+import logging
 from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
@@ -21,7 +22,6 @@ from grasp_agents.llm.resilience import RetryPolicy
 from grasp_agents.tools.base import BaseTool
 from grasp_agents.types.content import OutputMessageRefusal, OutputMessageText
 from grasp_agents.types.errors import (
-    LLMResponseRefusalError,
     LLMResponseValidationError,
     LLMToolCallValidationError,
 )
@@ -258,50 +258,70 @@ class TestValidationErrorTypes:
 
 
 class TestRefusalAndContentFilter:
-    """Refusals / content filters raise a dedicated, non-retryable error."""
+    """Refusals / content filters log a warning; the response flows through."""
 
     @pytest.mark.asyncio
-    async def test_refusal_part_raises_refusal_error(self):
+    async def test_refusal_returns_response_and_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ):
         llm = MockLLM(model_name="mock", responses=[_refusal_response()])
-        with pytest.raises(LLMResponseRefusalError):
-            await llm.generate_response(_USER_MSG)
+        with caplog.at_level(logging.WARNING, logger="grasp_agents.llm.llm"):
+            response = await llm.generate_response(_USER_MSG)
+        assert response.refusal == "I can't help with that."
+        assert any("refusal" in r.getMessage() for r in caplog.records)
 
     @pytest.mark.asyncio
-    async def test_content_filter_raises_refusal_error(self):
+    async def test_content_filter_returns_response_and_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ):
         llm = MockLLM(model_name="mock", responses=[_content_filter_response()])
-        with pytest.raises(LLMResponseRefusalError) as ei:
-            await llm.generate_response(_USER_MSG)
-        assert ei.value.reason == "content_filter"
+        with caplog.at_level(logging.WARNING, logger="grasp_agents.llm.llm"):
+            response = await llm.generate_response(_USER_MSG)
+        assert response.incomplete_details is not None
+        assert response.incomplete_details.reason == "content_filter"
+        assert any("content_filter" in r.getMessage() for r in caplog.records)
 
     @pytest.mark.asyncio
-    async def test_refusal_takes_precedence_over_schema(self):
-        """A refusal raises the refusal error, not a schema-validation error."""
-        llm = MockLLM(model_name="mock", responses=[_refusal_response()])
+    async def test_refusal_with_output_schema_is_resampled(self):
+        """With a schema, the refusal fails validation and re-samples."""
 
         class M(BaseModel):
             v: int
 
-        with pytest.raises(LLMResponseRefusalError):
-            await llm.generate_response(_USER_MSG, output_schema=M)
-
-    @pytest.mark.asyncio
-    async def test_refusal_is_not_retried(self):
-        """Even with validation retries available, a refusal is terminal."""
         llm = MockLLM(
             model_name="mock",
             responses=[_refusal_response(), _text_response('{"v": 1}')],
             retry_policy=RetryPolicy(validation_retries=3),
         )
-        with pytest.raises(LLMResponseRefusalError):
-            await llm.generate_response(_USER_MSG)
-        assert llm.call_count == 1
+        response = await llm.generate_response(_USER_MSG, output_schema=M)
+        assert llm.call_count == 2
+        assert response.output_text == '{"v": 1}'
 
     @pytest.mark.asyncio
-    async def test_refusal_raised_from_stream_path(self):
+    async def test_persistent_refusal_with_schema_raises_validation_error(self):
+        class M(BaseModel):
+            v: int
+
+        llm = MockLLM(
+            model_name="mock",
+            responses=[_refusal_response(), _refusal_response()],
+            retry_policy=RetryPolicy(validation_retries=1),
+        )
+        with pytest.raises(LLMResponseValidationError):
+            await llm.generate_response(_USER_MSG, output_schema=M)
+        assert llm.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_refusal_streams_through(self, caplog: pytest.LogCaptureFixture):
         llm = MockLLM(model_name="mock", responses=[_refusal_response()])
-        with pytest.raises(LLMResponseRefusalError):
-            async for _ in llm.generate_response_stream(_USER_MSG):
-                pass
+        events: list[LlmEvent] = []
+        with caplog.at_level(logging.WARNING, logger="grasp_agents.llm.llm"):
+            async for ev in llm.generate_response_stream(_USER_MSG):
+                events.append(ev)
+        completed = [e for e in events if isinstance(e, ResponseCompleted)]
+        assert len(completed) == 1
+        assert completed[0].response.refusal == "I can't help with that."
+        assert any("refusal" in r.getMessage() for r in caplog.records)
 
 
 # ---------- Retry behavior ----------

--- a/tests/llm/test_provider_converters.py
+++ b/tests/llm/test_provider_converters.py
@@ -36,6 +36,7 @@ from grasp_agents.types.items import (
     FunctionToolOutputItem,
     InputMessageItem,
 )
+from tests._helpers import AddTool
 
 _PDF_B64 = base64.b64encode(b"%PDF-1.4 fake").decode()
 
@@ -162,3 +163,39 @@ class TestGeminiSchemaGate:
         assert applied is not None
         assert applied.response_schema is _Out
         assert applied.response_mime_type == "application/json"
+
+
+class TestGeminiStrictToolsGate:
+    def _llm(self, **kwargs: object):
+        from grasp_agents.llm_providers.gemini.gemini_llm import GeminiLLM
+
+        return GeminiLLM(
+            model_name="gemini-2.5-flash",
+            api_provider={"name": "google", "base_url": None, "api_key": "dummy"},
+            **kwargs,  # type: ignore[arg-type]
+        )
+
+    def _config(self, llm: object, **kwargs: object):
+        params = llm._make_api_input([], tools={"add": AddTool()}, **kwargs)  # type: ignore[attr-defined]
+        return params["extra_settings"]["config"]
+
+    def test_no_tool_config_by_default(self) -> None:
+        config = self._config(self._llm())
+        assert config.tool_config is None
+
+    def test_strict_sets_validated_mode_without_tool_choice(self) -> None:
+        config = self._config(self._llm(apply_tool_call_schema_via_provider=True))
+        assert config.tool_config is not None
+        assert config.tool_config.function_calling_config.mode == "VALIDATED"
+
+    def test_strict_with_auto_tool_choice_uses_validated(self) -> None:
+        config = self._config(
+            self._llm(apply_tool_call_schema_via_provider=True), tool_choice="auto"
+        )
+        assert config.tool_config.function_calling_config.mode == "VALIDATED"
+
+    def test_strict_with_required_tool_choice_stays_any(self) -> None:
+        config = self._config(
+            self._llm(apply_tool_call_schema_via_provider=True), tool_choice="required"
+        )
+        assert config.tool_config.function_calling_config.mode == "ANY"

--- a/tests/llm/test_provider_imports.py
+++ b/tests/llm/test_provider_imports.py
@@ -1,0 +1,63 @@
+"""Provider LLM classes are re-exported lazily at grasp_agents.llm_providers."""
+
+import subprocess  # noqa: S404
+import sys
+from importlib import import_module
+
+import pytest
+
+REEXPORTED_NAMES = [
+    "AnthropicLLM",
+    "AnthropicLLMSettings",
+    "AnthropicPlatform",
+    "AzureClientConfig",
+    "BedrockClientConfig",
+    "GeminiLLM",
+    "GeminiLLMSettings",
+    "GeminiPlatform",
+    "GeminiVertexClientConfig",
+    "LiteLLM",
+    "LiteLLMSettings",
+    "OpenAILLM",
+    "OpenAILLMSettings",
+    "OpenAIResponsesLLM",
+    "OpenAIResponsesLLMSettings",
+    "VertexClientConfig",
+]
+
+
+@pytest.mark.parametrize("name", REEXPORTED_NAMES)
+def test_llm_providers_reexports(name: str) -> None:
+    providers = import_module("grasp_agents.llm_providers")
+    assert getattr(providers, name) is not None
+    assert name in providers.__all__
+    assert name in dir(providers)
+
+
+def test_reexports_are_the_provider_classes() -> None:
+    providers = import_module("grasp_agents.llm_providers")
+    from grasp_agents.llm_providers.anthropic import AnthropicLLM
+    from grasp_agents.llm_providers.openai_responses import OpenAIResponsesLLM
+
+    assert providers.AnthropicLLM is AnthropicLLM
+    assert providers.OpenAIResponsesLLM is OpenAIResponsesLLM
+
+
+def test_unknown_name_raises_attribute_error() -> None:
+    providers = import_module("grasp_agents.llm_providers")
+    with pytest.raises(AttributeError):
+        _ = providers.DoesNotExist
+
+
+def test_provider_packages_not_imported_eagerly() -> None:
+    # A fresh interpreter, so this test cannot disturb (or be disturbed by)
+    # module identity in the running suite.
+    script = (
+        "import sys\n"
+        "import grasp_agents.llm_providers\n"
+        "for sub in ('anthropic', 'gemini', 'litellm'):\n"
+        "    assert f'grasp_agents.llm_providers.{sub}' not in sys.modules, sub\n"
+        "from grasp_agents.llm_providers import AnthropicLLM\n"
+        "assert 'grasp_agents.llm_providers.anthropic' in sys.modules\n"
+    )
+    subprocess.run([sys.executable, "-c", script], check=True)  # noqa: S603

--- a/tests/llm/test_resilience.py
+++ b/tests/llm/test_resilience.py
@@ -362,7 +362,7 @@ class TestFallbackLLM:
             model_name="fallback", response=_text_response("from fallback")
         )
 
-        llm = FallbackLLM(model_name="", primary=primary, fallbacks=(fallback,))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
         result = await llm._generate_response_once(_USER_MSG)
 
         assert result.output_text == "from primary"
@@ -380,7 +380,7 @@ class TestFallbackLLM:
         )
         fallback = StubLLM(model_name="fallback", response=_text_response("recovered"))
 
-        llm = FallbackLLM(model_name="", primary=primary, fallbacks=(fallback,))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
         result = await llm._generate_response_once(_USER_MSG)
 
         assert result.output_text == "recovered"
@@ -401,7 +401,7 @@ class TestFallbackLLM:
             ),
         )
 
-        llm = FallbackLLM(model_name="", primary=primary, fallbacks=(fallback,))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
 
         with pytest.raises(LlmInternalServerError, match="server down"):
             await llm._generate_response_once(_USER_MSG)
@@ -417,7 +417,7 @@ class TestFallbackLLM:
             model_name="fallback", response=_text_response("should not reach")
         )
 
-        llm = FallbackLLM(model_name="", primary=primary, fallbacks=(fallback,))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
 
         with pytest.raises(ValueError, match="bad config"):
             await llm._generate_response_once(_USER_MSG)
@@ -427,7 +427,7 @@ class TestFallbackLLM:
     async def test_model_name_defaults_to_primary(self) -> None:
         """FallbackLLM.model_name inherits from primary when empty."""
         primary = StubLLM(model_name="gpt-4o")
-        llm = FallbackLLM(model_name="", primary=primary)
+        llm = FallbackLLM(primary=primary)
         assert llm.model_name == "gpt-4o"
 
     @pytest.mark.asyncio
@@ -445,7 +445,7 @@ class TestFallbackLLM:
         )
         fallback = StubLLM(model_name="fallback", response=_text_response("recovered"))
 
-        llm = FallbackLLM(model_name="", primary=primary, fallbacks=(fallback,))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
 
         events: list[LlmEvent] = []
         async for event in llm._generate_response_stream_once(_USER_MSG):
@@ -482,7 +482,7 @@ class TestFallbackLLM:
             ),
         )
 
-        llm = FallbackLLM(model_name="", primary=primary, fallbacks=(fallback,))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
 
         events: list[LlmEvent] = []
 
@@ -730,7 +730,7 @@ class TestStreamErrorMapping:
         """429 during primary's stream iteration → cascade to the fallback."""
         primary = LazyStreamCloudLLM(model_name="primary", fail_attempts=99)
         fallback = StubLLM(model_name="fallback", response=_text_response("rescued"))
-        llm = FallbackLLM(model_name="", primary=primary, fallbacks=(fallback,))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
 
         events: list[LlmEvent] = []
         async for event in llm._generate_response_stream_once(_USER_MSG):

--- a/tests/openai_completions/test_items_to_messages.py
+++ b/tests/openai_completions/test_items_to_messages.py
@@ -16,6 +16,7 @@ from grasp_agents.llm_providers.openai_completions.response_to_provider_inputs i
 from grasp_agents.types.content import (
     InputImage,
     InputText,
+    OutputMessageRefusal,
     OutputMessageText,
     ReasoningContent,
 )
@@ -137,6 +138,18 @@ class TestOutputMessageConversion:
 
         # Should have non-None content to avoid API errors
         assert msgs[0]["content"] is not None
+
+    def test_refusal_round_trips_on_assistant_message(self):
+        """A refusal part rides back as the assistant ``refusal`` field."""
+        item = OutputMessageItem(
+            content=[OutputMessageRefusal(refusal="I can't help with that.")],
+            status="completed",
+        )
+        msgs = items_to_completions_messages([item])
+
+        assert len(msgs) == 1
+        assert msgs[0]["role"] == "assistant"
+        assert msgs[0]["refusal"] == "I can't help with that."
 
 
 # ---------- Standalone tool calls ----------

--- a/uv.lock
+++ b/uv.lock
@@ -1181,7 +1181,7 @@ wheels = [
 
 [[package]]
 name = "grasp-agents"
-version = "1.0.14"
+version = "1.0.15"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
# LLM layer cleanup: flat provider imports, non-raising refusals, strict tool schemas on all providers

## Summary

This PR tightens the LLM layer in four areas — provider import ergonomics, refusal handling, provider-side ("strict") tool-schema enforcement, and the `FallbackLLM` constructor — plus a readability refactor of the `LLMAgent` run-entry path. Version bumped to 1.0.15.

## Flat provider imports

Provider classes are now re-exported at `grasp_agents.llm_providers`, replacing the deep per-module paths:

```python
from grasp_agents.llm_providers import AnthropicLLM, GeminiLLM, LiteLLM, OpenAILLM, OpenAIResponsesLLM
```

Settings and platform-config classes (`AnthropicLLMSettings`, `BedrockClientConfig`, `AzureClientConfig`, …) are included. Re-exports are lazy (`TYPE_CHECKING` imports + module `__getattr__`), so a provider's SDK only loads when its class is accessed — installs without the `anthropic`/`gemini` extras keep working, and accessing a missing provider raises an `ImportError` that names the extra to install. Static typing and IDE completion are unaffected. The old deep imports still work.

## Refusals no longer raise

`LLMResponseRefusalError` is removed. A refusal or provider content filter now logs a warning and the response flows through like any other:

- **Agentic runs**: the refusal message lands in the transcript, so the caller — and the model on the next turn — can see it and correct course. Refusal parts previously got dropped when converting the transcript back to provider inputs; they now round-trip everywhere (Chat Completions/LiteLLM: assistant `refusal` field; Anthropic and Gemini: rendered as text, since those APIs have no refusal input block; OpenAI Responses already round-tripped natively).
- **Structured-output calls**: a refusal fails schema validation and is re-sampled via `validation_retries` — refusals are largely stochastic, so retrying often recovers. A persistent refusal surfaces as `LLMResponseValidationError` after retries instead of a dedicated exception on the first one.

Refusal text in the warning is snippet-truncated by default and gated by `GRASP_LOG_LLM_OUTPUT`, like other logged bodies.

## Strict tool schemas on all providers

`apply_tool_call_schema_via_provider=True` previously only had an effect on the OpenAI providers. It now works across the board:

| Provider | Mechanism |
|---|---|
| OpenAI (Responses + Chat Completions) | `strict: true` + strict-transformed schema (unchanged) |
| **Anthropic** | `ToolParam(strict=True)` with the schema rewritten by the SDK's `transform_schema` (GA — no beta header; both available at our `anthropic>=0.84` floor). Note: unlike OpenAI's transform, `transform_schema` preserves the schema's `required` list rather than forcing every field required |
| **Gemini** | No per-tool flag exists — enforcement is a function-calling *mode*. Free-choice calls (`"auto"` or no `tool_choice`) use `FunctionCallingConfigMode.VALIDATED` (Preview, documented for Gemini 3+); `"required"`/named tool choices already use `ANY`, which constrains argument decoding. Opting in with no `tool_choice` now also emits a `tool_config` |
| LiteLLM | OpenAI-format `strict` passes through (unchanged); litellm strips it per provider where unsupported. Documented at the call site |

Both code paths are covered — streaming and non-streaming share the same request build, and the stream call sites are exercised by tests.

### Verification

Beyond unit tests on the converters and request builds, live integration tests (deselected by default, `-m integration`) verify the flag *does something* rather than merely being accepted:

- `test_strict_is_validated_server_side` (Anthropic): negative control — `strict: true` with an untransformed pydantic schema is rejected with `400 "'additionalProperties' must be explicitly set to false"`, while the identical schema without `strict` is accepted. This pins the server-side contract the converter's `transform_schema` step exists to satisfy.
- `test_validated_constrains_args_to_enum` (Gemini): differential — a tool with an enum parameter plus a prompt insisting on an out-of-enum value. In `AUTO` mode the model emitted the out-of-enum value; under `VALIDATED`, arguments are constrained into the enum every time.
- Streamed and non-streamed round-trips on both providers return schema-exact arguments.

One caveat found while probing: `gemini-2.5-flash` silently *accepts* `VALIDATED` despite the docs scoping it to Gemini 3+ — acceptance is not evidence of enforcement, which is why the tests above use negative controls rather than plain 200s.

## FallbackLLM constructor cleanup

`FallbackLLM` keeps inheriting from `LLM` — the inherited `generate_response(_stream)` entrypoints supply the validation/retry orchestration the cascade deliberately relies on (validation happens once, at the composite layer, with the composite's `retry_policy`; members' un-retried cores are called on purpose), and `model_name` feeds logging, cost attribution, and context-budget resolution. The constructor warts are fixed instead:

- `model_name` defaults to `""` and resolves to the primary's name — no more `FallbackLLM(model_name="", …)` sentinel.
- `primary` is now a required keyword-only field instead of a `None` default hidden behind a type-ignore.
- The docstring states which inherited knobs matter (`retry_policy`, `model_name`) and that `llm_settings` is inert on the composite — settings belong on the member LLMs.

## LLMAgent run-entry clarity

`LLMAgent`'s run entry is refactored for readability: the step open sequence (optional transcript reset, rollback-boundary archival, input append) is extracted into `_start_step`, with the invariant made explicit that everything fallible happens before the first mutation — a failure during input rendering/attachments leaves the session exactly as entered. Step-anchoring helpers are grouped together, and tests for initial-context building and team message anchoring are extended accordingly.

## Breaking changes

- **`LLMResponseRefusalError` is removed** (`grasp_agents.types.errors`). Callers that caught it should inspect `response.refusal` / `incomplete_details.reason == "content_filter"`, or expect `LLMResponseValidationError` for structured calls once retries are exhausted.
- **`FallbackLLM(primary=…)` is keyword-only.** Positional construction of `primary` no longer works (all known call sites already used keywords).

## Testing

- Full suite: 2608 passed.
- New unit tests: lazy provider re-exports (including a fresh-interpreter laziness check), refusal warn-and-flow on both streaming and non-streaming paths, refusal re-sampling under `validation_retries`, refusal round-trip per provider converter, strict/`VALIDATED` request builds per provider.
- New live integration tests (Anthropic + Gemini): strict tool calls, streamed and non-streamed, plus the server-side-validation negative control and the enum-constraint differential described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
