### PR TITLE
llm settings validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grasp_agents"
-version = "1.0.15"
+version = "1.0.16"
 description = "Grasp Agents Library"
 readme = "README.md"
 requires-python = ">=3.12,<4"

--- a/src/grasp_agents/llm/cloud_llm.py
+++ b/src/grasp_agents/llm/cloud_llm.py
@@ -3,10 +3,11 @@ import time
 from abc import abstractmethod
 from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any, NoReturn, Required, TypedDict
+from functools import cache
+from typing import Any, ClassVar, NoReturn, Required, TypedDict
 
 import httpx
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, TypeAdapter, with_config
 
 from grasp_agents import grasp_logging
 from grasp_agents.rate_limiting.rate_limiter import RateLimiter, limit_rate
@@ -38,10 +39,16 @@ class APIProvider(TypedDict, total=False):
     api_key: Required[str | None]
 
 
+@with_config(ConfigDict(extra="allow"))
 class CloudLLMSettings(LLMSettings, total=False):
     extra_headers: dict[str, Any] | None
     extra_body: object | None
     extra_query: dict[str, Any] | None
+
+
+@cache
+def _settings_adapter(settings_type: type) -> TypeAdapter[Any]:
+    return TypeAdapter(settings_type)
 
 
 LLMRateLimiter = RateLimiter[Response | AsyncIterator[LlmEvent]]
@@ -57,6 +64,11 @@ class ApiCallParams(TypedDict, total=False):
 
 @dataclass(frozen=True)
 class CloudLLM(LLM):
+    # Settings TypedDict that ``llm_settings`` is validated against at
+    # construction: declared keys are type-checked; undeclared keys pass
+    # through to the provider untouched. ``None`` disables validation.
+    _settings_type: ClassVar[Any] = CloudLLMSettings
+
     llm_settings: CloudLLMSettings | None = None
     # repr=False: carries the resolved API key — must not leak via repr/str
     # (logs, tracebacks, printed configs).
@@ -68,6 +80,9 @@ class CloudLLM(LLM):
     default_headers: Mapping[str, str] | None = None
 
     def __post_init__(self) -> None:
+        if self.llm_settings is not None and self._settings_type is not None:
+            _settings_adapter(self._settings_type).validate_python(self.llm_settings)
+
         if self.rate_limiter is not None:
             logger.info(
                 f"[{self.__class__.__name__}] Set rate limit to "

--- a/src/grasp_agents/llm/llm.py
+++ b/src/grasp_agents/llm/llm.py
@@ -11,7 +11,7 @@ from functools import cached_property
 from typing import Any, Self, TypedDict, final
 from uuid import uuid4
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, with_config
 
 from grasp_agents import grasp_logging
 from grasp_agents.tools.base import BaseTool, ToolChoice
@@ -40,6 +40,7 @@ logger = logging.getLogger(__name__)
 _RETRYABLE_ERRORS = (LLMToolCallValidationError, LLMResponseValidationError)
 
 
+@with_config(ConfigDict(extra="allow"))
 class LLMSettings(TypedDict, total=False):
     temperature: float | None
     top_p: float | None

--- a/src/grasp_agents/llm_providers/anthropic/anthropic_llm.py
+++ b/src/grasp_agents/llm_providers/anthropic/anthropic_llm.py
@@ -5,15 +5,19 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict
 
 from anthropic import AsyncAnthropic
 from anthropic._types import omit  # type: ignore[import]  # noqa: PLC2701
 from anthropic.types import (
+    MetadataParam,
+    OutputConfigParam,
+    ThinkingConfigParam,
     WebFetchTool20260209Param,
     WebSearchTool20250305Param,
     WebSearchTool20260209Param,
 )
+from pydantic import ConfigDict, with_config
 
 from grasp_agents.llm.cloud_llm import (
     ApiCallParams,
@@ -37,7 +41,6 @@ if TYPE_CHECKING:
         AsyncAnthropicBedrockMantle,  # pyright: ignore[reportPrivateImportUsage]
         AsyncAnthropicVertex,  # pyright: ignore[reportPrivateImportUsage]
     )
-    from anthropic.types import MetadataParam, OutputConfigParam
     from pydantic import BaseModel
 
     from grasp_agents.tools.base import BaseTool, ToolChoice
@@ -49,7 +52,6 @@ if TYPE_CHECKING:
     from . import (
         AnthropicMessage,
         AnthropicStreamEvent,
-        ThinkingConfigParam,
         ToolChoiceParam,
         ToolParam,
     )
@@ -77,19 +79,20 @@ _VERTEX_INSTALL_HINT = (
 )
 
 
+@with_config(ConfigDict(extra="allow"))
 class AnthropicLLMSettings(CloudLLMSettings, total=False):
     max_tokens: int
     thinking: ThinkingConfigParam | None
     stop_sequences: list[str] | None
     top_k: int | None
 
+    web_search: WebSearchToolParam | None
+    web_fetch: WebFetchToolParam | None
+
     # Structured outputs sent directly (the manual escape hatch). When
     # ``apply_output_schema_via_provider`` is set the schema travels via the
     # separate ``output_schema`` channel (``messages.parse``) instead.
     output_config: OutputConfigParam | None
-
-    web_search: WebSearchToolParam | None
-    web_fetch: WebFetchToolParam | None
 
     metadata: MetadataParam | None
     service_tier: Literal["auto", "standard_only"] | None
@@ -132,6 +135,8 @@ class VertexClientConfig(TypedDict, total=False):
 
 @dataclass(frozen=True)
 class AnthropicLLM(CloudLLM):
+    _settings_type: ClassVar[Any] = AnthropicLLMSettings
+
     litellm_provider: str | None = "anthropic"
     llm_settings: AnthropicLLMSettings | None = None
     # Matches the SDK default. A long generation (large max_tokens, extended

--- a/src/grasp_agents/llm_providers/gemini/gemini_llm.py
+++ b/src/grasp_agents/llm_providers/gemini/gemini_llm.py
@@ -5,11 +5,20 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypedDict
 
 from google.genai import Client
+from google.genai.types import (
+    AutomaticFunctionCallingConfigDict,
+    GenerationConfigRoutingConfigDict,
+    MediaResolution,
+    ModelArmorConfigDict,
+    ModelSelectionConfigDict,
+    ServiceTier,
+    UrlContext,
+)
 from google.genai.types import HttpOptions as GeminiHttpOptions
-from google.genai.types import UrlContext
+from pydantic import ConfigDict, with_config
 
 from grasp_agents.llm.cloud_llm import (
     ApiCallParams,
@@ -18,7 +27,14 @@ from grasp_agents.llm.cloud_llm import (
     CloudLLMSettings,
 )
 
-from . import GeminiConfig, GeminiGoogleSearch, GeminiGoogleSearchDict, GeminiTool
+from . import (
+    GeminiConfig,
+    GeminiGoogleSearch,
+    GeminiGoogleSearchDict,
+    GeminiSafetySettingDict,
+    GeminiThinkingConfigDict,
+    GeminiTool,
+)
 from .error_mapping import map_api_error
 from .llm_event_converters import GeminiStreamConverter
 from .provider_output_to_response import provider_output_to_response
@@ -28,14 +44,6 @@ from .tool_converters import to_api_tool_config, to_api_tools
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Mapping, Sequence
 
-    from google.genai.types import (
-        AutomaticFunctionCallingConfigDict,
-        GenerationConfigRoutingConfigDict,
-        MediaResolution,
-        ModelArmorConfigDict,
-        ModelSelectionConfigDict,
-        ServiceTier,
-    )
     from pydantic import BaseModel
 
     from grasp_agents.tools.base import BaseTool, ToolChoice
@@ -44,16 +52,12 @@ if TYPE_CHECKING:
     from grasp_agents.types.llm_events import LlmEvent
     from grasp_agents.types.response import Response
 
-    from . import (
-        GeminiHttpOptionsDict,
-        GeminiResponse,
-        GeminiSafetySettingDict,
-        GeminiThinkingConfigDict,
-    )
+    from . import GeminiHttpOptionsDict, GeminiResponse
 
 logger = logging.getLogger(__name__)
 
 
+@with_config(ConfigDict(extra="allow"))
 class GeminiLLMSettings(CloudLLMSettings, total=False):
     max_output_tokens: int
     top_k: float
@@ -113,6 +117,8 @@ class GeminiVertexClientConfig(TypedDict, total=False):
 
 @dataclass(frozen=True)
 class GeminiLLM(CloudLLM):
+    _settings_type: ClassVar[Any] = GeminiLLMSettings
+
     litellm_provider: str | None = "vertex_ai"
     llm_settings: GeminiLLMSettings | None = None
     # Per-request HTTP timeout in seconds (``None`` disables).

--- a/src/grasp_agents/llm_providers/litellm/lite_llm.py
+++ b/src/grasp_agents/llm_providers/litellm/lite_llm.py
@@ -2,7 +2,7 @@ import logging
 from collections import defaultdict
 from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import litellm
 from litellm.litellm_core_utils.get_supported_openai_params import (
@@ -16,7 +16,7 @@ from litellm.utils import (
     supports_response_schema,
     supports_tool_choice,
 )
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, with_config
 
 from grasp_agents.llm.cloud_llm import ApiCallParams, APIProvider, CloudLLM
 from grasp_agents.llm_providers.openai_completions import OpenAILLMSettings
@@ -49,12 +49,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+@with_config(ConfigDict(extra="allow"))
 class LiteLLMSettings(OpenAILLMSettings, total=False):
     thinking: AnthropicThinkingParam | None
 
 
 @dataclass(frozen=True)
 class LiteLLM(CloudLLM):
+    _settings_type: ClassVar[Any] = LiteLLMSettings
+
     llm_settings: LiteLLMSettings | None = None
 
     client_timeout: float = 60.0

--- a/src/grasp_agents/llm_providers/openai_completions/completions_llm.py
+++ b/src/grasp_agents/llm_providers/openai_completions/completions_llm.py
@@ -3,7 +3,7 @@ import os
 from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import Any, Literal, TypedDict
+from typing import Any, ClassVar, Literal, TypedDict
 
 from openai import AsyncAzureOpenAI, AsyncOpenAI, AsyncStream
 from openai._types import omit  # type: ignore  # noqa: PLC2701
@@ -11,7 +11,7 @@ from openai.lib.streaming.chat import (
     AsyncChatCompletionStreamManager as OpenAIAsyncChatCompletionStreamManager,
 )
 from openai.lib.streaming.chat import ChunkEvent as OpenAIChunkEvent
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, with_config
 
 from grasp_agents.llm.cloud_llm import (
     ApiCallParams,
@@ -75,7 +75,12 @@ _COMPAT_LITELLM_PROVIDERS = {
     "openrouter": "openrouter",
 }
 
+CompletionsReasoningEffort = Literal[
+    "none", "disable", "minimal", "low", "medium", "high"
+]
 
+
+@with_config(ConfigDict(extra="allow"))
 class OpenAILLMSettings(CloudLLMSettings, total=False):
     max_completion_tokens: int | None
     seed: int | None
@@ -86,9 +91,7 @@ class OpenAILLMSettings(CloudLLMSettings, total=False):
     logprobs: bool | None
     top_logprobs: int | None
 
-    reasoning_effort: (
-        Literal["none", "disable", "minimal", "low", "medium", "high"] | None
-    )
+    reasoning_effort: CompletionsReasoningEffort | None
 
     parallel_tool_calls: bool
 
@@ -139,6 +142,8 @@ class AzureClientConfig(TypedDict, total=False):
 
 @dataclass(frozen=True)
 class OpenAILLM(CloudLLM):
+    _settings_type: ClassVar[Any] = OpenAILLMSettings
+
     litellm_provider: str | None = "openai"
     llm_settings: OpenAILLMSettings | None = None
     openai_client_timeout: float = 600.0

--- a/src/grasp_agents/llm_providers/openai_responses/responses_llm.py
+++ b/src/grasp_agents/llm_providers/openai_responses/responses_llm.py
@@ -3,7 +3,7 @@ import os
 from collections.abc import AsyncIterator, Iterable, Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, field
-from typing import Any, Literal, cast
+from typing import Any, ClassVar, Literal, cast
 
 from openai import AsyncAzureOpenAI, AsyncOpenAI
 from openai._types import omit  # noqa: PLC2701
@@ -38,7 +38,7 @@ from openai.types.responses.tool_param import (
 from openai.types.responses.web_search_tool_param import WebSearchToolParam
 from openai.types.shared import Reasoning
 from openai.types.shared_params import Metadata
-from pydantic import BaseModel, TypeAdapter
+from pydantic import BaseModel, ConfigDict, TypeAdapter, with_config
 
 from grasp_agents.llm.cloud_llm import (
     ApiCallParams,
@@ -99,25 +99,32 @@ def _items_after_last_response(
     return api_input[start:]
 
 
+VerbosityLevel = Literal["low", "medium", "high"]
+PromptCacheRetention = Literal["in_memory", "24h"]
+
+
+@with_config(ConfigDict(extra="allow"))
 class OpenAIResponsesLLMSettings(CloudLLMSettings, total=False):
     reasoning: Reasoning
+    verbosity: VerbosityLevel | None
     parallel_tool_calls: bool
     max_output_tokens: int
     max_tool_calls: int | None
     top_logprobs: int | None
-    web_search: WebSearchToolParam | None
-
-    truncation: Literal["auto", "disabled"] | None
-    service_tier: Literal["auto", "default", "flex", "scale", "priority"] | None
-    include: list[ResponseIncludable] | None
-    context_management: Iterable[ResponsesContextManagement] | None
 
     prompt_cache_key: str
-    prompt_cache_retention: Literal["in_memory", "24h"] | None
-    safety_identifier: str
+    prompt_cache_retention: PromptCacheRetention | None
+
+    context_management: Iterable[ResponsesContextManagement] | None
+    truncation: Literal["auto", "disabled"] | None
+    include: list[ResponseIncludable] | None
+
+    web_search: WebSearchToolParam | None
 
     text: ResponseTextConfigParam
     stream_options: ResponsesStreamOptionsParam | None
+    safety_identifier: str
+    service_tier: Literal["auto", "default", "flex", "scale", "priority"] | None
     metadata: Metadata | None
     store: bool | None
     user: str
@@ -132,6 +139,8 @@ class ResponsesApiCallParams(ApiCallParams, total=False):
 
 @dataclass(frozen=True)
 class OpenAIResponsesLLM(CloudLLM):
+    _settings_type: ClassVar[Any] = OpenAIResponsesLLMSettings
+
     litellm_provider: str | None = "openai"
     llm_settings: OpenAIResponsesLLMSettings | None = None
     # "openai" routes to api.openai.com (or an OpenAI-compatible endpoint via

--- a/tests/llm/test_settings_forwarding.py
+++ b/tests/llm/test_settings_forwarding.py
@@ -6,6 +6,8 @@ representative sample of the expanded settings lands in the API request that
 ``_make_api_input`` builds — i.e. nothing is silently dropped.
 """
 
+from typing import cast
+
 import pytest
 
 from grasp_agents.llm.cloud_llm import APIProvider
@@ -35,17 +37,25 @@ def test_anthropic_forwards_new_settings(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 def test_openai_completions_forwards_new_settings() -> None:
-    from grasp_agents.llm_providers.openai_completions.completions_llm import OpenAILLM
+    from grasp_agents.llm_providers.openai_completions.completions_llm import (
+        OpenAILLM,
+        OpenAILLMSettings,
+    )
 
+    # ``not_yet_declared`` is not in the settings TypedDict — undeclared keys
+    # must still reach the API untouched.
     llm = OpenAILLM(
         model_name="gpt-4o",
         api_provider=_OPENAI,
-        llm_settings={"n": 2, "service_tier": "flex", "verbosity": "low"},
+        llm_settings=cast(
+            "OpenAILLMSettings",
+            {"n": 2, "service_tier": "flex", "not_yet_declared": "kept"},
+        ),
     )
     extra = llm._make_api_input([]).get("extra_settings", {})
     assert extra["n"] == 2
     assert extra["service_tier"] == "flex"
-    assert extra["verbosity"] == "low"
+    assert extra["not_yet_declared"] == "kept"
 
 
 def test_openai_responses_forwards_new_settings() -> None:

--- a/tests/llm/test_settings_validation.py
+++ b/tests/llm/test_settings_validation.py
@@ -1,0 +1,131 @@
+"""
+Provider settings TypedDicts are a pydantic-validatable contract: annotations
+resolve at runtime, declared keys are type-checked, and undeclared keys are
+PRESERVED (pass through to the provider — never silently dropped). ``CloudLLM``
+validates at construction.
+"""
+
+from typing import Any, cast
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from grasp_agents.llm.cloud_llm import CloudLLMSettings
+from grasp_agents.llm.llm import LLMSettings
+from grasp_agents.llm_providers.anthropic.anthropic_llm import (
+    AnthropicLLM,
+    AnthropicLLMSettings,
+)
+from grasp_agents.llm_providers.gemini.gemini_llm import GeminiLLMSettings
+from grasp_agents.llm_providers.litellm.lite_llm import LiteLLM, LiteLLMSettings
+from grasp_agents.llm_providers.openai_completions.completions_llm import (
+    OpenAILLM,
+    OpenAILLMSettings,
+)
+from grasp_agents.llm_providers.openai_responses.responses_llm import (
+    OpenAIResponsesLLMSettings,
+)
+
+ALL_SETTINGS_TYPES: list[Any] = [
+    LLMSettings,
+    CloudLLMSettings,
+    AnthropicLLMSettings,
+    GeminiLLMSettings,
+    OpenAILLMSettings,
+    OpenAIResponsesLLMSettings,
+    LiteLLMSettings,
+]
+
+VALID_SETTINGS: list[tuple[Any, dict[str, Any]]] = [
+    (LLMSettings, {"temperature": 1.0, "top_p": 0.9}),
+    (CloudLLMSettings, {"temperature": 1.0, "extra_headers": {"x-key": "v"}}),
+    (
+        AnthropicLLMSettings,
+        {
+            "temperature": 1.0,
+            "max_tokens": 1024,
+            "thinking": {"type": "enabled", "budget_tokens": 4096},
+        },
+    ),
+    (
+        GeminiLLMSettings,
+        {
+            "temperature": 1.0,
+            "thinking_config": {"include_thoughts": True, "thinking_budget": 8192},
+        },
+    ),
+    (OpenAILLMSettings, {"temperature": 1.0, "reasoning_effort": "medium"}),
+    (
+        OpenAIResponsesLLMSettings,
+        {"temperature": 1.0, "reasoning": {"effort": "medium"}},
+    ),
+    (LiteLLMSettings, {"temperature": 1.0, "reasoning_effort": "disable"}),
+]
+
+
+@pytest.mark.parametrize(
+    ("settings_type", "settings"),
+    VALID_SETTINGS,
+    ids=lambda v: v.__name__ if isinstance(v, type) else None,
+)
+def test_settings_validate_and_preserve_keys(
+    settings_type: Any, settings: dict[str, Any]
+) -> None:
+    validated = TypeAdapter(settings_type).validate_python(settings)
+    assert set(validated) == set(settings)
+
+
+@pytest.mark.parametrize("settings_type", ALL_SETTINGS_TYPES, ids=lambda v: v.__name__)
+def test_undeclared_keys_are_preserved_not_dropped(settings_type: Any) -> None:
+    settings = {"temperature": 1.0, "brand_new_provider_param": {"x": 1}}
+    assert TypeAdapter(settings_type).validate_python(settings) == settings
+
+
+@pytest.mark.parametrize("settings_type", ALL_SETTINGS_TYPES, ids=lambda v: v.__name__)
+def test_all_settings_keys_are_optional(settings_type: Any) -> None:
+    assert TypeAdapter(settings_type).validate_python({}) == {}
+
+
+@pytest.mark.parametrize("settings_type", ALL_SETTINGS_TYPES, ids=lambda v: v.__name__)
+def test_declared_key_type_error_is_rejected(settings_type: Any) -> None:
+    with pytest.raises(ValidationError, match="temperature"):
+        TypeAdapter(settings_type).validate_python({"temperature": "hot"})
+
+
+def test_settings_enforce_nested_required_keys() -> None:
+    with pytest.raises(ValidationError):
+        TypeAdapter(AnthropicLLMSettings).validate_python(
+            {"thinking": {"type": "enabled"}}  # missing required budget_tokens
+        )
+
+
+def test_llm_construction_rejects_mistyped_declared_key() -> None:
+    with pytest.raises(ValidationError, match="temperature"):
+        OpenAILLM(
+            model_name="openai/gpt-5.1",
+            llm_settings=cast("OpenAILLMSettings", {"temperature": "hot"}),
+        )
+
+
+def test_llm_construction_accepts_valid_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-dummy")
+    llm = AnthropicLLM(
+        model_name="claude-sonnet-4-5",
+        llm_settings=AnthropicLLMSettings(
+            temperature=1.0, thinking={"type": "enabled", "budget_tokens": 4096}
+        ),
+    )
+    assert llm.llm_settings is not None
+
+
+def test_llm_construction_passes_undeclared_settings_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-dummy")
+    llm = LiteLLM(
+        model_name="openai/gpt-5.1",
+        llm_settings=cast("Any", {"provider_specific_param": 1}),
+    )
+    assert llm.llm_settings == {"provider_specific_param": 1}

--- a/uv.lock
+++ b/uv.lock
@@ -1181,7 +1181,7 @@ wheels = [
 
 [[package]]
 name = "grasp-agents"
-version = "1.0.15"
+version = "1.0.16"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
# Validate LLM settings at construction

Provider `llm_settings` TypedDicts are now a pydantic-validatable contract, and every `CloudLLM` validates its settings when constructed.

Previously, running the settings through pydantic (e.g. holding them in an application config model) either failed — the SDK types they reference were `TYPE_CHECKING`-only, so their annotations could not be resolved at runtime — or, worse, silently **dropped** any key pydantic didn't recognize. A misspelled or misplaced settings key could vanish between a config and the provider with no error anywhere.

## Changes

- Settings-referenced SDK types are imported at runtime in the Anthropic and Gemini providers (the OpenAI providers already were), so `TypeAdapter(<ProviderSettings>)` works out of the box.
- All settings TypedDicts carry `extra="allow"`: declared keys are type-checked, while **undeclared keys are preserved and forwarded to the provider untouched**. The settings classes remain a typed convenience subset — new SDK params work without waiting for a declaration, and pydantic validation can no longer drop them.
- `CloudLLM.__post_init__` validates `llm_settings` against the provider's settings class: a mistyped declared key (`temperature="hot"`) or a malformed nested structure (`thinking` missing `budget_tokens`) now raises `ValidationError` at construction instead of failing inside an API call. Custom providers can opt out via `_settings_type = None`.

## Behavior change

Constructing an LLM with an invalid **declared** settings value now raises immediately. Undeclared keys are unaffected and forward to the API as before.

## Tests

`tests/llm/test_settings_validation.py` pins the contract per provider: valid settings round-trip, undeclared keys are preserved (never dropped), every key stays optional, declared-key type errors and nested required keys are enforced, and construction-time validation behaves as described. The settings-forwarding tests keep pinning that undeclared keys reach the request.
