### PR TITLE
Bg tasks cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grasp_agents"
-version = "1.0.18"
+version = "1.0.19"
 description = "Grasp Agents Library"
 readme = "README.md"
 requires-python = ">=3.12,<4"

--- a/src/grasp_agents/agent/agent_context.py
+++ b/src/grasp_agents/agent/agent_context.py
@@ -18,7 +18,7 @@ that inject messages into the transcript between turns, sharing one mirrored
 lifecycle: a monotonic per-item seq (task ``launch_seq`` / mail consumption
 ``seq``) whose high-waters are checkpointed and ``seed_*``-ed back on resume;
 durable effects deferred until the absorbing turn is checkpointed
-(``flush_delivered`` / ``flush_acks``); and rollback keyed on ``seq >`` the
+(``flush_flips`` / ``flush_acks``); and rollback keyed on ``seq >`` the
 boundary's high-water — tasks launched past it are *cancelled*, task notes
 truncated by the cut are *redelivered*, consumed mail is *voided* (senders
 notified, never re-delivered).
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     from grasp_agents.tools.bash_session import BashSessionHolder
     from grasp_agents.tools.file_edit.session_state import FileEditSessionState
     from grasp_agents.tools.notebook_exec import KernelHolder
+    from grasp_agents.types.items import InputMessageItem
 
     from .background_tasks import BackgroundTaskManager
     from .llm_agent_transcript import LLMAgentTranscript
@@ -171,7 +172,7 @@ class AgentContext:
             dotfile_overrides=dotfile_overrides,
             shell_cwd=self.shell_state.cwd,
             deferred_delivered=self.bg_tasks.export_deferred_delivered(),
-            deferred_killed=self.bg_tasks.export_deferred_killed(),
+            deferred_cancelled=self.bg_tasks.export_deferred_cancelled(),
             task_launch_seq=self.bg_tasks.last_launch_seq,
             mail_consumption_seq=(
                 self.inbox.last_consumption_seq if self.inbox is not None else 0
@@ -187,35 +188,26 @@ class AgentContext:
         state: AgentContextState,
         *,
         rebind_kernels: bool = False,
-        keep_deferred_delivered: bool = False,
     ) -> None:
         """
-        Reapply a :meth:`snapshot` snapshot.
+        Reapply a :meth:`snapshot` snapshot. Call it only after the caller's
+        transcript surgery (settle prune / rewind truncation / cold reload):
+        the live transcript decides which deferred flips survive. In-memory
+        tasks launched past the restored watermark are cancelled — their
+        launching calls are no longer in the history the model sees.
 
-        Always restores the transactional subset, keeping the context
-        consistent with the rolled-back transcript: the file-read ledger
-        forgets Reads whose results were rolled back, the fresh-``Bash`` cwd
-        matches the history the model still sees, and deferred task-record
-        flips are discarded (their completion notes were rolled back, so the
-        records stay COMPLETED for a later resume to re-inject). In-memory
-        tasks launched past the restored watermark are cancelled — the
-        restored transcript no longer holds their launching calls, so their
-        completions must not deliver (vacuous on a cold reload, which has no
-        in-memory tasks).
-
-        ``keep_deferred_delivered`` marks a restore whose transcript surgery kept
-        the delivered completion notes (a failed-run settle prunes only the
-        trailing response round): the live not-yet-flushed DELIVERED flips are
-        merged over the snapshot's instead of discarded — dropping them would
-        leave the records COMPLETED, and a later resume would re-inject notes
-        the transcript already holds.
+        Live-flip keep-rules: a not-yet-flushed DELIVERED flip survives iff
+        its note is still within the kept transcript
+        (``note_transcript_pos <= len(transcript)``) — dropping a kept note's
+        flip re-injects a duplicate on resume; keeping a cut note's buries
+        the outcome as DELIVERED. CANCELLED flips ALL survive: a cancellation
+        is a physical fact no boundary falsifies — and the snapshot's flips
+        stop a killed task's resurrection when the monotone
+        ``task_launch_seq`` defeats the resume orphan guard.
 
         ``rebind_kernels`` (step rollback paired with a restored filesystem
-        snapshot) additionally seeds the kernels' execution contexts so they
-        re-attach inside the restored sandbox — mirroring resume. A failed run
-        leaves the kernels alone (default): live processes are
-        non-transactional, their side effects can't be unwound, and the
-        kernel-reset notice covers genuine restarts.
+        snapshot) re-attaches the kernels' execution contexts inside the
+        restored sandbox; a failed-run settle leaves the live kernels alone.
         """
         self.file_edit_state.import_state(
             state.read_file_state, state.dotfile_overrides
@@ -223,15 +215,23 @@ class AgentContext:
 
         self.shell_state.cwd = state.shell_cwd
 
-        deferred_delivered = state.deferred_delivered
-        if keep_deferred_delivered:
-            deferred_delivered = {
-                **deferred_delivered,
-                **self.bg_tasks.export_deferred_delivered(),
+        kept = len(self.transcript.messages)
+        live_flips = {
+            key: flip
+            for key, flip in self.bg_tasks.export_deferred_delivered().items()
+            if flip.get("note_transcript_pos", 0) <= kept
+        }
+        self.bg_tasks.restore_deferred_delivered(
+            {**state.deferred_delivered, **live_flips}
+        )
+        self.bg_tasks.restore_deferred_cancelled(
+            {
+                **state.deferred_cancelled,
+                **self.bg_tasks.export_deferred_cancelled(),
             }
-        self.bg_tasks.restore_deferred_delivered(deferred_delivered)
-        self.bg_tasks.restore_deferred_killed(state.deferred_killed)
+        )
         self.bg_tasks.seed_launch_seq(state.task_launch_seq)
+
         # After the restore_deferred_* imports: cancelling defers CANCELLED
         # record updates, which the imports must not clobber.
         self.bg_tasks.cancel_launched_after(state.task_launch_seq)
@@ -239,7 +239,7 @@ class AgentContext:
         # Leases are NOT dropped here: a settle keeps the absorbed-but-unacked
         # message in the transcript, and its lease is what stops the loop from
         # re-taking (duplicating) it. The callers that discard the message's
-        # turn — cold reload and step rollback — drop leases themselves.
+        # turn — cold reload and :meth:`rewind` — drop leases themselves.
         if self.inbox is not None:
             self.inbox.seed_consumption_seq(state.mail_consumption_seq)
 
@@ -248,6 +248,70 @@ class AgentContext:
                 self.ipy_kernel_holder.rebind(state.ipy_exec_context_id)
             if state.nb_exec_context_id is not None:
                 self.nb_kernel_holder.rebind(state.nb_exec_context_id)
+
+    async def rewind(
+        self,
+        state: AgentContextState,
+        *,
+        message_count: int,
+        committed_mail_seq: int,
+        ctx: SessionContext[Any],
+        rebind_kernels: bool = False,
+    ) -> list[InputMessageItem]:
+        """
+        The context half of a step rollback: truncate the transcript to
+        ``message_count``, reapply ``state`` (:meth:`restore`), then reconcile
+        the two side channels' durable halves — where :meth:`restore` is a pure
+        in-memory reset, the channels also have effects the reset cannot
+        express. A delivered task note that sat past the cut while its
+        launching call survived just lost the only live copy of its outcome:
+        re-inject it at the rewind point (returned for the caller to surface
+        as resume notifications). Mail consumed past the boundary was absorbed
+        by turns the truncation dropped: void it.
+
+        ``committed_mail_seq`` is the pre-rollback *persisted* consumption
+        high-water — the head's, captured before the boundary becomes the new
+        head — bounding the seq range of mail to void.
+
+        Runs only at quiescence (no live run); the persisted-head / filesystem
+        crash protocol around it is the caller's.
+        """
+        self.transcript.messages = self.transcript.messages[:message_count]
+
+        # Exported before the restore replaces it: a drained-but-unflushed
+        # note's deferred flip is the only trace that the note (now truncated)
+        # was delivered — ``redeliver_after`` overlays it onto the records.
+        deferred_flips = self.bg_tasks.export_deferred_delivered()
+
+        self.restore(state, rebind_kernels=rebind_kernels)
+
+        injected = await self.bg_tasks.redeliver_after(
+            message_count=message_count,
+            task_launch_seq=state.task_launch_seq,
+            ctx=ctx,
+            pre_restore_deferred_delivered=deferred_flips,
+        )
+
+        # The mailbox half: mail consumed past the boundary is VOIDED, never
+        # re-delivered — a rollback rewrites history, so the human supplies
+        # new input while dropped peers get a resend note (never-consumed
+        # messages stay pending). Leased (un-acked) takes are acked-and-
+        # voided; leases are in-memory, so a crash mid-rollback degrades to
+        # crash semantics — the re-driven rollback finds the messages still
+        # pending and re-delivers instead of voiding.
+        mailbox_hw = state.mail_consumption_seq
+        leased = self.inbox.drop_leases() if self.inbox is not None else []
+        if committed_mail_seq > mailbox_hw or leased:
+            from grasp_agents.mailbox import void_mail_after  # noqa: PLC0415
+
+            transport = ctx.transport
+            # Seed the counter: a cold rollback's fresh transport starts at
+            # zero, and later takes must not re-mint seqs held by voided
+            # records (max-only, so a live transport is unaffected).
+            transport.seed_consumption_seq(self.agent_name, committed_mail_seq)
+            await void_mail_after(transport, self.agent_name, mailbox_hw, leased=leased)
+
+        return injected
 
     async def close(self, *, ctx: SessionContext[Any] | None = None) -> None:
         """

--- a/src/grasp_agents/agent/agent_loop.py
+++ b/src/grasp_agents/agent/agent_loop.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Final, Protocol
 
 from pydantic import BaseModel
 
+from grasp_agents.context.system_reminder import wrap_in_system_reminder
 from grasp_agents.context.untrusted_content import wrap_untrusted
 from grasp_agents.durability.checkpoints import AgentCheckpointLocation
 from grasp_agents.durability.store_keys import make_tool_call_path
@@ -60,8 +61,8 @@ from .loop_state import (
     NextStep,
     NextStepContinue,
     NextStepForceFinalAnswer,
-    NextStepForceResidentReply,
-    NextStepResidentReply,
+    NextStepForceResidentAnswer,
+    NextStepResidentAnswer,
     NextStepRunTools,
     NextStepStop,
     decide_next_step,
@@ -103,6 +104,7 @@ class CheckpointCallback(Protocol):
         turn: int = ...,
         location: AgentCheckpointLocation = ...,
         output: str | None = ...,
+        stop_reason: StopReason | None = ...,
     ) -> None: ...
 
 
@@ -296,11 +298,18 @@ class AgentLoop[CtxT]:
         return self._cw
 
     async def checkpoint(
-        self, *, turn: int, location: AgentCheckpointLocation, output: str | None = None
+        self,
+        *,
+        turn: int,
+        location: AgentCheckpointLocation,
+        output: str | None = None,
+        stop_reason: StopReason | None = None,
     ) -> None:
         """Persist session state if a checkpoint callback is configured."""
         if self.checkpoint_callback:
-            await self.checkpoint_callback(turn=turn, location=location, output=output)
+            await self.checkpoint_callback(
+                turn=turn, location=location, output=output, stop_reason=stop_reason
+            )
 
     # --- Hook dispatch ---
 
@@ -822,7 +831,9 @@ class AgentLoop[CtxT]:
         extra_llm_settings: dict[str, Any],
     ) -> AsyncIterator[Event[Any]]:
         user_message = InputMessageItem.from_text(
-            "Exceeded the maximum number of turns: provide a final answer now!",
+            wrap_in_system_reminder(
+                "Exceeded the maximum number of turns: provide a final answer now!"
+            ),
             role="user",
         )
         self._agent_ctx.transcript.update([user_message])
@@ -1189,6 +1200,7 @@ class AgentLoop[CtxT]:
             turn=self.turn,
             location=AgentCheckpointLocation.AFTER_FINAL_ANSWER,
             output=self._final_answer,
+            stop_reason=step.stop_reason,
         )
 
         yield TurnEndEvent(
@@ -1232,8 +1244,9 @@ class AgentLoop[CtxT]:
 
         await self.checkpoint(
             turn=self.turn,
-            location=AgentCheckpointLocation.AFTER_FORCED_FINAL_ANSWER,
+            location=AgentCheckpointLocation.AFTER_FINAL_ANSWER,
             output=self._final_answer,
+            stop_reason=stop_reason,
         )
 
         yield TurnEndEvent(
@@ -1258,13 +1271,13 @@ class AgentLoop[CtxT]:
                 self.max_turns,
             )
 
-    async def _handle_resident_reply(
-        self, step: NextStepResidentReply, *, exec_id: str
+    async def _handle_resident_answer(
+        self, step: NextStepResidentAnswer, *, exec_id: str
     ) -> AsyncIterator[Event[Any]]:
         """
-        ``NextStepResidentReply``: a resident produced its reply to the current
+        ``NextStepResidentAnswer``: a resident produced its answer to the current
         message and the open inbox recycles the loop instead of stopping. Persist
-        the turn — a resident reply otherwise never checkpoints, so the answer
+        the turn — a resident answer otherwise never checkpoints, so the answer
         would be re-generated on resume — which also releases any message this turn
         absorbed (the ack flush in :meth:`checkpoint`). Non-terminal: the loop
         continues and parks for the next message (the tail is now an answer, so it
@@ -1283,7 +1296,7 @@ class AgentLoop[CtxT]:
             data=TurnEndInfo(turn=self.turn, had_tool_calls=False),
         )
 
-    async def _handle_force_resident_reply(
+    async def _handle_force_resident_answer(
         self,
         response: Response,
         *,
@@ -1291,7 +1304,7 @@ class AgentLoop[CtxT]:
         extra_llm_settings: dict[str, Any],
     ) -> AsyncIterator[Event[Any]]:
         """
-        ``NextStepForceResidentReply``: a resident burned its per-message turn
+        ``NextStepForceResidentAnswer``: a resident burned its per-message turn
         budget without an answer it can return. The resident analog of
         :meth:`_handle_force_final_answer`: close dangling tool calls, force-generate
         a final answer for this message, persist it (``AFTER_RESIDENT_ANSWER``,
@@ -1300,7 +1313,7 @@ class AgentLoop[CtxT]:
         force path).
         """
         logger.warning(
-            "Resident '%s' hit its per-message turn budget (%s) — forcing a reply "
+            "Resident '%s' hit its per-message turn budget (%s) — forcing an answer "
             "and moving on to the next message.",
             self.agent_name,
             self.max_turns,
@@ -1588,12 +1601,12 @@ class AgentLoop[CtxT]:
                     yield event
                 return
 
-            if isinstance(step, NextStepResidentReply):
-                async for event in self._handle_resident_reply(step, exec_id=exec_id):
+            if isinstance(step, NextStepResidentAnswer):
+                async for event in self._handle_resident_answer(step, exec_id=exec_id):
                     yield event
 
-            if isinstance(step, NextStepForceResidentReply):
-                async for event in self._handle_force_resident_reply(
+            if isinstance(step, NextStepForceResidentAnswer):
+                async for event in self._handle_force_resident_answer(
                     response,
                     exec_id=exec_id,
                     extra_llm_settings=extra_llm_settings,

--- a/src/grasp_agents/agent/background_tasks.py
+++ b/src/grasp_agents/agent/background_tasks.py
@@ -9,9 +9,14 @@ from datetime import UTC, datetime, timedelta
 from logging import getLogger
 from typing import TYPE_CHECKING, Any, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, TypeAdapter
 from pydantic_core import to_jsonable_python
 
+from grasp_agents.context.prompt_builder import SystemPromptSection
+from grasp_agents.context.system_reminder import (
+    SESSION_RESUMED_SUBJECT,
+    wrap_in_system_reminder,
+)
 from grasp_agents.durability.checkpoint_store import CheckpointStore
 from grasp_agents.durability.checkpoints import CheckpointKind
 from grasp_agents.durability.store_keys import (
@@ -20,7 +25,12 @@ from grasp_agents.durability.store_keys import (
     make_tool_call_path,
     task_prefix,
 )
-from grasp_agents.durability.task_record import TaskRecord, TaskStatus
+from grasp_agents.durability.task_record import (
+    TaskCancelledFlip,
+    TaskDeliveredFlip,
+    TaskRecord,
+    TaskStatus,
+)
 from grasp_agents.session_context import SessionContext
 from grasp_agents.tools.base import BaseTool
 from grasp_agents.types.events import (
@@ -58,6 +68,9 @@ logger = getLogger(__name__)
 MAX_TASK_LOG_BYTES = 64 * 1024 * 1024
 
 
+# --- Task notifications ---
+
+
 def _fmt_duration(seconds: float) -> str:
     """Compact human duration: ``45s`` / ``4m12s`` / ``1h05m``."""
     s = int(seconds)
@@ -70,93 +83,307 @@ def _fmt_duration(seconds: float) -> str:
     return f"{h}h{m:02d}m"
 
 
-class KillTaskResult(BaseModel):
+BACKGROUND_TASKS_SECTION_NAME = "background_tasks"
+
+
+def make_background_tasks_section(
+    *, section_name: str = BACKGROUND_TASKS_SECTION_NAME
+) -> SystemPromptSection:
     """
-    What ``KillTask`` returns for a stopped background task.
+    Build the background-task guidance section (waiting behavior, progress
+    logs, KillTask), auto-attached by ``LLMAgent``.
 
-    ``status`` is ``cancelled`` when the task was still running and ``KillTask``
-    stopped it (the common case), or ``completed`` / ``failed`` when it had
-    already reached that terminal state before the kill arrived. ``output`` is
-    an excerpt of the text the task produced (the full output is in its
-    ``.grasp`` log); ``result`` is the tool's own terminal output (e.g. a
-    ``BashResult``) when it had finished, else ``None``.
+    Renders only when the toolset has a backgroundable tool
+    (``auto_background_at`` set). The tools are read live off the call's
+    ``agent_ctx`` at prompt-build time, so tools wired after construction
+    (e.g. by a team onto its residents) are picked up at the next run entry.
+    The KillTask line renders only when that tool is attached.
     """
 
-    task_id: str
-    tool_name: str
-    status: Literal["cancelled", "completed", "failed"]
-    output: str = ""
-    result: Any = None
+    def compute(
+        *,
+        ctx: SessionContext[Any] | None = None,
+        exec_id: str | None = None,
+        agent_ctx: "AgentContext | None" = None,
+        **_: Any,
+    ) -> str | None:
+        del ctx, exec_id
+        if agent_ctx is None:
+            return None
+        tools = agent_ctx.tools
+        if all(t.auto_background_at is None for t in tools.values()):
+            return None
+
+        lines = [
+            "<background_tasks>",
+            (
+                "Some of your tools run as background tasks: a backgrounded "
+                "call immediately returns a <task_notification> with status "
+                '"running" and a task_id, while the work continues.'
+            ),
+            (
+                "- You will receive another <task_notification> when a task "
+                "finishes — until then, assume it is still running and do NOT "
+                "repeat the call. You can continue with other work."
+            ),
+            (
+                "- If the only thing left to do is wait for background tasks, "
+                "report that you are waiting for them to finish WITHOUT "
+                "calling any tools."
+            ),
+            (
+                "- A task's <log_file> tag, when present (not every task has "
+                "a log), names the file its streamed output is mirrored to — "
+                "Read or Grep that file to check progress so far (it is "
+                "partial until the task finishes, and a read's own exit code "
+                "reflects the read, not the task)."
+            ),
+            (
+                '- A notification with status "interrupted" means the task '
+                "was stopped before finishing (e.g. by a restart): check any "
+                "partial output it produced, then continue from where it "
+                "left off when possible, or re-run it from scratch."
+            ),
+        ]
+        if "KillTask" in tools:
+            lines.append(
+                "- Stop a task with KillTask if you no longer need it or the "
+                "user wants to cancel it."
+            )
+        lines.append("</background_tasks>")
+
+        return "\n".join(lines)
+
+    return SystemPromptSection(name=section_name, compute=compute)
 
 
-def _task_notification(
+def _make_launch_note(
     *,
     task_id: str,
     tool_name: str,
-    status: str,
+    tool_call_id: str,
+    backgrounded_after: float | None,
+    log_path: str | None,
+) -> str:
+    """
+    The immediate tool result for a backgrounded call: the same XML block as a
+    completion note, with status RUNNING. ``backgrounded_after`` is the
+    deadline a positive-``auto_background_at`` call outlived (``None`` for an
+    immediate background); it shapes only the subject line, never the task's
+    kind. The waiting/log/kill guidance is not repeated here — it lives in the
+    auto-attached ``background_tasks`` system-prompt section
+    (:func:`make_background_tasks_section`).
+    """
+    subject = (
+        "Task launched and running in the background"
+        if backgrounded_after is None
+        else (
+            f"Task was moved to the background after running "
+            f"for {backgrounded_after:g}s"
+        )
+    )
+    parts = [
+        "<task_notification>",
+        f"<subject> {subject} </subject>",
+        f"<task_id> {task_id} </task_id>",
+        f"<tool_name> {tool_name} </tool_name>",
+        f"<tool_call_id> {tool_call_id} </tool_call_id>",
+        f"<status> {TaskStatus.RUNNING.value} </status>",
+    ]
+
+    if log_path is not None:
+        parts.append(f"<log_file> {log_path} </log_file>")
+
+    parts.append("</task_notification>")
+
+    return "\n".join(parts)
+
+
+def _make_launch_event(
+    agent_name: str,
+    task_id: str,
+    tool_name: str,
+    tool_call_id: str,
+    *,
+    log_path: str | None,
+    exec_id: str,
+) -> BackgroundTaskLaunchedEvent:
+    """
+    Build the launched event both backgrounding modes bubble.
+
+    ``output_name`` is surfaced only for a task that has a ``.grasp`` log
+    (``log_path`` set); a sub-agent without one advertises ``None``. It equals
+    the log's basename by construction (``open_task_log`` builds the filename
+    with ``task_log_name``).
+    """
+    return BackgroundTaskLaunchedEvent(
+        source=agent_name,
+        exec_id=exec_id,
+        data=BackgroundTaskInfo(
+            task_id=task_id,
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+            output_name=task_log_name(tool_call_id) if log_path else None,
+        ),
+    )
+
+
+# Fallback cap on inlined chars when the tool's own ``max_inline_result_chars``
+# is unavailable — a completion note rebuilt from a durable record (resume
+# re-injection / rollback re-delivery; the setting is not persisted) or a
+# ``KillTask`` excerpt for a tool without a cap — so a large output is never
+# inlined whole into the transcript.
+_DEFAULT_INLINE_CAP = 8000
+
+
+def _make_outcome_note(
+    *,
+    task_id: str,
+    tool_name: str,
+    tool_call_id: str,
+    failed: bool,
+    interrupted: bool = False,
     result: str | None = None,
     error: str | None = None,
     log_path: str | None = None,
     elapsed_s: float | None = None,
 ) -> str:
     """Build an XML-tagged task notification for LLM consumption."""
+    status = "interrupted" if interrupted else "failed" if failed else "completed"
+    subject = f"Task {status}"
+
     parts = [
         "<task_notification>",
-        f"<task_id>{task_id}</task_id>",
-        f"<tool_name>{tool_name}</tool_name>",
-        f"<status>{status}</status>",
+        f"<subject> {subject} </subject>",
+        f"<task_id> {task_id} </task_id>",
+        f"<tool_name> {tool_name} </tool_name>",
+        f"<tool_call_id> {tool_call_id} </tool_call_id>",
+        f"<status> {status} </status>",
     ]
+
     if elapsed_s is not None:
-        parts.append(f"<ran_for>{_fmt_duration(elapsed_s)}</ran_for>")
+        parts.append(f"<ran_for> {_fmt_duration(elapsed_s)} </ran_for>")
+
     if result is not None:
         parts.append(f"<result>\n{result}\n</result>")
+
     if error is not None:
         parts.append(f"<error>\n{error}\n</error>")
+
     if log_path is not None:
-        parts.append(f"<output_file>\n{log_path}\n</output_file>")
+        parts.append(f"<log_file>\n{log_path}\n</log_file>")
+
     parts.append("</task_notification>")
 
     return "\n".join(parts)
 
 
-@dataclass
-class BackgroundTask:
-    """
-    A backgrounded unit of work — kind-agnostic.
+def _task_record_to_input_message(
+    record: TaskRecord, *, failed: bool
+) -> InputMessageItem:
+    """A task's completion note rebuilt from its durable record."""
+    raw = record.error if failed else record.result
+    body: str | None = None
+    if raw is not None:
+        body, _ = excerpt_for_inline(
+            raw, _DEFAULT_INLINE_CAP, log_file=record.output_path
+        )
 
-    The manager drives ``tool.run_stream`` in ``task`` and appends every event
-    to ``events`` (the buffer). ``cursor`` tracks how far :meth:`drain` has
-    consumed that buffer at the turn boundary — in one pass it re-emits each new
-    event to the parent stream (live progress) and mirrors stream text to the
-    on-disk progress log. ``task_key`` is set only for a *resumable* tool (its
-    ``TaskRecord`` is persisted so a restart can re-spawn it); a backgrounded
-    shell command is not resumable, so it has none.
-    """
+    return InputMessageItem.from_text(
+        _make_outcome_note(
+            task_id=record.task_id,
+            tool_name=record.tool_name,
+            tool_call_id=record.tool_call_id,
+            failed=failed,
+            result=None if failed else body,
+            error=body if failed else None,
+            log_path=record.output_path,
+        ),
+        role="user",
+    )
 
-    task_id: str
-    tool_name: str
-    exec_id: str
-    task: asyncio.Task[None]
-    events: list[Event[Any]] = field(default_factory=list[Event[Any]])
-    # Monotonic per-agent launch sequence number (mirrored on the durable
-    # ``TaskRecord``). Watermarks record its high-water value; a transcript
-    # rewind cancels tasks above the watermark — their launching calls are
-    # no longer in the history the model sees.
-    launch_seq: int = 0
-    # Whether this task's result gates the final answer (it is part of the
-    # answer). Read from ``tool.blocks_final_answer`` at launch — independent of
-    # how the task was backgrounded (immediate vs deadline).
-    blocks_final_answer: bool = True
-    # Cap on inlined result chars in the completion note (``tool``'s setting); a
-    # larger result is excerpted, with the note pointing at the on-disk log.
-    max_inline_result_chars: int | None = None
-    tool_call_id: str | None = None
-    task_key: str | None = None
-    cursor: int = 0  # events consumed by drain (bubbled to parent + flushed to log)
-    delivered: bool = False  # completion note reached the transcript
-    started_at: float = field(default_factory=time.monotonic)  # for live elapsed
-    log_path: str | None = None  # resolved .grasp/tasks log file, once written
-    log_bytes: int = 0  # bytes appended to the log so far (for the size cap)
+
+# --- Task record persistence ---
+
+# Validate a restored flip map (a raw dict off a persisted head) back into its
+# typed shape.
+_delivered_map_adapter: TypeAdapter[dict[str, TaskDeliveredFlip]] = TypeAdapter(
+    dict[str, TaskDeliveredFlip]
+)
+_cancelled_map_adapter: TypeAdapter[dict[str, TaskCancelledFlip]] = TypeAdapter(
+    dict[str, TaskCancelledFlip]
+)
+
+
+def _serialize_result(result: Any) -> str:
+    """
+    Serialize a task result the way the foreground transcript does
+    (``FunctionToolOutputItem.from_tool_result``): a string passes through
+    verbatim (no spurious quotes), anything else is JSON via ``to_jsonable_python``
+    so a pydantic result renders as data, not a Python ``repr`` (which would leak
+    ``<Enum.X: 'x'>``-style values into the model's completion note).
+    """
+    if isinstance(result, str):
+        return result
+    return json.dumps(to_jsonable_python(result), indent=2)
+
+
+async def _save_record_update(
+    store: CheckpointStore, task_key: str, **updates: Any
+) -> None:
+    """
+    Load → apply ``updates`` (stamping ``updated_at``) → save a ``TaskRecord``.
+    A no-op when no record exists at ``task_key``.
+    """
+    existing = await store.load(task_key)
+    if not existing:
+        return
+    record = TaskRecord.model_validate_json(existing)
+    record = record.model_copy(update={**updates, "updated_at": datetime.now(UTC)})
+    await store.save(task_key, record.model_dump_json().encode())
+
+
+async def _save_record_outcome(
+    store: CheckpointStore,
+    task_key: str,
+    result: Any | None = None,
+    error: ToolErrorInfo | None = None,
+) -> None:
+    if error is not None:
+        await _save_record_update(
+            store, task_key, status=TaskStatus.FAILED, error=_serialize_result(error)
+        )
+    else:
+        await _save_record_update(
+            store,
+            task_key,
+            status=TaskStatus.COMPLETED,
+            result=_serialize_result(result),
+        )
+
+
+# --- Task event stream utilities ---
+
+
+def _stream_text(events: list[Event[Any]]) -> str:
+    """Concatenated incremental output text across ``events`` (rendered via str)."""
+    return "".join(str(e.data) for e in events if isinstance(e, ToolStreamEvent))
+
+
+def _outcome_from_events(
+    events: list[Event[Any]],
+) -> tuple[Any | None, ToolErrorInfo | None]:
+    """The task's terminal result and whether it failed (last writer wins)."""
+    result: Any = None
+    error: ToolErrorInfo | None = None
+
+    for event in events:
+        if isinstance(event, ToolErrorEvent):
+            error = event.data
+        elif isinstance(event, ToolOutputEvent):
+            result = event.data
+
+    return result, error
 
 
 async def _consume(
@@ -177,20 +404,22 @@ async def _consume(
     :meth:`resume_durable`), instead of a ``RUNNING`` record that would force a
     re-run or lose the outcome.
     """
-    result: Any = None
-    failed = False
+    result: Any | None = None
+    error: ToolErrorInfo | None = None
+
     try:
         async for event in stream:
             events.append(event)
             if isinstance(event, ToolOutputEvent):
                 result = event.data
             elif isinstance(event, ToolErrorEvent):
-                result = event.data
-                failed = True
+                error = event.data
+
     except asyncio.CancelledError:
         # A genuine interruption (KillTask / shutdown / process death): leave the
         # record RUNNING so a later resume can re-spawn or report the task.
         raise
+
     except Exception as exc:
         # The task errored (e.g. a sub-agent that could not resume). Record it as
         # a clean failure: don't leak a dangling task exception, and don't leave
@@ -198,102 +427,88 @@ async def _consume(
         logger.warning("Background task errored: %r", exc)
         err = ToolErrorEvent(data=ToolErrorInfo(tool_name="", error=f"{exc}"))
         events.append(err)
-        result = err.data
-        failed = True
+        error = err.data
 
     if store is not None and task_key is not None:
-        await _persist_outcome(store, task_key, result, failed=failed)
+        await _save_record_outcome(store, task_key, result=result, error=error)
 
 
-async def _save_record_update(
-    store: CheckpointStore, task_key: str, **updates: Any
-) -> None:
+@dataclass
+class BackgroundTask:
     """
-    Load → apply ``updates`` (stamping ``updated_at``) → save a ``TaskRecord``.
-    A no-op when no record exists at ``task_key``.
+    A backgrounded unit of work — kind-agnostic.
+
+    The manager drives ``tool.run_stream`` in ``consumer`` and appends every
+    event to ``events`` (the buffer). ``cursor`` tracks how far :meth:`drain` has
+    consumed that buffer at the turn boundary — in one pass it re-emits each new
+    event to the parent stream (live progress) and mirrors stream text to the
+    on-disk progress log. ``task_key`` is set only for a *resumable* tool (its
+    ``TaskRecord`` is persisted so a restart can re-spawn it); a backgrounded
+    shell command is not resumable, so it has none.
     """
-    existing = await store.load(task_key)
-    if not existing:
-        return
-    record = TaskRecord.model_validate_json(existing)
-    record = record.model_copy(update={**updates, "updated_at": datetime.now(UTC)})
-    await store.save(task_key, record.model_dump_json().encode())
+
+    task_id: str
+    tool_name: str
+    tool_call_id: str
+    exec_id: str
+
+    consumer: asyncio.Task[None]
+    events: list[Event[Any]] = field(default_factory=list[Event[Any]])
+
+    # Monotonic per-agent launch sequence number (mirrored on the durable
+    # ``TaskRecord``). Watermarks record its high-water value; a transcript
+    # rewind cancels tasks above the watermark — their launching calls are
+    # no longer in the history the model sees.
+    launch_seq: int = 0
+
+    # Whether this task's result gates the final answer (it is part of the
+    # answer). Read from ``tool.blocks_final_answer`` at launch — independent of
+    # how the task was backgrounded (immediate vs deadline).
+    blocks_final_answer: bool = True
+
+    # Cap on inlined result chars in the completion note (``tool``'s setting); a
+    # larger result is excerpted, with the note pointing at the on-disk log.
+    max_inline_result_chars: int | None = None
+
+    task_key: str | None = None
+    cursor: int = 0  # events consumed by drain (bubbled to parent + flushed to log)
+    delivered: bool = False  # completion note reached the transcript
+
+    log_path: str | None = None  # resolved .grasp/tasks log file, once written
+    log_bytes: int = 0  # bytes appended to the log so far (for the size cap)
+
+    started_at: float = field(default_factory=time.monotonic)  # for live elapsed
+
+    def trim_consumed(self) -> None:
+        """Drop drained (bubbled + flushed) leading events; keep results."""
+        keep_from = self.cursor
+        for i in range(keep_from):
+            if isinstance(self.events[i], ToolErrorEvent | ToolOutputEvent):
+                keep_from = i  # never drop a terminal result event
+                break
+        if keep_from <= 0:
+            return
+        del self.events[:keep_from]
+        self.cursor -= keep_from
 
 
-async def _persist_outcome(
-    store: CheckpointStore, task_key: str, result: Any, *, failed: bool
-) -> None:
-    """Flip an existing ``TaskRecord`` to its terminal outcome (no-op if absent)."""
-    if failed:
-        await _save_record_update(
-            store, task_key, status=TaskStatus.FAILED, error=_serialize_result(result)
-        )
-    else:
-        await _save_record_update(
-            store,
-            task_key,
-            status=TaskStatus.COMPLETED,
-            result=_serialize_result(result),
-        )
+class KillTaskResult(BaseModel):
+    """
+    What ``KillTask`` returns for a stopped background task.
 
+    ``status`` is ``cancelled`` when the task was still running and ``KillTask``
+    stopped it (the common case), or ``completed`` / ``failed`` when it had
+    already reached that terminal state before the kill arrived. ``output`` is
+    an excerpt of the text the task produced (the full output is in its
+    ``.grasp`` log); ``result`` is the tool's own terminal output (e.g. a
+    ``BashResult``) when it had finished, else ``None``.
+    """
 
-def _result_of(events: list[Event[Any]]) -> tuple[Any, bool]:
-    """The task's terminal result and whether it failed (last writer wins)."""
+    task_id: str
+    tool_name: str
+    status: Literal["cancelled", "completed", "failed"]
+    output: str = ""
     result: Any = None
-    failed = False
-    for event in events:
-        if isinstance(event, ToolErrorEvent):
-            result = event.data
-            failed = True
-        elif isinstance(event, ToolOutputEvent):
-            result = event.data
-    return result, failed
-
-
-def _stream_text(events: list[Event[Any]]) -> str:
-    """Concatenated incremental output text across ``events`` (rendered via str)."""
-    return "".join(str(e.data) for e in events if isinstance(e, ToolStreamEvent))
-
-
-def _serialize_result(result: Any) -> str:
-    """
-    Serialize a task result the way the foreground transcript does
-    (``FunctionToolOutputItem.from_tool_result``): a string passes through
-    verbatim (no spurious quotes), anything else is JSON via ``to_jsonable_python``
-    so a pydantic result renders as data, not a Python ``repr`` (which would leak
-    ``<Enum.X: 'x'>``-style values into the model's completion note).
-    """
-    if isinstance(result, str):
-        return result
-    return json.dumps(to_jsonable_python(result), indent=2)
-
-
-# Cap on inlined chars when a completion note is REBUILT from a durable record
-# (resume re-injection / rollback re-delivery). The tool's own
-# ``max_inline_result_chars`` is not persisted, so a conservative default
-# keeps a large stored result from being inlined whole into the transcript.
-_REINJECT_INLINE_CAP = 8000
-
-
-def _record_note(record: TaskRecord, *, failed: bool) -> InputMessageItem:
-    """A task's completion note rebuilt from its durable record."""
-    raw = record.error if failed else record.result
-    body: str | None = None
-    if raw is not None:
-        body, _ = excerpt_for_inline(
-            raw, _REINJECT_INLINE_CAP, output_file=record.output_path
-        )
-    return InputMessageItem.from_text(
-        _task_notification(
-            task_id=record.task_id,
-            tool_name=record.tool_name,
-            status="failed" if failed else "completed",
-            result=None if failed else body,
-            error=body if failed else None,
-            log_path=record.output_path,
-        ),
-        role="user",
-    )
 
 
 class BackgroundTaskManager[CtxT]:
@@ -329,10 +544,13 @@ class BackgroundTaskManager[CtxT]:
         max_task_log_bytes: int = MAX_TASK_LOG_BYTES,
     ) -> None:
         self._agent_name = agent_name
+
         self._transcript = transcript
         self._tools = tools
         self._tasks: dict[str, BackgroundTask] = {}
+
         self._bg_counter = 0
+
         self._max_background = max_background
         self._max_task_log_bytes = max_task_log_bytes
 
@@ -341,17 +559,18 @@ class BackgroundTaskManager[CtxT]:
         # :meth:`wait_idle` blocks on the next one — one queue, every task kind.
         self._completions: asyncio.Queue[str] = asyncio.Queue()
 
-        # Deferred record updates (task_key → field update), applied by
-        # :meth:`flush_delivered` once a checkpoint has persisted the
+        # Deferred DELIVERED flips (task_key → field update), applied by
+        # :meth:`flush_flips` once a checkpoint has persisted the
         # transcript that carries the corresponding notification.
-        self._deferred_delivered: dict[str, dict[str, Any]] = {}
+        self._deferred_delivered: dict[str, TaskDeliveredFlip] = {}
 
-        # Deferred CANCELLED flips for tasks killed by
-        # :meth:`cancel_launched_after`, also applied by :meth:`flush_delivered`.
+        # Deferred CANCELLED flips for tasks cancelled by
+        # :meth:`cancel_launched_after`, also applied by :meth:`flush_flips`.
         # Kept apart from ``_deferred_delivered`` because a watermark restore
-        # wholesale-replaces that map — a kill must survive it (the killed
-        # launch is gone from the transcript no matter which boundary is live).
-        self._deferred_killed: dict[str, dict[str, Any]] = {}
+        # wholesale-replaces that map — a cancellation must survive it (the
+        # cancelled launch is gone from the transcript no matter which boundary
+        # is live).
+        self._deferred_cancelled: dict[str, TaskCancelledFlip] = {}
 
         self.path = path
 
@@ -364,7 +583,7 @@ class BackgroundTaskManager[CtxT]:
         released only by :meth:`cancel_all` (via ``LLMAgent.aclose``) or
         ``KillTask``.
         """
-        return any(not bt.task.done() for bt in self._tasks.values())
+        return any(not bt.consumer.done() for bt in self._tasks.values())
 
     @property
     def has_blocking_tasks(self) -> bool:
@@ -372,7 +591,10 @@ class BackgroundTaskManager[CtxT]:
         True while any *answer-blocking* background task is undelivered.
 
         Consulted by the JUDGE phase: such a task's result is part of the
-        answer, so it gates even a final answer. Non-blocking tasks (e.g. a
+        answer, so it gates a bounded run's final answer — ending the run
+        early would leave no loop for the result to be delivered to. It does
+        not gate a resident's answer: the resident loop outlives it and
+        receives the completion on wake. Non-blocking tasks (e.g. a
         backgrounded shell command) are excluded — they must never hold the run
         hostage. A task stops blocking once its completion note is delivered
         (``delivered``).
@@ -393,29 +615,141 @@ class BackgroundTaskManager[CtxT]:
         """
         return not self._completions.empty()
 
-    async def wait_idle(self, timeout: float | None = None) -> None:  # noqa: ASYNC109
-        """
-        Block until the next tracked task completes — the loop's idle wait.
+    def _check_capacity(self) -> None:
+        if len(self._tasks) >= self._max_background:
+            raise RuntimeError(
+                f"Too many background tasks ({self._max_background}); kill or "
+                "drain existing ones first."
+            )
 
-        Returns immediately if a completion is already queued, or if every
-        tracked task has delivered (so the loop never blocks with no work
-        outstanding). The awaited
-        id is requeued so :meth:`drain` still delivers it. ``timeout`` bounds the
-        wait (the caller passes the remaining run-deadline budget) so an idle
-        wait on a task that never completes cannot sail past ``run_timeout`` — on
-        expiry it returns and the loop's next deadline check stops the run.
+    def _task_store_key(self, ctx: SessionContext[CtxT], call_id: str) -> str | None:
+        """Store key for a backgrounded call's ``TaskRecord`` (``None`` if none)."""
+        child_path = make_tool_call_path(self.path, call_id)
+        if ctx.checkpoint_store is None or child_path is None:
+            return None
+        return make_store_key(ctx.session_key, CheckpointKind.TASK, child_path)
+
+    async def _resolve_log(
+        self,
+        name: str,
+        tool: BaseTool[BaseModel, Any, CtxT],
+        *,
+        ctx: SessionContext[CtxT],
+    ) -> str | None:
+        if not tool.has_progress_log or ctx.file_backend is None:
+            return None
+        return await open_task_log(ctx.file_backend, name=name)
+
+    def _next_id(self) -> tuple[str, int]:
+        """Mint a task id and its ``launch_seq`` (the id's numeric suffix)."""
+        self._bg_counter += 1
+        return f"bg_{self._bg_counter}", self._bg_counter
+
+    @property
+    def last_launch_seq(self) -> int:
+        """High-water launch seq: every launch so far has ``launch_seq <=`` this."""
+        return self._bg_counter
+
+    def seed_launch_seq(self, seq: int) -> None:
         """
-        if not self._completions.empty():
-            return
-        if all(bt.delivered for bt in self._tasks.values()):
-            return
-        try:
-            task_id = await asyncio.wait_for(self._completions.get(), timeout)
-        except TimeoutError:
-            return
-        self._completions.put_nowait(task_id)
+        Seed the launch counter from a restored watermark.
+
+        Never lowers it: after a rewind the cancelled launches' seqs stay
+        burned, so a re-run's fresh launches can't be mistaken for them.
+        """
+        self._bg_counter = max(self._bg_counter, seq)
+
+    def _reserve_task_id(self, task_id: str) -> None:
+        """
+        Advance the id counter past an existing task's id.
+
+        A re-spawned task keeps its original id (e.g. ``bg_2``); the resumed
+        manager's counter, however, restarts at zero. Without this, a *new* tool
+        call in the same resumed run would be assigned a colliding ``bg_N``,
+        overwriting the re-spawned task in ``_tasks`` and crossing their result
+        deliveries (the re-spawned task's real result is persisted to its record
+        but never delivered; the new call's result is delivered under its id).
+        """
+        _, _, suffix = task_id.rpartition("_")
+        if suffix.isdigit():
+            self._bg_counter = max(self._bg_counter, int(suffix))
+
+    def _register(
+        self,
+        *,
+        task_id: str,
+        tool_call_id: str,
+        launch_seq: int,
+        consumer: asyncio.Task[None],
+        events: list[Event[Any]],
+        tool: BaseTool[BaseModel, Any, CtxT],
+        exec_id: str,
+        task_key: str | None,
+        started_at: float,
+        log_path: str | None = None,
+    ) -> None:
+        """
+        Track a backgrounded task and enqueue its id when it ends.
+
+        Builds the ``BackgroundTask`` from the tool — ``blocks_final_answer`` /
+        ``max_inline_result_chars`` come from it, so both backgrounding modes and
+        a resume re-spawn are tracked identically — and wires the done-callback
+        that feeds the single completion queue. ``started_at`` is the task's
+        launch stamp (for live elapsed); ``log_path`` its resolved ``.grasp`` log
+        (``None`` for a tool without one).
+        """
+        bt = BackgroundTask(
+            task_id=task_id,
+            launch_seq=launch_seq,
+            tool_name=tool.name,
+            exec_id=exec_id,
+            tool_call_id=tool_call_id,
+            consumer=consumer,
+            events=events,
+            blocks_final_answer=tool.blocks_final_answer,
+            max_inline_result_chars=tool.max_inline_result_chars,
+            task_key=task_key,
+            started_at=started_at,
+            log_path=log_path,
+        )
+        self._tasks[task_id] = bt
+        consumer.add_done_callback(
+            lambda _, tid=task_id: self._completions.put_nowait(tid)
+        )
 
     # --- Launch ---
+
+    async def _write_running_record(
+        self,
+        task_key: str,
+        call: FunctionToolCallItem,
+        task_id: str,
+        *,
+        launch_seq: int,
+        ctx: SessionContext[CtxT],
+        log_path: str | None = None,
+    ) -> None:
+        """
+        Persist a RUNNING ``TaskRecord`` so a restart can surface this task.
+
+        ``log_path`` is the task's ``.grasp`` log — resolved up front for a
+        tool with ``has_progress_log`` so the record carries it in a single
+        write; ``None`` for a tool with no log.
+        """
+        store = ctx.checkpoint_store
+        if store is None:
+            return
+        record = TaskRecord(
+            session_key=ctx.session_key,
+            task_id=task_id,
+            launch_seq=launch_seq,
+            tool_call_id=call.call_id,
+            tool_name=call.name,
+            tool_call_arguments=call.arguments,
+            status=TaskStatus.RUNNING,
+            output_path=log_path,
+        )
+        await store.save(task_key, record.model_dump_json().encode())
 
     async def run_backgroundable(
         self,
@@ -464,12 +798,15 @@ class BackgroundTaskManager[CtxT]:
                 self._check_capacity()
             except RuntimeError as exc:
                 return f"Tool '{tool.name}' could not be backgrounded: {exc}", None
+
             task_id, launch_seq = self._next_id()
             log_path = await self._resolve_log(call.call_id, tool, ctx=ctx)
+
             # Persist the RUNNING record *before* starting the task so a
             # near-instant finish still updates an existing record, and wire
             # outcome persistence into ``_consume`` (resumable tools rely on it
             # for a result that lands between drains).
+
             if task_key is not None:
                 await self._write_running_record(
                     task_key,
@@ -477,33 +814,50 @@ class BackgroundTaskManager[CtxT]:
                     task_id,
                     launch_seq=launch_seq,
                     ctx=ctx,
-                    output_path=log_path,
+                    log_path=log_path,
                 )
+
+            # Create and register the task
+
             stream = tool.run_stream(
                 inp, ctx=ctx, exec_id=exec_id, path=child_path, agent_ctx=agent_ctx
             )
             started_at = time.monotonic()
-            task = asyncio.create_task(
+            consumer = asyncio.create_task(
                 _consume(stream, events, store=ctx.checkpoint_store, task_key=task_key)
             )
             self._register(
-                task_id=task_id,
-                launch_seq=launch_seq,
-                task=task,
+                consumer=consumer,
                 events=events,
+                task_id=task_id,
+                tool_call_id=call.call_id,
+                launch_seq=launch_seq,
                 tool=tool,
                 exec_id=exec_id,
-                tool_call_id=call.call_id,
                 task_key=task_key,
                 started_at=started_at,
                 log_path=log_path,
             )
-            note = self._launch_note(
-                tool, task_id, backgrounded_after=None, log_path=log_path
+
+            # Make a launch note for the agent
+
+            launch_note = _make_launch_note(
+                task_id=task_id,
+                tool_name=tool.name,
+                tool_call_id=call.call_id,
+                backgrounded_after=None,
+                log_path=log_path,
             )
-            return note, self._make_launched_event(
-                task_id, tool.name, call.call_id, log_path=log_path, exec_id=exec_id
+            launch_event = _make_launch_event(
+                agent_name=self._agent_name,
+                task_id=task_id,
+                tool_name=tool.name,
+                tool_call_id=call.call_id,
+                log_path=log_path,
+                exec_id=exec_id,
             )
+
+            return launch_note, launch_event
 
         # abg > 0: run in the foreground, racing the deadline. ``started_at`` is
         # stamped at launch (not at sideline), so a backgrounded task's reported
@@ -511,40 +865,47 @@ class BackgroundTaskManager[CtxT]:
         # key up front: if the call backgrounds, its eventual finish must flip
         # the RUNNING record to COMPLETED/FAILED (a foreground finish writes
         # nothing — no record exists yet).
+
         stream = tool.run_stream(
             inp, ctx=ctx, exec_id=exec_id, path=child_path, agent_ctx=agent_ctx
         )
         started_at = time.monotonic()
-        task = asyncio.create_task(
+        consumer = asyncio.create_task(
             _consume(stream, events, store=ctx.checkpoint_store, task_key=task_key)
         )
+
         try:
-            await asyncio.wait_for(asyncio.shield(task), timeout=abg)
+            await asyncio.wait_for(asyncio.shield(consumer), timeout=abg)
         except TimeoutError:
             try:
                 self._check_capacity()
             except RuntimeError as exc:
-                task.cancel()
+                consumer.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
-                    await task
+                    await consumer
                 return f"Tool '{tool.name}' could not be backgrounded: {exc}", None
+
             task_id, launch_seq = self._next_id()
-            # Resolve the log once, up front, so the single record write
-            # already carries ``output_path`` and the note can cite the file the
-            # loop will have flushed output to by the model's next turn.
             log_path = await self._resolve_log(call.call_id, tool, ctx=ctx)
+
             self._register(
-                task_id=task_id,
-                launch_seq=launch_seq,
-                task=task,
+                consumer=consumer,
                 events=events,
+                task_id=task_id,
+                tool_call_id=call.call_id,
+                launch_seq=launch_seq,
                 tool=tool,
                 exec_id=exec_id,
-                tool_call_id=call.call_id,
                 task_key=task_key,
                 started_at=started_at,
                 log_path=log_path,
             )
+
+            # Unlike the immediate mode, the record cannot be written before
+            # the task starts: whether this call backgrounds at all is known
+            # only once it outlives the deadline, and a foreground finish must
+            # leave no record (resume would re-inject an outcome the model
+            # already saw inline).
             if task_key is not None:
                 await self._write_running_record(
                     task_key,
@@ -552,275 +913,70 @@ class BackgroundTaskManager[CtxT]:
                     task_id,
                     launch_seq=launch_seq,
                     ctx=ctx,
-                    output_path=log_path,
+                    log_path=log_path,
                 )
-                if task.done() and ctx.checkpoint_store is not None:
+                if consumer.done() and ctx.checkpoint_store is not None:
                     # The call finished while the RUNNING record was being
                     # written — ``_consume``'s own outcome write found no
                     # record to update, so persist the outcome here.
-                    result, failed = _result_of(events)
-                    await _persist_outcome(
-                        ctx.checkpoint_store, task_key, result, failed=failed
+                    result, error = _outcome_from_events(events)
+                    await _save_record_outcome(
+                        ctx.checkpoint_store, task_key, result=result, error=error
                     )
-            note = self._launch_note(
-                tool, task_id, backgrounded_after=abg, log_path=log_path
+
+            launch_note = _make_launch_note(
+                task_id=task_id,
+                tool_name=tool.name,
+                tool_call_id=call.call_id,
+                backgrounded_after=abg,
+                log_path=log_path,
             )
-            return note, self._make_launched_event(
-                task_id, tool.name, call.call_id, log_path=log_path, exec_id=exec_id
+            launch_event = _make_launch_event(
+                agent_name=self._agent_name,
+                task_id=task_id,
+                tool_name=tool.name,
+                tool_call_id=call.call_id,
+                log_path=log_path,
+                exec_id=exec_id,
             )
+
+            return launch_note, launch_event
+
         except asyncio.CancelledError:
-            task.cancel()
+            consumer.cancel()
             with contextlib.suppress(asyncio.CancelledError):
-                await task
+                await consumer
             raise
 
-        result, _ = _result_of(events)
+        # The call finished in the foreground
 
-        return result, None
+        result, error = _outcome_from_events(events)
 
-    def _launch_note(
-        self,
-        tool: BaseTool[BaseModel, Any, CtxT],
-        task_id: str,
-        *,
-        backgrounded_after: float | None,
-        log_path: str | None,
-    ) -> str:
+        return error or result, None
+
+    async def wait_idle(self, timeout: float | None = None) -> None:  # noqa: ASYNC109
         """
-        Build the launch note returned as the immediate tool result.
+        Block until the next tracked task completes — the loop's idle wait.
 
-        ``backgrounded_after`` is the deadline a positive-``auto_background_at``
-        call outlived (``None`` for an immediate background); it shapes only the
-        opening clause. The rest — result-on-completion, the optional log pointer
-        (present iff the tool has a ``.grasp`` log), and the ``KillTask`` hint —
-        is identical, so the note encodes only *how* the call backgrounded, never
-        the task's kind.
+        Returns immediately if a completion is already queued, or if every
+        tracked task has delivered (so the loop never blocks with no work
+        outstanding). The awaited
+        id is requeued so :meth:`drain` still delivers it. ``timeout`` bounds the
+        wait (the caller passes the remaining run-deadline budget) so an idle
+        wait on a task that never completes cannot sail past ``run_timeout`` — on
+        expiry it returns and the loop's next deadline check stops the run.
         """
-        parts: list[str] = []
-
-        if backgrounded_after is None:
-            opening = f"Task '{tool.name}' launched in the background (id: {task_id})."
-        else:
-            opening = (
-                f"Tool '{tool.name}' is still running after {backgrounded_after:g}s "
-                f"and was moved to the background (id: {task_id})."
-            )
-        parts.append(opening)
-
-        waiting_guidance = (
-            "You will receive a <task_notification> when it finishes — "
-            "until then, assume it is still running and do NOT call it again. "
-            "You can continue with other work. "
-            "If the only thing left to do is wait for background tasks, "
-            "report immediately that you are waiting for the task(s) to finish "
-            "WITHOUT calling any tools."
-        )
-        parts.append(waiting_guidance)
-
-        if log_path is not None:
-            output_guidance = (
-                f"Its output is streaming to {log_path} — Read or Grep that file "
-                "to check progress so far (it is partial until the task "
-                "finishes, and a read's own exit code reflects the read, not "
-                "the task)."
-            )
-            parts.append(output_guidance)
-
-        kill_guidance = (
-            "Stop it with KillTask if you no longer need it "
-            "or the user wants to cancel it."
-        )
-        parts.append(kill_guidance)
-
-        return "\n".join(parts)
-
-    def _next_id(self) -> tuple[str, int]:
-        """Mint a task id and its ``launch_seq`` (the id's numeric suffix)."""
-        self._bg_counter += 1
-        return f"bg_{self._bg_counter}", self._bg_counter
-
-    @property
-    def last_launch_seq(self) -> int:
-        """High-water launch seq: every launch so far has ``launch_seq <=`` this."""
-        return self._bg_counter
-
-    def seed_launch_seq(self, seq: int) -> None:
-        """
-        Seed the launch counter from a restored watermark.
-
-        Never lowers it: after a rewind the cancelled launches' seqs stay
-        burned, so a re-run's fresh launches can't be mistaken for them.
-        """
-        self._bg_counter = max(self._bg_counter, seq)
-
-    def _reserve_task_id(self, task_id: str) -> None:
-        """
-        Advance the id counter past an existing task's id.
-
-        A re-spawned task keeps its original id (e.g. ``bg_2``); the resumed
-        manager's counter, however, restarts at zero. Without this, a *new* tool
-        call in the same resumed run would be assigned a colliding ``bg_N``,
-        overwriting the re-spawned task in ``_tasks`` and crossing their result
-        deliveries (the re-spawned task's real result is persisted to its record
-        but never delivered; the new call's result is delivered under its id).
-        """
-        _, _, suffix = task_id.rpartition("_")
-        if suffix.isdigit():
-            self._bg_counter = max(self._bg_counter, int(suffix))
-
-    def _check_capacity(self) -> None:
-        """
-        Raise if the background-task ceiling is reached.
-
-        Applies to both backgrounding modes; the caller turns the failure into a
-        launch note rather than letting it abort the turn.
-        """
-        if len(self._tasks) >= self._max_background:
-            raise RuntimeError(
-                f"Too many background tasks ({self._max_background}); kill or "
-                "drain existing ones first."
-            )
-
-    def _register(
-        self,
-        *,
-        task_id: str,
-        launch_seq: int,
-        task: asyncio.Task[None],
-        events: list[Event[Any]],
-        tool: BaseTool[BaseModel, Any, CtxT],
-        exec_id: str,
-        tool_call_id: str | None,
-        task_key: str | None,
-        started_at: float,
-        log_path: str | None = None,
-    ) -> None:
-        """
-        Track a backgrounded task and enqueue its id when it ends.
-
-        Builds the ``BackgroundTask`` from the tool — ``blocks_final_answer`` /
-        ``max_inline_result_chars`` come from it, so both backgrounding modes and
-        a resume re-spawn are tracked identically — and wires the done-callback
-        that feeds the single completion queue. ``started_at`` is the task's
-        launch stamp (for live elapsed); ``log_path`` its resolved ``.grasp`` log
-        (``None`` for a tool without one).
-        """
-        bt = BackgroundTask(
-            task_id=task_id,
-            launch_seq=launch_seq,
-            tool_name=tool.name,
-            exec_id=exec_id,
-            tool_call_id=tool_call_id,
-            task=task,
-            events=events,
-            blocks_final_answer=tool.blocks_final_answer,
-            max_inline_result_chars=tool.max_inline_result_chars,
-            task_key=task_key,
-            started_at=started_at,
-            log_path=log_path,
-        )
-        self._tasks[task_id] = bt
-        task.add_done_callback(lambda _, tid=task_id: self._completions.put_nowait(tid))
-
-    async def _resolve_log(
-        self,
-        name: str,
-        tool: BaseTool[BaseModel, Any, CtxT],
-        *,
-        ctx: SessionContext[CtxT],
-    ) -> str | None:
-        """
-        Resolve a backgrounded task's ``.grasp`` log path, or ``None``.
-
-        Gated on ``tool.has_progress_log``: only a tool that mirrors incremental
-        output to a log gets one resolved (eagerly, at background time, so the
-        record and launch note can cite it). A tool whose events are
-        structural — a sub-agent — has no log, independent of *how* it
-        backgrounded.
-        """
-        if not tool.has_progress_log or ctx.file_backend is None:
-            return None
-        return await open_task_log(ctx.file_backend, name=name)
-
-    def _make_launched_event(
-        self,
-        task_id: str,
-        tool_name: str,
-        call_id: str,
-        *,
-        log_path: str | None,
-        exec_id: str,
-    ) -> BackgroundTaskLaunchedEvent:
-        """
-        Build the launched event both backgrounding modes bubble.
-
-        ``output_name`` is surfaced only for a task that has a ``.grasp`` log
-        (``log_path`` set); a sub-agent without one advertises ``None``.
-        """
-        return BackgroundTaskLaunchedEvent(
-            source=self._agent_name,
-            exec_id=exec_id,
-            data=BackgroundTaskInfo(
-                task_id=task_id,
-                tool_name=tool_name,
-                tool_call_id=call_id,
-                output_name=task_log_name(call_id) if log_path else None,
-            ),
-        )
-
-    # --- TaskRecord persistence ---
-
-    def _task_store_key(self, ctx: SessionContext[CtxT], call_id: str) -> str | None:
-        """Store key for a backgrounded call's ``TaskRecord`` (``None`` if none)."""
-        child_path = make_tool_call_path(self.path, call_id)
-        if ctx.checkpoint_store is None or child_path is None:
-            return None
-        return make_store_key(ctx.session_key, CheckpointKind.TASK, child_path)
-
-    async def _write_running_record(
-        self,
-        task_key: str,
-        call: FunctionToolCallItem,
-        task_id: str,
-        *,
-        launch_seq: int,
-        ctx: SessionContext[CtxT],
-        output_path: str | None = None,
-    ) -> None:
-        """
-        Persist a RUNNING ``TaskRecord`` so a restart can surface this task.
-
-        ``output_path`` is the task's ``.grasp`` log — resolved up front for a
-        tool with ``has_progress_log`` so the record carries it in a single
-        write; ``None`` for a tool with no log.
-        """
-        store = ctx.checkpoint_store
-        if store is None:
+        if not self._completions.empty():
             return
-        record = TaskRecord(
-            session_key=ctx.session_key,
-            task_id=task_id,
-            launch_seq=launch_seq,
-            tool_call_id=call.call_id,
-            tool_name=call.name,
-            tool_call_arguments=call.arguments,
-            status=TaskStatus.RUNNING,
-            output_path=output_path,
-        )
-        await store.save(task_key, record.model_dump_json().encode())
-
-    async def _mark_record(
-        self,
-        task_key: str | None,
-        *,
-        ctx: SessionContext[CtxT] | None,
-        **updates: Any,
-    ) -> None:
-        """Load → update → save a ``TaskRecord`` (no-op if no store / key / record)."""
-        store = ctx.checkpoint_store if ctx else None
-        if store is None or task_key is None:
+        if all(bt.delivered for bt in self._tasks.values()):
             return
-        await _save_record_update(store, task_key, **updates)
+        try:
+            task_id = await asyncio.wait_for(self._completions.get(), timeout)
+        except TimeoutError:
+            return
+        self._completions.put_nowait(task_id)
+
+    # --- Turn-boundary drain ---
 
     async def _append_log(
         self, bt: BackgroundTask, text: str, backend: "FileBackend"
@@ -836,113 +992,17 @@ class BackgroundTaskManager[CtxT]:
         """
         if not text or bt.log_path is None or bt.log_bytes >= self._max_task_log_bytes:
             return
+
         chunk = text.encode()
         remaining = self._max_task_log_bytes - bt.log_bytes
+
         if len(chunk) > remaining:
             chunk = chunk[:remaining] + b"\n... [log truncated] ...\n"
             bt.log_bytes = self._max_task_log_bytes  # saturate → stop appending
         else:
             bt.log_bytes += len(chunk)
+
         await append_task_log(backend, bt.log_path, chunk)
-
-    def get(self, task_id: str) -> BackgroundTask:
-        bt = self._tasks.get(task_id)
-        if bt is None:
-            known = ", ".join(sorted(self._tasks)) or "none"
-            raise ValueError(
-                f"Unknown background task id {task_id!r} (known: {known})."
-            )
-        return bt
-
-    def remove(self, task_id: str) -> None:
-        self._tasks.pop(task_id, None)
-
-    # --- Stop (KillTask) ---
-
-    async def kill_task(
-        self, task_id: str, *, ctx: SessionContext[CtxT] | None = None
-    ) -> KillTaskResult:
-        """Cancel a task (its stream closes → process group killed) and read it."""
-        bt = self.get(task_id)
-        # Capture whether it had already finished *before* we cancel: a task
-        # still tracked here that is already done finished on its own, so the
-        # outcome is genuine; otherwise we are the ones stopping it.
-        already_done = bt.task.done()
-        if not already_done:
-            bt.task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await bt.task
-
-        result, failed = _result_of(bt.events)
-        # A head+tail excerpt of what it produced, so the model sees why it was
-        # killed without bloating the transcript; the full output is in the log.
-        output, _ = excerpt_for_inline(
-            _stream_text(bt.events),
-            bt.max_inline_result_chars or 8000,
-            output_file=bt.log_path,
-        )
-        status: Literal["cancelled", "completed", "failed"]
-        if failed:
-            status = "failed"
-        elif already_done:
-            status = "completed"
-        else:
-            status = "cancelled"
-        # Deliberately stopped → record is terminal, so a later resume does not
-        # report the killed task as interrupted.
-        await self._mark_record(
-            bt.task_key,
-            ctx=ctx,
-            status=TaskStatus.CANCELLED,
-            error="Stopped by KillTask",
-        )
-        self._tasks.pop(task_id, None)
-        return KillTaskResult(
-            task_id=task_id,
-            tool_name=bt.tool_name,
-            status=status,
-            output=output,
-            result=result,
-        )
-
-    def cancel_launched_after(self, seq: int) -> None:
-        """
-        Cancel every task with ``launch_seq > seq`` — synchronous and I/O-free.
-
-        Applied by :meth:`AgentContext.restore` whenever the transcript is
-        rewound past the tool calls that launched these tasks (a failed-run
-        settle or a step rollback; vacuous on a cold reload): their
-        launches are no longer in the history the model sees, so letting them
-        finish would inject completion notes for calls that never happened.
-        Cancelled tasks are dropped from tracking immediately, so a completion
-        already queued for :meth:`drain` is suppressed rather than delivered.
-        Tasks at or below ``seq`` keep running — their launches are still in
-        the kept transcript, and their notes deliver normally later.
-
-        Durable record flips (→ CANCELLED) are deferred to
-        :meth:`flush_delivered`, after the pruned transcript is durable; a
-        crash before that is covered by the resume-side orphan guard in
-        :meth:`resume_durable`.
-        """
-        for task_id, bt in list(self._tasks.items()):
-            if bt.launch_seq <= seq:
-                continue
-            if not bt.task.done():
-                bt.task.cancel()
-            del self._tasks[task_id]
-            if bt.task_key is not None:
-                self._deferred_delivered.pop(bt.task_key, None)
-                self._deferred_killed[bt.task_key] = {
-                    "status": TaskStatus.CANCELLED,
-                    "error": "Cancelled: the launching tool call was rolled back",
-                }
-            logger.info(
-                "Cancelled background task %s (%s): launched after the rewind point",
-                task_id,
-                bt.tool_name,
-            )
-
-    # --- Turn-boundary drain ---
 
     async def drain(
         self, *, exec_id: str, ctx: SessionContext[CtxT]
@@ -972,14 +1032,17 @@ class BackgroundTaskManager[CtxT]:
         # for a sub-agent; ``blocks_final_answer`` governs only the JUDGE gate)
         # and mirror this pass's stream text to its ``.grasp`` log in one append.
         backend = ctx.file_backend
+
         for bt in list(self._tasks.values()):
             start = bt.cursor
+
             while bt.cursor < len(bt.events):
                 event = bt.events[bt.cursor]
                 bt.cursor += 1
                 if isinstance(event, ToolStreamEvent) and event.source == bt.tool_name:
                     event = event.model_copy(update={"task_id": bt.task_id})
                 yield event
+
             if backend is not None and bt.cursor > start:
                 await self._append_log(
                     bt, _stream_text(bt.events[start : bt.cursor]), backend
@@ -991,28 +1054,28 @@ class BackgroundTaskManager[CtxT]:
             if bt is None or bt.delivered:
                 continue
 
-            result, failed = _result_of(bt.events)
-            status = "failed" if failed else "completed"
-            full = _serialize_result(result)
+            result, error = _outcome_from_events(bt.events)
+            failed = error is not None
+
+            full = _serialize_result(error) if failed else _serialize_result(result)
             cap = bt.max_inline_result_chars
 
-            result_file: str | None = None
+            log_file: str | None = None
             if cap is not None and len(full) > cap and ctx.file_backend is not None:
-                result_file = await write_result_file(
+                log_file = await write_result_file(
                     ctx.file_backend, name=bt.tool_call_id or bt.task_id, text=full
                 )
 
-            body, _ = excerpt_for_inline(
-                full, cap, output_file=result_file or bt.log_path
-            )
+            body, _ = excerpt_for_inline(full, cap, log_file=log_file or bt.log_path)
             note_result = None if failed else body
             note_error = body if failed else None
 
             notification = InputMessageItem.from_text(
-                _task_notification(
+                _make_outcome_note(
                     task_id=bt.task_id,
                     tool_name=bt.tool_name,
-                    status=status,
+                    tool_call_id=bt.tool_call_id,
+                    failed=failed,
                     result=note_result,
                     error=note_error,
                     log_path=bt.log_path,
@@ -1023,7 +1086,7 @@ class BackgroundTaskManager[CtxT]:
             self._transcript.update([notification])
 
             # Durable record → DELIVERED (resumable tasks only). Deferred to
-            # :meth:`flush_delivered` after the next checkpoint persists the
+            # :meth:`flush_flips` after the next checkpoint persists the
             # transcript holding this note: flipping now would lose the
             # outcome on a crash before that checkpoint (resume skips
             # DELIVERED records). The note's transcript position rides along —
@@ -1032,10 +1095,9 @@ class BackgroundTaskManager[CtxT]:
             # observability; reclaim with ``prune_delivered``.
             if ctx.checkpoint_store is not None and bt.task_key is not None:
                 self._deferred_delivered[bt.task_key] = {
-                    "status": TaskStatus.DELIVERED,
                     "result": None if failed else _serialize_result(result),
-                    "error": _serialize_result(result) if failed else None,
-                    "delivered_msg_count": len(self._transcript.messages),
+                    "error": _serialize_result(error) if failed else None,
+                    "note_transcript_pos": len(self._transcript.messages),
                 }
 
             yield BackgroundTaskCompletedEvent(
@@ -1044,7 +1106,7 @@ class BackgroundTaskManager[CtxT]:
                 data=BackgroundTaskInfo(
                     task_id=bt.task_id,
                     tool_name=bt.tool_name,
-                    tool_call_id=bt.tool_call_id or "",
+                    tool_call_id=bt.tool_call_id,
                 ),
             )
             yield UserMessageEvent(
@@ -1063,24 +1125,16 @@ class BackgroundTaskManager[CtxT]:
         # BOTH the bubble (parent stream) and flush (.grasp log) cursors are
         # durable elsewhere, so drop them to bound memory for a long, chatty
         # backgrounded command. Stops before any terminal result event so
-        # ``_result_of`` / ``kill_task`` still find it.
+        # ``_outcome_from_events`` / ``kill_task`` still find it.
         for bt in self._tasks.values():
-            self._trim_consumed(bt)
+            bt.trim_consumed()
 
-    @staticmethod
-    def _trim_consumed(bt: BackgroundTask) -> None:
-        """Drop drained (bubbled + flushed) leading events; keep results."""
-        keep_from = bt.cursor
-        for i in range(keep_from):
-            if isinstance(bt.events[i], ToolErrorEvent | ToolOutputEvent):
-                keep_from = i  # never drop a terminal result event
-                break
-        if keep_from <= 0:
-            return
-        del bt.events[:keep_from]
-        bt.cursor -= keep_from
-
-    # --- Cancel ---
+    # --- Cancellation / kill ---
+    #
+    # "Kill" is the model-facing surface only (the ``KillTask`` tool →
+    # :meth:`kill_task`): an explicit, targeted stop of one task. Every
+    # framework-initiated stop — session teardown, transcript rewind — and the
+    # terminal record status use "cancel(led)".
 
     async def cancel_all(self, ctx: SessionContext[CtxT] | None = None) -> None:
         """
@@ -1102,18 +1156,127 @@ class BackgroundTaskManager[CtxT]:
                     error="Cancelled: agent session closed",
                 )
 
-        tasks = [bt.task for bt in self._tasks.values()]
-        for t in tasks:
-            t.cancel()
-        if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
+        consumers = [bt.consumer for bt in self._tasks.values()]
+        for c in consumers:
+            c.cancel()
+        if consumers:
+            await asyncio.gather(*consumers, return_exceptions=True)
+
         self._tasks.clear()
+
         # Cancelled tasks' done-callbacks enqueue their ids; drop them so a
         # reused manager starts clean.
         while not self._completions.empty():
             self._completions.get_nowait()
 
-    # --- Session resume ---
+    async def kill_task(
+        self, task_id: str, *, ctx: SessionContext[CtxT] | None = None
+    ) -> KillTaskResult:
+        """Cancel a task (its stream closes → process group killed) and read it."""
+        bt = self._tasks.get(task_id)
+        if bt is None:
+            known = ", ".join(sorted(self._tasks)) or "none"
+            raise ValueError(
+                f"Unknown background task id {task_id!r} (known: {known})."
+            )
+
+        already_done = bt.consumer.done()
+        if not already_done:
+            bt.consumer.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await bt.consumer
+
+        result, error = _outcome_from_events(bt.events)
+
+        status_at_kill: Literal["cancelled", "completed", "failed"]
+        if error is not None:
+            status_at_kill = "failed"
+        elif already_done:
+            status_at_kill = "completed"
+        else:
+            status_at_kill = "cancelled"
+
+        # A head+tail excerpt of what it produced, so the model sees why it was
+        # killed without bloating the transcript; the full output is in the log.
+        output, _ = excerpt_for_inline(
+            _stream_text(bt.events),
+            bt.max_inline_result_chars or _DEFAULT_INLINE_CAP,
+            log_file=bt.log_path,
+        )
+
+        # Mark as terminal, so a later resume does not
+        # report the killed task as interrupted.
+
+        store = ctx.checkpoint_store if ctx else None
+        if store is not None and bt.task_key is not None:
+            await _save_record_update(
+                store,
+                bt.task_key,
+                status=TaskStatus.CANCELLED,
+                error="Stopped by KillTask",
+            )
+        self._tasks.pop(task_id, None)
+
+        return KillTaskResult(
+            task_id=task_id,
+            tool_name=bt.tool_name,
+            status=status_at_kill,
+            output=output,
+            result=result,
+        )
+
+    # --- Resume ---
+
+    def _try_respawn_child(
+        self,
+        record: TaskRecord,
+        *,
+        task_key: str,
+        ctx: SessionContext[CtxT] | None,
+        exec_id: str | None,
+        agent_ctx: "AgentContext | None" = None,
+    ) -> bool:
+        """Re-spawn a child task from its session checkpoint."""
+        if not ctx or not exec_id or not ctx.checkpoint_store:
+            return False
+
+        tool = self._tools.get(record.tool_name) if self._tools else None
+        if not tool or not tool.resumable:
+            return False
+
+        child_path = make_tool_call_path(self.path, record.tool_call_id)
+
+        events: list[Event[Any]] = []
+        stream = tool.resume_stream(
+            ctx=ctx,
+            exec_id=exec_id,
+            path=child_path,
+            agent_ctx=agent_ctx,
+            tool_call_arguments=record.tool_call_arguments,
+        )
+        consumer = asyncio.create_task(
+            _consume(stream, events, store=ctx.checkpoint_store, task_key=task_key)
+        )
+        self._register(
+            consumer=consumer,
+            events=events,
+            task_id=record.task_id,
+            tool_call_id=record.tool_call_id,
+            launch_seq=record.launch_seq,
+            tool=tool,
+            exec_id=exec_id,
+            task_key=task_key,
+            started_at=time.monotonic(),
+            log_path=record.output_path,
+        )
+        logger.info(
+            "Re-spawned child task %s (%s) at task key %s",
+            record.task_id,
+            record.tool_name,
+            task_key,
+        )
+
+        return True
 
     async def resume_durable(
         self,
@@ -1145,17 +1308,13 @@ class BackgroundTaskManager[CtxT]:
         if store is None or ctx is None:
             return []
 
-        # Scope to *this* manager's own background tasks. Records live at
-        # ``<session>/task/<path>/tc_<call_id>``; sibling agents and nested
-        # sub-agents own separate subtrees and resume via their own managers,
-        # so a session-wide scan would make us handle (and mis-route) their
-        # tasks. Keep only direct ``tc_*`` children — a deeper segment belongs
-        # to a nested sub-agent.
+        # Scope to this BG task manager
         prefix = make_store_key(ctx.session_key, CheckpointKind.TASK, self.path) + "/"
         keys = [k for k in await store.list_keys(prefix) if is_direct_child(k, prefix)]
 
         notifications: list[InputMessageItem] = []
         deferred_keys: list[str] = []
+
         for key in keys:
             record = await store.load_json(key, TaskRecord, subject="task record")
             if record is None:
@@ -1178,10 +1337,11 @@ class BackgroundTaskManager[CtxT]:
             if key in self._deferred_delivered:
                 continue
 
-            # A deferred kill restored with the head: the task was cancelled
-            # by a rewind whose CANCELLED flip a crash kept from flushing.
-            # Never re-spawn or report it; the flip lands at the next flush.
-            if key in self._deferred_killed:
+            # A deferred cancellation restored with the head: the task was
+            # cancelled by a rewind whose CANCELLED flip a crash kept from
+            # flushing. Never re-spawn or report it; the flip lands at the
+            # next flush.
+            if key in self._deferred_cancelled:
                 continue
 
             # Orphan guard: launched after the restored head's boundary, so its
@@ -1214,18 +1374,20 @@ class BackgroundTaskManager[CtxT]:
                     continue
 
                 elapsed = (record.updated_at - record.created_at).total_seconds()
+                partial_output = (
+                    "Any partial output it produced before stopping is in the log file."
+                    if record.output_path
+                    else "It has no output log."
+                )
+                error = f"The task was stopped before completing. {partial_output}"
                 notification = InputMessageItem.from_text(
-                    _task_notification(
+                    _make_outcome_note(
                         task_id=record.task_id,
                         tool_name=record.tool_name,
-                        status="interrupted",
-                        error=(
-                            "Task was stopped. "
-                            "Any partial output it produced before stopping is in the "
-                            "log below. Check the output and attempt to continue from "
-                            "where it left off whenever possible, or re-run from "
-                            "scratch if not."
-                        ),
+                        tool_call_id=record.tool_call_id,
+                        failed=False,
+                        interrupted=True,
+                        error=error,
                         log_path=record.output_path,
                         elapsed_s=elapsed,
                     ),
@@ -1233,21 +1395,24 @@ class BackgroundTaskManager[CtxT]:
                 )
                 # The interrupted notice was delivered → terminal (DELIVERED),
                 # not FAILED (which is an errored task, re-injected below).
-                update = {
-                    "status": TaskStatus.DELIVERED,
+                update: TaskDeliveredFlip = {
                     "error": "Interrupted: session restarted",
                 }
+
             elif record.status in {TaskStatus.COMPLETED, TaskStatus.FAILED}:
                 # Finished (ok or errored) but the crash kept ``drain`` from
-                # delivering it — re-inject the outcome, then mark it delivered.
-                notification = _record_note(
-                    record, failed=record.status == TaskStatus.FAILED
+                # delivering it — re-inject the outcome, then mark it delivered
+                # (the record already carries it, so the flip adds nothing).
+                notification = _task_record_to_input_message(
+                    record,
+                    failed=(record.status == TaskStatus.FAILED),
                 )
-                update = {"status": TaskStatus.DELIVERED}
+                update = {}
+
             else:
                 continue
 
-            # Deferred to ``flush_delivered`` (after the checkpoint that
+            # Deferred to ``flush_flips`` (after the checkpoint that
             # persists the notice) — same loss-window reasoning as ``drain``.
             self._deferred_delivered[key] = update
             deferred_keys.append(key)
@@ -1261,62 +1426,158 @@ class BackgroundTaskManager[CtxT]:
             # (Silently re-spawned resumable tasks add no notice and so don't
             # trigger a framing on their own.)
             framing = InputMessageItem.from_text(
-                "<session_resumed>\n"
-                "Resumed from a checkpoint: your conversation and task records "
-                "were restored from disk, but any in-flight work that was only "
-                "in memory is gone. The background tasks below were running "
-                "when the previous run stopped."
-                "\n</session_resumed>",
+                wrap_in_system_reminder(
+                    "Resumed from a checkpoint: your conversation and task "
+                    "records were restored from disk, but any in-flight work "
+                    "that was only in memory is gone. The background tasks "
+                    "below were running when the previous run stopped.",
+                    subject=SESSION_RESUMED_SUBJECT,
+                ),
                 role="user",
             )
+
             injected = [framing, *notifications]
             self._transcript.update(injected)
+
             # Stamp each re-injected note's transcript position on its
             # deferred flip (mirrors ``drain``): a later rollback truncating
             # below the note must know to re-inject it. The notices sit at
             # the tail of ``injected``, after the framing line.
             total = len(self._transcript.messages)
             for offset, key in enumerate(deferred_keys):
-                self._deferred_delivered[key]["delivered_msg_count"] = (
+                self._deferred_delivered[key]["note_transcript_pos"] = (
                     total - len(deferred_keys) + offset + 1
                 )
 
         logger.info(
             "Handled %d task records for session %s", len(keys), ctx.session_key
         )
+
         return injected
 
-    def export_deferred_delivered(self) -> dict[str, dict[str, Any]]:
-        """The deferred record updates not yet flushed (rollback snapshot)."""
-        return dict(self._deferred_delivered)
-
-    def restore_deferred_delivered(self, deferred: dict[str, dict[str, Any]]) -> None:
+    async def redeliver_after(
+        self,
+        *,
+        message_count: int,
+        task_launch_seq: int,
+        ctx: SessionContext[CtxT],
+        pre_restore_deferred_delivered: Mapping[str, Mapping[str, Any]],
+    ) -> list[InputMessageItem]:
         """
-        Restore a :meth:`export_deferred_delivered` snapshot: on a rollback the
-        deferred flips are discarded, so records whose notes were rolled back
-        stay COMPLETED for a later resume to re-inject. A failed-run settle
-        instead keeps the live flips for the notes it kept (see
-        ``AgentContext.restore``'s ``keep_deferred_delivered``).
-        """
-        self._deferred_delivered = dict(deferred)
+        The bg-task half of a step rollback, called after the transcript is
+        truncated to ``message_count``: a delivered record whose completion
+        note sat past the cut (``note_transcript_pos > message_count``) while
+        its launching call survived (``launch_seq <= task_launch_seq``) just
+        lost the only live copy of its outcome — the finished task is no
+        longer tracked in memory, and resume skips DELIVERED records, so
+        nothing else would ever re-surface it and the agent would wait on it
+        forever. Re-inject each such note at the rewind point and re-defer its
+        DELIVERED flip with the new position.
 
-    def export_deferred_killed(self) -> dict[str, dict[str, Any]]:
-        """The deferred CANCELLED flips not yet flushed."""
-        return dict(self._deferred_killed)
-
-    def restore_deferred_killed(self, killed: dict[str, dict[str, Any]]) -> None:
+        ``pre_restore_deferred_delivered`` overlays not-yet-flushed DELIVERED
+        flips onto the stored records: a drained-but-unflushed note (its
+        record still COMPLETED) sits in the truncated span exactly like a
+        flushed one's. It must be the map exported *before* the rollback's
+        context restore — the post-restore live map is never a substitute: it
+        holds the boundary's flips, whose positions all sit at or before the
+        cut. Records launched *after* the boundary are
+        ``cancel_launched_after``'s business — their launching calls are
+        gone, so their outcomes stay buried. Returns the injected messages
+        for the caller to surface as events.
         """
-        Merge a snapshot's deferred CANCELLED flips UNDER the live ones: a
-        kill is never discarded by a watermark restore (the killed launch is
-        gone from the transcript no matter which boundary is live), and a
-        cold resume re-arms kills whose flush a crash pre-empted — otherwise
-        the restored head's ``task_launch_seq`` (raised past the killed
-        launches before the flush) would defeat the resume orphan guard and
-        resurrect them.
-        """
-        self._deferred_killed = {**killed, **self._deferred_killed}
+        store = ctx.checkpoint_store
+        if store is None:
+            return []
 
-    async def flush_delivered(self, *, ctx: SessionContext[CtxT]) -> None:
+        deferred = _delivered_map_adapter.validate_python(
+            pre_restore_deferred_delivered
+        )
+
+        prefix = make_store_key(ctx.session_key, CheckpointKind.TASK, self.path) + "/"
+        keys = [k for k in await store.list_keys(prefix) if is_direct_child(k, prefix)]
+
+        matches: list[tuple[str, TaskRecord, int]] = []
+        for key in keys:
+            record = await store.load_json(key, TaskRecord, subject="task record")
+            if record is None or record.launch_seq > task_launch_seq:
+                continue
+
+            flip = deferred.get(key)
+            is_delivered = record.status is TaskStatus.DELIVERED or flip is not None
+            note_pos = record.note_transcript_pos
+            if flip is not None:
+                note_pos = flip.get("note_transcript_pos", note_pos)
+            if not is_delivered or note_pos is None or note_pos <= message_count:
+                continue
+
+            matches.append((key, record, note_pos))
+
+        # Original observation order: the positions the notes held before the
+        # truncation (completion order, which can differ from launch order).
+        matches.sort(key=operator.itemgetter(2))
+
+        injected: list[InputMessageItem] = []
+        for key, record, _note_pos in matches:
+            is_fail = record.result is None and record.error is not None
+            notification = _task_record_to_input_message(record, failed=is_fail)
+
+            self._transcript.update([notification])
+            self._deferred_delivered[key] = {
+                "note_transcript_pos": len(self._transcript.messages),
+            }
+
+            injected.append(notification)
+
+            logger.info(
+                "Re-injected background task %s (%s): its completion note was "
+                "truncated by a rollback",
+                record.task_id,
+                record.tool_name,
+            )
+        return injected
+
+    def cancel_launched_after(self, task_launch_seq: int) -> None:
+        """
+        Cancel every task with ``seq > task_launch_seq`` — synchronous and I/O-free.
+
+        Applied by :meth:`AgentContext.restore` whenever the transcript is
+        rewound past the tool calls that launched these tasks (a failed-run
+        settle or a step rollback; vacuous on a cold reload): their
+        launches are no longer in the history the model sees, so letting them
+        finish would inject completion notes for calls that never happened.
+        Cancelled tasks are dropped from tracking immediately, so a completion
+        already queued for :meth:`drain` is suppressed rather than delivered.
+        Tasks at or below ``task_launch_seq`` keep running — their launches are still in
+        the kept transcript, and their notes deliver normally later.
+
+        Durable record flips (→ CANCELLED) are deferred to
+        :meth:`flush_flips`, after the pruned transcript is durable; a
+        crash before that is covered by the resume-side orphan guard in
+        :meth:`resume_durable`.
+        """
+        for task_id, bt in list(self._tasks.items()):
+            if bt.launch_seq <= task_launch_seq:
+                continue
+
+            if not bt.consumer.done():
+                bt.consumer.cancel()
+
+            del self._tasks[task_id]
+
+            if bt.task_key is not None:
+                self._deferred_delivered.pop(bt.task_key, None)
+                self._deferred_cancelled[bt.task_key] = {
+                    "error": "Cancelled: the launching tool call was rolled back",
+                }
+            logger.info(
+                "Cancelled background task %s (%s): launched after the rewind point",
+                task_id,
+                bt.tool_name,
+            )
+
+    # --- Deferred record flips (DELIVERED / CANCELLED) ---
+
+    async def flush_flips(self, *, ctx: SessionContext[CtxT]) -> None:
         """
         Apply deferred terminal record updates (→ ``DELIVERED`` / ``CANCELLED``).
 
@@ -1327,98 +1588,62 @@ class BackgroundTaskManager[CtxT]:
         so resume would never re-inject the outcome. (A crash between the
         checkpoint and this flush yields at worst a re-injected note — a
         duplicate beats a lost outcome.) The same holds for a
-        :meth:`cancel_launched_after` kill: its CANCELLED flip waits until the
-        transcript no longer referencing the launch is durable, so a crash in
-        between resumes with the launch still on record.
+        :meth:`cancel_launched_after` cancellation: its CANCELLED flip waits
+        until the transcript no longer referencing the launch is durable, so a
+        crash in between resumes with the launch still on record.
         """
         store = ctx.checkpoint_store
-        if store is None or not (self._deferred_delivered or self._deferred_killed):
+        if store is None or not (self._deferred_delivered or self._deferred_cancelled):
             return
-        # A kill wins over a delivery flip for the same record: the kill came
-        # later, when the delivered note was rolled back. Each entry is
-        # dropped only once applied, so a store error mid-flush keeps the
-        # rest deferred for the next flush instead of losing them (a re-apply
-        # is idempotent — updates are absolute field sets).
-        deferred = {**self._deferred_delivered, **self._deferred_killed}
-        for key, update in deferred.items():
-            await _save_record_update(store, key, **update)
-            self._deferred_delivered.pop(key, None)
-            self._deferred_killed.pop(key, None)
 
-    async def redeliver_after(
-        self,
-        *,
-        message_count: int,
-        task_launch_seq: int,
-        ctx: SessionContext[CtxT],
-        deferred_delivered: Mapping[str, dict[str, Any]] | None = None,
-    ) -> list[InputMessageItem]:
+        # The status is implied by the map an entry sits in. A cancellation
+        # wins over a delivery flip for the same record: it came later, when
+        # the delivered note was rolled back. Each entry is dropped only once
+        # applied, so a store error mid-flush keeps the rest deferred for the
+        # next flush instead of losing them (a re-apply is idempotent —
+        # updates are absolute field sets).
+        for key, update in list(self._deferred_delivered.items()):
+            if key not in self._deferred_cancelled:
+                await _save_record_update(
+                    store, key, status=TaskStatus.DELIVERED, **update
+                )
+            del self._deferred_delivered[key]
+
+        for key, flip in list(self._deferred_cancelled.items()):
+            await _save_record_update(store, key, status=TaskStatus.CANCELLED, **flip)
+            del self._deferred_cancelled[key]
+
+    def export_deferred_delivered(self) -> dict[str, dict[str, Any]]:
+        """The deferred record updates not yet flushed (rollback snapshot)."""
+        return {k: dict(v) for k, v in self._deferred_delivered.items()}
+
+    def restore_deferred_delivered(
+        self, deferred: Mapping[str, Mapping[str, Any]]
+    ) -> None:
         """
-        The bg-task half of a step rollback, called after the transcript is
-        truncated to ``message_count``: a delivered record whose completion
-        note sat past the cut (``delivered_msg_count > message_count``) while
-        its launching call survived (``launch_seq <= task_launch_seq``) just
-        lost the only live copy of its outcome — the finished task is no
-        longer tracked in memory, and resume skips DELIVERED records, so
-        nothing else would ever re-surface it and the agent would wait on it
-        forever. Re-inject each such note at the rewind point and re-defer its
-        DELIVERED flip with the new position.
-
-        ``deferred_delivered`` overlays not-yet-flushed DELIVERED flips onto
-        the stored records: a drained-but-unflushed note (its record still
-        COMPLETED) sits in the truncated span exactly like a flushed one's.
-        The caller passes the map exported *before* the rollback's context
-        restore replaced it. Records launched *after* the boundary are
-        ``cancel_launched_after``'s business — their launching calls are
-        gone, so their outcomes stay buried. Returns the injected messages
-        for the caller to surface as events.
+        Restore a :meth:`export_deferred_delivered` snapshot, replacing the
+        live map. The caller keeps a live flip by merging it into the snapshot
+        first — ``AgentContext.restore`` does so exactly for the flips whose
+        notes survived its transcript surgery, so a rolled-back note's record
+        stays COMPLETED for a later re-injection.
         """
-        store = ctx.checkpoint_store
-        if store is None:
-            return []
-        deferred = (
-            dict(self._deferred_delivered)
-            if deferred_delivered is None
-            else deferred_delivered
-        )
-        prefix = make_store_key(ctx.session_key, CheckpointKind.TASK, self.path) + "/"
-        keys = [k for k in await store.list_keys(prefix) if is_direct_child(k, prefix)]
+        self._deferred_delivered = _delivered_map_adapter.validate_python(deferred)
 
-        matches: list[tuple[str, TaskRecord, int]] = []
-        for key in keys:
-            record = await store.load_json(key, TaskRecord, subject="task record")
-            if record is None or record.launch_seq > task_launch_seq:
-                continue
-            flip = deferred.get(key, {})
-            is_delivered = (
-                record.status is TaskStatus.DELIVERED
-                or flip.get("status") is TaskStatus.DELIVERED
-            )
-            count = flip.get("delivered_msg_count", record.delivered_msg_count)
-            if not is_delivered or count is None or count <= message_count:
-                continue
-            matches.append((key, record, count))
-        # Original observation order: the positions the notes held before the
-        # truncation (completion order, which can differ from launch order).
-        matches.sort(key=operator.itemgetter(2))
+    def export_deferred_cancelled(self) -> dict[str, dict[str, Any]]:
+        """The deferred CANCELLED flips not yet flushed."""
+        return {k: dict(v) for k, v in self._deferred_cancelled.items()}
 
-        injected: list[InputMessageItem] = []
-        for key, record, _count in matches:
-            is_fail = record.result is None and record.error is not None
-            notification = _record_note(record, failed=is_fail)
-            self._transcript.update([notification])
-            self._deferred_delivered[key] = {
-                "status": TaskStatus.DELIVERED,
-                "delivered_msg_count": len(self._transcript.messages),
-            }
-            injected.append(notification)
-            logger.info(
-                "Re-injected background task %s (%s): its completion note was "
-                "truncated by a rollback",
-                record.task_id,
-                record.tool_name,
-            )
-        return injected
+    def restore_deferred_cancelled(
+        self, cancelled: Mapping[str, Mapping[str, Any]]
+    ) -> None:
+        """
+        Restore an :meth:`export_deferred_cancelled` snapshot, replacing the
+        live map. As with the delivered flips, the caller keeps live entries
+        by merging them into the snapshot first — ``AgentContext.restore``
+        keeps ALL of them (a cancellation is a physical fact no transcript
+        boundary falsifies; the keep-rules for both maps live there).
+        """
+        self._deferred_cancelled = _cancelled_map_adapter.validate_python(cancelled)
 
     # --- Offline cleanup ---
 
@@ -1456,56 +1681,5 @@ class BackgroundTaskManager[CtxT]:
             if record.status == TaskStatus.DELIVERED and record.updated_at < cutoff:
                 await store.delete(key)
                 pruned += 1
+
         return pruned
-
-    def _try_respawn_child(
-        self,
-        record: TaskRecord,
-        *,
-        task_key: str,
-        ctx: SessionContext[CtxT] | None,
-        exec_id: str | None,
-        agent_ctx: "AgentContext | None" = None,
-    ) -> bool:
-        """Re-spawn a child task from its session checkpoint."""
-        if not ctx or not exec_id or not ctx.checkpoint_store:
-            return False
-
-        tool = self._tools.get(record.tool_name) if self._tools else None
-        if not tool or not tool.resumable:
-            return False
-
-        child_path = make_tool_call_path(self.path, record.tool_call_id)
-
-        events: list[Event[Any]] = []
-        stream = tool.resume_stream(
-            ctx=ctx,
-            exec_id=exec_id,
-            path=child_path,
-            agent_ctx=agent_ctx,
-            tool_call_arguments=record.tool_call_arguments,
-        )
-        async_task = asyncio.create_task(
-            _consume(stream, events, store=ctx.checkpoint_store, task_key=task_key)
-        )
-
-        self._register(
-            task_id=record.task_id,
-            launch_seq=record.launch_seq,
-            task=async_task,
-            events=events,
-            tool=tool,
-            exec_id=exec_id,
-            tool_call_id=record.tool_call_id,
-            task_key=task_key,
-            started_at=time.monotonic(),
-            log_path=record.output_path,
-        )
-
-        logger.info(
-            "Re-spawned child task %s (%s) at task key %s",
-            record.task_id,
-            record.tool_name,
-            task_key,
-        )
-        return True

--- a/src/grasp_agents/agent/llm_agent.py
+++ b/src/grasp_agents/agent/llm_agent.py
@@ -67,6 +67,7 @@ from grasp_agents.types.errors import ProcInputValidationError
 from grasp_agents.types.events import (
     Event,
     ProcPayloadOutEvent,
+    StopReason,
     SystemMessageEvent,
     UserMessageEvent,
 )
@@ -80,6 +81,7 @@ from grasp_agents.utils.validation import validate_obj_from_json_or_py_string
 
 from .agent_context import AgentContext
 from .agent_loop import AgentLoop
+from .background_tasks import make_background_tasks_section
 from .context_window import ContextWindowManager
 from .llm_agent_transcript import LLMAgentTranscript
 from .tool_decision import ToolCallDecision
@@ -351,6 +353,12 @@ class LLMAgent[InT, OutT, CtxT](
             )
         if enable_skills:
             self._prompt_builder.add_system_prompt_section(make_skills_section())
+
+        # Always registered: the compute reads the toolset live off the call's
+        # agent_ctx and renders nothing while no backgroundable tool is
+        # attached, so tools wired after construction (e.g. by a team) are
+        # picked up at the next run entry.
+        self._prompt_builder.add_system_prompt_section(make_background_tasks_section())
 
         if mcp_clients:
             from grasp_agents.mcp.section import (  # noqa: PLC0415
@@ -651,7 +659,7 @@ class LLMAgent[InT, OutT, CtxT](
 
         transport = self._ctx.transport
         inbox = self._agent_ctx.inbox
-        if inbox is None or inbox.transport is not transport:
+        if inbox is None or not inbox.is_view_of(transport):
             # A resident's human turns are rollback anchors: the boundary is
             # archived at the inbox take, before the message is stamped or
             # appended, so a rollback to it voids the message itself.
@@ -854,7 +862,6 @@ class LLMAgent[InT, OutT, CtxT](
 
         return location in {
             AgentCheckpointLocation.AFTER_FINAL_ANSWER,
-            AgentCheckpointLocation.AFTER_FORCED_FINAL_ANSWER,
             AgentCheckpointLocation.AFTER_RESIDENT_ANSWER,
         }
 
@@ -864,6 +871,7 @@ class LLMAgent[InT, OutT, CtxT](
         turn: int = 0,
         output: str | None = None,
         location: AgentCheckpointLocation = AgentCheckpointLocation.AFTER_INPUT,
+        stop_reason: StopReason | None = None,
     ) -> None:
         """Persist current conversation state to the store."""
         # Snapshot the filesystem first so the ref describes it as of this
@@ -912,6 +920,7 @@ class LLMAgent[InT, OutT, CtxT](
             folds=list(self._cw.folds),
             output=output,
             location=location,
+            stop_reason=stop_reason,
         )
         await self._serialize_agent_checkpoint(self._ctx, checkpoint)
 
@@ -921,7 +930,7 @@ class LLMAgent[InT, OutT, CtxT](
         # The persisted transcript now contains any delivered background-task
         # notes — only now is it safe to flip their durable records to
         # DELIVERED.
-        await self._agent_ctx.bg_tasks.flush_delivered(ctx=self._ctx)
+        await self._agent_ctx.bg_tasks.flush_flips(ctx=self._ctx)
 
         # Same persist covers a resident's drained inbox message: ack it now
         # (the inbox analog of the bg-task flush) so a crash before the
@@ -948,10 +957,10 @@ class LLMAgent[InT, OutT, CtxT](
         if pruned.removed_count and self._committed is not None:
             state = self._committed.agent_ctx_state
             # Settling prunes only the trailing response round, never a
-            # delivered completion note (a user-role message before it) — the
-            # kept transcript still holds every unflushed DELIVERED flip's
-            # note, so the flips must survive the boundary restore.
-            self._agent_ctx.restore(state, keep_deferred_delivered=True)
+            # delivered completion note (a user-role message before it) — so
+            # the restore's position rule keeps every unflushed DELIVERED
+            # flip.
+            self._agent_ctx.restore(state)
 
         # An in-flight inbox message stays LEASED: the settle keeps its user
         # turn (settling never prunes user messages), so the transcript still
@@ -1015,43 +1024,30 @@ class LLMAgent[InT, OutT, CtxT](
     async def rollback_to_step(self, step: int) -> None:
         """
         Rewind the session to the start of ``step``, discarding it and every
-        later step.
+        later step — the inverse of stepped delivery (``run(..., step=...)``).
+        Truncates the transcript and its durable log to ``step``'s boundary
+        and reapplies the state captured there; afterwards the agent is
+        parked at ``step`` with a ``ROLLED_BACK`` head, so ``run(step=step)``
+        is a fresh delivery, not a cached one.
 
-        The inverse of stepped delivery (``run(..., step=...)``): truncates the
-        transcript and its durable message-log back to ``step``'s boundary,
-        resets the turn counter and cached output, and reapplies the run state
-        captured at that boundary.
-        Afterwards ``self.step`` is ``step`` (parked at its start) and the
-        persisted head is tagged ``ROLLED_BACK``, so ``run(step=step)`` is a
-        fresh delivery rather than a cached re-delivery.
+        A boundary carrying an ``fs_snapshot_ref`` also restores the
+        *session-shared* filesystem (crash-safe via
+        :meth:`SessionContext.restore_fs_snapshot`); a subagent's boundary
+        carries none, so its rollback leaves the shared filesystem — and the
+        kernels living in it — untouched. A resident's mail consumed after
+        the boundary (the anchoring human message included) is voided, never
+        re-delivered: the human supplies new input, dropped peers get a
+        resend note, never-consumed messages stay pending.
 
-        The filesystem (``ctx.environment``) is *session-shared*, so restoring
-        it is a global side effect — meaningful only for the agent that owns
-        the environment (the coordinator) — and goes through
-        :meth:`SessionContext.restore_fs_snapshot`, which re-points the
-        session checkpoint at the restored ref so a crash mid-rollback never
-        cold-resumes into the pre-rollback filesystem. A subagent's boundary
-        carries no ``fs_snapshot_ref``, so rolling one back rewinds its own
-        transcript, turn, and agent context but leaves the shared filesystem
-        (and, since kernel state lives in it, the kernels) untouched.
-
-        A resident's mailbox rewinds with it: messages consumed after the
-        boundary — the anchoring human message included — are voided, never
-        re-delivered (a rollback rewrites history; the human supplies new
-        input, and peers whose messages were dropped are notified so they can
-        resend). Messages never consumed stay pending. Only valid *between
-        runs*: rewinding
-        under a live loop would race the turn cycle, so a mid-run call is
-        refused — cancel or finish the run first.
+        Only valid between runs — a mid-run call is refused.
 
         Raises:
-            KeyError: ``step`` has no recorded boundary — it never started, or
-                an earlier rollback already discarded it.
-            RuntimeError: the agent is mid-run; or a snapshot ref recorded at
-                the boundary must be restored but ``ctx.environment`` is not
-                ``SnapshotCapable``; or another agent holds the session's
-                environment-rewind right
-                (see :meth:`SessionContext.claim_session_writer`).
+            KeyError: no recorded boundary for ``step`` (never started, or
+                discarded by an earlier rollback).
+            RuntimeError: mid-run; or the boundary's snapshot ref needs a
+                ``SnapshotCapable`` environment; or another agent holds the
+                session's environment-rewind right
+                (:meth:`SessionContext.claim_session_writer`).
 
         """
         if self._run_active:
@@ -1114,39 +1110,36 @@ class LLMAgent[InT, OutT, CtxT](
         if fs_ref is not None:
             await self._ctx.restore_fs_snapshot(fs_ref, claimant=self.name)
 
-        self.transcript.messages = self.transcript.messages[: boundary.message_count]
-        self._loop.turn = boundary.turn
-        # Exported before the restore replaces it: a drained-but-unflushed
-        # note's deferred flip is the only trace that the note (now truncated)
-        # was delivered — ``redeliver_after`` overlays it onto the records.
-        deferred_flips = self._agent_ctx.bg_tasks.export_deferred_delivered()
-        self._agent_ctx.restore(
-            boundary.agent_ctx_state, rebind_kernels=fs_ref is not None
-        )
-        # A completion note delivered after the boundary for a task launched
-        # before it was just truncated away while its durable record stays
-        # DELIVERED (resume skips it): re-inject it at the rewind point and
-        # queue it for the next run to stream. Orphan launches past the
-        # boundary were already cancelled by the restore.
+        # Cut the transcript and reconcile the side channels (task-note
+        # re-injection, mail voiding) — :meth:`AgentContext.rewind`. Reads the
+        # pre-rollback ``_committed`` mail high-water, so it must run before
+        # ``boundary`` becomes the head.
         self._resume_notifications.extend(
-            await self._agent_ctx.bg_tasks.redeliver_after(
+            await self._agent_ctx.rewind(
+                boundary.agent_ctx_state,
                 message_count=boundary.message_count,
-                task_launch_seq=boundary.agent_ctx_state.task_launch_seq,
+                committed_mail_seq=(
+                    self._committed.agent_ctx_state.mail_consumption_seq
+                    if self._committed is not None
+                    else 0
+                ),
                 ctx=self._ctx,
-                deferred_delivered=deferred_flips,
+                rebind_kernels=fs_ref is not None,
             )
         )
-        await self._rollback_mailbox(boundary)
+        self._loop.turn = boundary.turn
         self._committed = boundary
         self._cw.reset_anchor()
 
         # Parked at the start of ``step``, ready to (re)deliver it.
         self._step = step
+
         # The step's anchor boundary was just destroyed — invalidate the memo
         # so the human's next (replacement) message re-mints and
         # re-archives it (a memo hit would skip the mint after a pure-resume
         # entry cleared ``_step``, leaving the head unstepped).
         self._anchored_message_id = None
+
         self.prompt_cache_key = boundary.prompt_cache_key
 
         # Drop the rewound step's boundary and every later one — the boundary
@@ -1161,10 +1154,12 @@ class LLMAgent[InT, OutT, CtxT](
         self._cw.drop_folds_after(boundary.message_count)
 
         await self._persist_rollback(boundary, step=step)
+
         # The rolled-back head no longer references the cancelled tasks'
         # launches — safe to flip their records now rather than waiting for
         # the next loop save.
-        await self._agent_ctx.bg_tasks.flush_delivered(ctx=self._ctx)
+        await self._agent_ctx.bg_tasks.flush_flips(ctx=self._ctx)
+
         logger.info(
             "agent '%s' rolled back to step %d (messages=%d, turn=%d)",
             self.name,
@@ -1172,42 +1167,6 @@ class LLMAgent[InT, OutT, CtxT](
             boundary.message_count,
             boundary.turn,
         )
-
-    async def _rollback_mailbox(self, boundary: StepWatermark) -> None:
-        """
-        The mailbox half of a rollback: messages consumed after ``boundary``
-        are VOIDED, never re-delivered — a rollback rewrites history, so the
-        human supplies new input instead of a replay (their dropped messages
-        are discarded silently), while peers whose messages were dropped get
-        a note so they can resend what is still relevant. Messages never
-        consumed stay pending; leased (un-acked) takes are acked-and-voided.
-        Leases are in-memory, so a crash mid-rollback degrades them to crash
-        semantics: the re-driven rollback in a fresh process finds them still
-        pending and they are re-delivered rather than voided. Reads the
-        pre-rollback ``_committed`` high-water, so it must run before
-        ``boundary`` becomes the head.
-        """
-        inbox = self._agent_ctx.inbox
-        leased = inbox.drop_leases() if inbox is not None else []
-
-        mailbox_hw = boundary.agent_ctx_state.mail_consumption_seq
-        committed_hw = (
-            self._committed.agent_ctx_state.mail_consumption_seq
-            if self._committed is not None
-            else 0
-        )
-        if committed_hw <= mailbox_hw and not leased:
-            # No mail was absorbed past the boundary — nothing to void.
-            return
-
-        from grasp_agents.mailbox import void_mail_after  # noqa: PLC0415
-
-        transport = self._ctx.transport
-        # Seed the counter: a cold rollback's fresh transport starts at zero,
-        # and later takes must not re-mint seqs held by voided records
-        # (max-only, so a live transport is unaffected).
-        transport.seed_consumption_seq(self.name, committed_hw)
-        await void_mail_after(transport, self.name, mailbox_hw, leased=leased)
 
     async def _persist_rollback(self, boundary: StepWatermark, *, step: int) -> None:
         """

--- a/src/grasp_agents/agent/loop_state.py
+++ b/src/grasp_agents/agent/loop_state.py
@@ -48,11 +48,11 @@ class NextStepRunTools:
 
 
 @dataclass(frozen=True, slots=True)
-class NextStepResidentReply:
+class NextStepResidentAnswer:
     """
-    Non-terminal: a resident actor (open inbox) produced its reply to the current
+    Non-terminal: a resident actor (open inbox) produced its answer to the current
     inbox message — the resident analog of :class:`NextStepStop`, which would end
-    a lone agent's run. The handler persists the turn (a resident reply otherwise
+    a lone agent's run. The handler persists the turn (a resident answer otherwise
     never checkpoints, so the answer would be re-generated on resume); the loop
     then parks for the next message.
     """
@@ -61,7 +61,7 @@ class NextStepResidentReply:
 
 
 @dataclass(frozen=True, slots=True)
-class NextStepForceResidentReply:
+class NextStepForceResidentAnswer:
     """
     Non-terminal: a resident actor burned its per-message turn budget without
     producing an answer it can return — the resident analog of
@@ -85,8 +85,8 @@ type NextStep = (
     NextStepStop
     | NextStepForceFinalAnswer
     | NextStepRunTools
-    | NextStepResidentReply
-    | NextStepForceResidentReply
+    | NextStepResidentAnswer
+    | NextStepForceResidentAnswer
     | NextStepContinue
 )
 
@@ -116,17 +116,28 @@ def decide_next_step(
     was delivered) is capped at ``max_turns`` rather than the lifetime ``turn``,
     which grows unbounded across messages. A resident never stops or force-ends
     its run; instead, finishing a message recycles the loop to wait for the next
-    one. A satisfied answer becomes a ``NextStepResidentReply``; blowing the
-    per-message budget without one becomes a ``NextStepForceResidentReply`` (force
+    one. A satisfied answer becomes a ``NextStepResidentAnswer``; blowing the
+    per-message budget without one becomes a ``NextStepForceResidentAnswer`` (force
     an answer, then move on) — so a model stuck in a tool loop on one message
-    cannot spin forever.
+    cannot spin forever. A resident also never waits on answer-blocking
+    background work: its loop outlives the answer, so a pending completion
+    wakes the parked loop and is delivered as a new turn.
     """
     # A resident's budget is per message; a lone agent's is the whole run.
     budget_turn = turns_on_message if inbox_open else turn
     over_budget = budget_turn >= max_turns
 
-    # A blown deadline or an exhausted budget overrides waiting on background work.
-    wait_for_bg = blocking_bg_tasks and not over_budget and not deadline_exceeded
+    # Only a bounded run waits on answer-blocking background work: its answer
+    # ends the run, leaving no loop for a pending result to be delivered to. A
+    # resident's loop survives its answer, so it answers now and receives the
+    # completion on wake. A blown deadline or an exhausted budget overrides
+    # the wait.
+    wait_for_bg = (
+        blocking_bg_tasks
+        and not inbox_open
+        and not over_budget
+        and not deadline_exceeded
+    )
 
     if final_answer is not None and not wait_for_bg and not inbox_open:
         return NextStepStop(final_answer=final_answer)
@@ -137,16 +148,16 @@ def decide_next_step(
     if over_budget and not inbox_open:
         return NextStepForceFinalAnswer()
 
-    # The resident's reply for this message, if it has one it can return now.
-    resident_answer = final_answer if (inbox_open and not wait_for_bg) else None
+    # The resident's answer for this message, if it has one it can return now.
+    resident_answer = final_answer if inbox_open else None
 
     if over_budget and inbox_open:
         # Resident past its per-message budget: wrap this message up now —
-        # never run more tools or continue. Reply with the answer if there is
+        # never run more tools or continue. Answer with the one it has if there is
         # one, else force one (closing dangling tool calls), then park.
         if resident_answer is not None:
-            return NextStepResidentReply(final_answer=resident_answer)
-        return NextStepForceResidentReply()
+            return NextStepResidentAnswer(final_answer=resident_answer)
+        return NextStepForceResidentAnswer()
 
     if tool_calls:
         return NextStepRunTools(tool_calls=tool_calls)
@@ -157,6 +168,6 @@ def decide_next_step(
         # ending the run. Checked after tool_calls so a turn that both answers and
         # calls tools still runs the tools first (matching a resident's prior
         # behavior); reasoning turns (no final answer) fall through to Continue.
-        return NextStepResidentReply(final_answer=resident_answer)
+        return NextStepResidentAnswer(final_answer=resident_answer)
 
     return NextStepContinue()

--- a/src/grasp_agents/agent/task_progress.py
+++ b/src/grasp_agents/agent/task_progress.py
@@ -93,11 +93,12 @@ async def write_result_file(
     except Exception:
         logger.warning("Could not write result file for %r", name)
         return None
+
     return path
 
 
 def excerpt_for_inline(
-    text: str, cap: int | None, *, output_file: str | None = None
+    text: str, cap: int | None, *, log_file: str | None = None
 ) -> tuple[str, bool]:
     """
     Fit a result into the limited inline space (a transcript message or a
@@ -105,7 +106,7 @@ def excerpt_for_inline(
 
     Returns ``text`` unchanged when no cap applies or it already fits. Otherwise
     keeps a head + tail of ``cap`` chars total with a middle marker; when an
-    ``output_file`` is known (a spilled result or a task's ``.grasp`` log), the
+    ``log_file`` is known (a spilled result or a task's ``.grasp`` log), the
     marker points there so the model can ``Read`` / ``Grep`` the full output on
     demand rather than bloating the transcript with it.
     """
@@ -114,8 +115,9 @@ def excerpt_for_inline(
     head = cap // 2
     tail = cap - head
     omitted = len(text) - cap
-    pointer = f" — full output in {output_file}" if output_file else ""
+    pointer = f" — full output in {log_file}" if log_file else ""
     marker = f"\n... [{omitted} chars omitted{pointer}] ...\n"
+
     return text[:head] + marker + text[-tail:], True
 
 
@@ -140,5 +142,5 @@ async def spill_if_large(
     )
     if output_file is None:
         return text
-    excerpt, _ = excerpt_for_inline(text, cap, output_file=output_file)
+    excerpt, _ = excerpt_for_inline(text, cap, log_file=output_file)
     return excerpt

--- a/src/grasp_agents/context/system_reminder.py
+++ b/src/grasp_agents/context/system_reminder.py
@@ -7,7 +7,16 @@ summaries produced by context compaction — so special messages are identified 
 one consistent tag rather than ad-hoc phrasing.
 """
 
+import re
+
 SYSTEM_REMINDER_TAG = "system-reminder"
+
+# Well-known subject of the resume framing note injected by
+# ``BackgroundTaskManager.resume_durable`` — shared with the UIs that render
+# it specially, so producer and detector cannot drift.
+SESSION_RESUMED_SUBJECT = "session resumed"
+
+_SUBJECT_RE = re.compile(rf'^<{SYSTEM_REMINDER_TAG} subject="(?P<subject>[^"]*)">')
 
 
 def wrap_in_system_reminder(text: str, *, subject: str | None = None) -> str:
@@ -17,3 +26,14 @@ def wrap_in_system_reminder(text: str, *, subject: str | None = None) -> str:
     """
     attr = f' subject="{subject}"' if subject else ""
     return f"<{SYSTEM_REMINDER_TAG}{attr}>\n{text}\n</{SYSTEM_REMINDER_TAG}>"
+
+
+def match_system_reminder_subject(text: str) -> str | None:
+    """
+    The ``subject`` attribute if ``text`` is a subject-tagged
+    ``<system-reminder>`` message, else ``None`` — the inverse of
+    :func:`wrap_in_system_reminder`, for a UI telling framework notices apart
+    from raw user input.
+    """
+    match = _SUBJECT_RE.match(text.lstrip())
+    return match.group("subject") if match else None

--- a/src/grasp_agents/durability/checkpoints.py
+++ b/src/grasp_agents/durability/checkpoints.py
@@ -5,13 +5,13 @@ from typing import Any, Self
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from grasp_agents.durability.context_serialization import ContextKind
-from grasp_agents.types.events import ProcPacketOutEvent, RunPacketOutEvent
+from grasp_agents.types.events import ProcPacketOutEvent, RunPacketOutEvent, StopReason
 from grasp_agents.types.folds import FoldSpec
 from grasp_agents.types.items import InputItem
 from grasp_agents.types.packet import Packet
 from grasp_agents.types.response import ResponseUsage
 
-CURRENT_SCHEMA_VERSION: int = 14
+CURRENT_SCHEMA_VERSION: int = 15
 """
 Version of the persisted checkpoint / task-record schema.
 
@@ -148,6 +148,22 @@ SCHEMA_VERSION_SUMMARIES: dict[int, str] = {
         "or resave the session); v13 code resuming a v14 session skips the "
         "new guards."
     ),
+    15: (
+        "AgentCheckpoint gained ``stop_reason`` — how the run that saved this "
+        "head ended (final_answer, max_turns, or timeout); None on mid-run, "
+        "resident, and rollback heads. "
+        "AgentCheckpointLocation.AFTER_FORCED_FINAL_ANSWER was collapsed into "
+        "AFTER_FINAL_ANSWER: location now names only the loop save-point, and "
+        "forced-ness moved to stop_reason. "
+        "TaskRecord.delivered_msg_count was renamed to "
+        "note_transcript_pos (the completion note's 1-based transcript position), "
+        "and AgentContextState.deferred_killed to "
+        "deferred_cancelled. v14 records load fine (stop_reason defaults "
+        "None; a v14 DELIVERED task record loses its rewind horizon, so a "
+        "rollback no longer re-injects its note; a v14 head's unflushed "
+        "deferred flips are dropped) EXCEPT a head parked at "
+        "after_forced_final_answer (rerun or resave the session)."
+    ),
 }
 """
 One-line summary per schema version. The current version MUST have an entry.
@@ -177,11 +193,14 @@ class AgentCheckpointLocation(Enum):
     """How a checkpoint head came to be — its loop save-point, or a rollback."""
 
     AFTER_INPUT = "after_input"
+
     AFTER_TOOL_RESULT = "after_tool_result"
+
+    # The run ended with an answer — the model's own stop, or one
+    # force-generated at budget/deadline exhaustion; the head's
+    # ``stop_reason`` records which.
     AFTER_FINAL_ANSWER = "after_final_answer"
-    # A force-generated final answer: the turn budget (MAX_TURNS) or the run's
-    # wall-clock deadline (TIMEOUT) was exhausted.
-    AFTER_FORCED_FINAL_ANSWER = "after_forced_final_answer"
+
     # A resident agent's answer to one inbox message (its tool-loop turns in
     # between checkpoint as AFTER_TOOL_RESULT): the per-message analog of
     # AFTER_FINAL_ANSWER for an agent that never ends its run. Persists the
@@ -189,12 +208,14 @@ class AgentCheckpointLocation(Enum):
     # drives an fs-snapshot so a restored transcript and filesystem stay in
     # step.
     AFTER_RESIDENT_ANSWER = "after_resident_answer"
+
     # Not a loop save-point: the pre-rollback head re-marked by
     # rollback_to_step before its first durable side effect (``current.step``
     # carries the target). A resume finding this completes the rollback —
     # the filesystem/mailbox may already be rewound under the old transcript.
     # Committing the ROLLED_BACK head overwrites (atomically clears) it.
     ROLLING_BACK = "rolling_back"
+
     # Not a loop save-point: a synthetic head written by rollback_to_step,
     # parked at the start of the rolled-back-to step.
     ROLLED_BACK = "rolled_back"
@@ -219,26 +240,34 @@ class AgentContextState(BaseModel):
     read_file_state: dict[str, float] = Field(default_factory=dict[str, float])
     dotfile_overrides: list[str] = Field(default_factory=list[str])
     shell_cwd: str | None = None
+
+    # Deferred DELIVERED flips for task results the transcript holds but no
+    # checkpoint has persisted yet (each value is a ``TaskDeliveredFlip``).
     deferred_delivered: dict[str, dict[str, Any]] = Field(
         default_factory=dict[str, dict[str, Any]]
     )
-    # Deferred CANCELLED flips for tasks killed by a rewind, persisted so a
-    # crash before their flush cannot resurrect the killed tasks on resume:
-    # the same head that raises ``task_launch_seq`` past a killed launch (which
-    # defeats the resume orphan guard) also carries the kill itself.
-    deferred_killed: dict[str, dict[str, Any]] = Field(
+
+    # Deferred CANCELLED flips for tasks cancelled by a rewind, persisted so a
+    # crash before their flush cannot resurrect the cancelled tasks on resume:
+    # the same head that raises ``task_launch_seq`` past a cancelled launch
+    # (which defeats the resume orphan guard) also carries the cancellation
+    # itself. Each value is a ``TaskCancelledFlip``.
+    deferred_cancelled: dict[str, dict[str, Any]] = Field(
         default_factory=dict[str, dict[str, Any]]
     )
+
     # High-water background-task launch seq at this boundary: every task
     # launched by then has ``launch_seq <= task_launch_seq``. A rewind to this
     # boundary cancels tasks above it (their launching calls left the
     # transcript); resume dead-letters task records above it.
     task_launch_seq: int = 0
+
     # High-water inbox consumption seq at this boundary: every message absorbed
     # by then has ``seq <= mail_consumption_seq``. A step rollback to this
     # boundary voids acked mailbox records above it (their turns left the
     # transcript) — never re-delivered; senders are notified instead.
     mail_consumption_seq: int = 0
+
     ipy_exec_context_id: str | None = None
     nb_exec_context_id: str | None = None
 
@@ -257,16 +286,18 @@ class StepWatermark(BaseModel):
     message_count: int = 0
     # The message-log file ``message_count`` indexes. Meaningful only on a
     # head's ``current`` — stamped by the checkpoint serializers, never by
-    # callers. Rollback boundaries leave it defaulted: the log is append +
-    # suffix-truncate + content-preserving rewrite, so a boundary's
-    # ``message_count`` stays a valid prefix of whatever version is live.
+    # callers (rollback boundaries leave it defaulted).
     log_version: int = 0
+
     turn: int = 0
     step: int | None = None
+
     prompt_cache_key: str | None = None
+
     # Filesystem ref (restored via the environment's SnapshotCapable seam); the
     # rest of the session-resource state rides in ``agent_ctx_state``.
     fs_snapshot_ref: str | None = None
+
     agent_ctx_state: AgentContextState = Field(default_factory=AgentContextState)
 
 
@@ -343,9 +374,10 @@ class AgentCheckpoint(ProcessorCheckpoint):
     rewinds to the *start* of a step (its input not yet present). Both kinds
     carry the read-before-write ledger and kernel-context ids (in their
     ``agent_ctx_state``). ``step_watermarks`` is empty for chat / untracked
-    deliveries. ``output`` and ``location`` describe the current head only —
-    the step's cached answer and where in the loop it was saved — so they live
-    here rather than on the rewind coordinate.
+    deliveries. ``output``, ``location``, and ``stop_reason`` describe the
+    current head only — the step's cached answer, where in the loop it was
+    saved, and how the run ended — so they live here rather than on the
+    rewind coordinate.
     """
 
     # The transcript is persisted out-of-band as an append-only message log
@@ -378,8 +410,14 @@ class AgentCheckpoint(ProcessorCheckpoint):
     # reads it. ``None`` while a step is incomplete.
     output: str | None = None
 
-    # Where in the agent loop this head was saved (diagnostics only).
+    # Where in the agent loop this head was saved, or a rollback-protocol
+    # marker.
     location: AgentCheckpointLocation = AgentCheckpointLocation.AFTER_INPUT
+
+    # How the run that saved this head ended: the model's own final answer,
+    # or one force-generated at turn-budget/deadline exhaustion. ``None`` on
+    # mid-run, resident, and rollback heads.
+    stop_reason: StopReason | None = None
 
 
 class WorkflowCheckpoint(ProcessorCheckpoint):

--- a/src/grasp_agents/durability/task_record.py
+++ b/src/grasp_agents/durability/task_record.py
@@ -1,4 +1,5 @@
 from enum import StrEnum, auto
+from typing import NotRequired, TypedDict
 
 from .checkpoints import PersistedRecord
 
@@ -9,6 +10,28 @@ class TaskStatus(StrEnum):
     FAILED = auto()
     CANCELLED = auto()
     DELIVERED = auto()  # Result/error was injected into parent memory
+
+
+class TaskDeliveredFlip(TypedDict):
+    """
+    A deferred DELIVERED update for a ``TaskRecord``: the fields
+    ``BackgroundTaskManager.flush_flips`` writes alongside the DELIVERED
+    status once the transcript carrying the task's note is durable.
+    """
+
+    result: NotRequired[str | None]
+    error: NotRequired[str | None]
+    note_transcript_pos: NotRequired[int]
+
+
+class TaskCancelledFlip(TypedDict):
+    """
+    A deferred CANCELLED update for a task cancelled by a transcript rewind,
+    written alongside the CANCELLED status once the rewound transcript is
+    durable.
+    """
+
+    error: str
 
 
 class TaskRecord(PersistedRecord):
@@ -38,11 +61,12 @@ class TaskRecord(PersistedRecord):
     result: str | None = None
     error: str | None = None
 
-    # Transcript length right after this task's completion note was appended —
-    # the note's rewind horizon: a rollback that truncates below it re-injects
-    # the note (``BackgroundTaskManager.redeliver_after``). Set when the
-    # record flips DELIVERED.
-    delivered_msg_count: int | None = None
+    # 1-based transcript position of this task's completion note (== the
+    # transcript length right after the note was appended) — the note's rewind
+    # horizon: a rollback that cuts the transcript below it re-injects the
+    # note (``BackgroundTaskManager.redeliver_after``). Set when the record
+    # flips DELIVERED.
+    note_transcript_pos: int | None = None
 
     # The agent-readable ``.grasp/tasks`` log file holding this task's full
     # streamed output (the single source of truth for it; ``None`` when no file

--- a/src/grasp_agents/inbox.py
+++ b/src/grasp_agents/inbox.py
@@ -64,9 +64,13 @@ class AgentInbox:
         # :meth:`LLMAgent.attach_inbox`) instead of building one per run.
         self._leased: dict[str, TeamMessage] = {}
 
-    @property
-    def transport(self) -> Transport[TeamMessage]:
-        return self._transport
+    def is_view_of(self, transport: Transport[TeamMessage]) -> bool:
+        """
+        Whether this inbox is a view over exactly ``transport`` (identity).
+        The transport itself is not exposed — session code reaches it via
+        ``SessionContext.transport``, the one canonical handle.
+        """
+        return self._transport is transport
 
     async def post(self, message: TeamMessage) -> None:
         """Deliver ``message`` through the transport (routed by its recipients)."""
@@ -120,7 +124,7 @@ class AgentInbox:
     async def flush_acks(self) -> None:
         """
         Release every leased message — the inbox counterpart to
-        :meth:`BackgroundTaskManager.flush_delivered`. Called right after the
+        :meth:`BackgroundTaskManager.flush_flips`. Called right after the
         checkpoint that persisted the turn which consumed them: the messages are
         now durably absorbed into the log, so removing them from the mailbox can no
         longer strand them (resume re-derives the owed response from the log). A
@@ -139,7 +143,7 @@ class AgentInbox:
         In-memory only — the messages stay pending in the mailbox. A cold
         reload leaves them there for re-delivery (their takes were never
         checkpointed); a step rollback voids them instead (the caller acks
-        and notifies — see ``LLMAgent._rollback_mailbox``). NOT for a
+        and notifies — see ``AgentContext.rewind``). NOT for a
         failed-run settle: settling keeps the absorbed message's turn, and
         its lease is what prevents a duplicate re-take.
         """

--- a/src/grasp_agents/ui/_event_render.py
+++ b/src/grasp_agents/ui/_event_render.py
@@ -33,6 +33,10 @@ from rich.text import Text, TextType
 from rich.theme import Theme
 
 from grasp_agents.context.projection import fold_summary_text
+from grasp_agents.context.system_reminder import (
+    SESSION_RESUMED_SUBJECT,
+    match_system_reminder_subject,
+)
 from grasp_agents.context.untrusted_content import unwrap_untrusted
 from grasp_agents.printer import sanitize_terminal_text
 from grasp_agents.skills import match_invocation_wrapper
@@ -244,7 +248,7 @@ def render_event(
             return render_task_notification(
                 text, agent=event.destination or event.source
             )
-        if "<session_resumed>" in text:
+        if match_system_reminder_subject(text) == SESSION_RESUMED_SUBJECT:
             return render_resume_notice(text)
         # A user-invoked skill (slash-command) — show the message verbatim (the
         # ``<system-reminder subject="user invoked skill …">`` wrapper and the

--- a/src/grasp_agents/ui/console.py
+++ b/src/grasp_agents/ui/console.py
@@ -24,6 +24,10 @@ from rich.console import Console
 from rich.markup import escape
 from rich.text import Text
 
+from grasp_agents.context.system_reminder import (
+    SESSION_RESUMED_SUBJECT,
+    match_system_reminder_subject,
+)
 from grasp_agents.printer import render_payload
 from grasp_agents.types.events import (
     BackgroundTaskCompletedEvent,
@@ -330,7 +334,10 @@ class EventConsole:
             # Framework notices (task results, resume framing) always show and
             # are rendered specially by render_event; regular user input is on
             # by default but can be turned off.
-            is_notice = "<task_notification>" in text or "<session_resumed>" in text
+            is_notice = (
+                "<task_notification>" in text
+                or match_system_reminder_subject(text) == SESSION_RESUMED_SUBJECT
+            )
             if is_notice or self.show_input_messages:
                 self._on_user_message(event)
 

--- a/tests/agent/test_background_task_rewind.py
+++ b/tests/agent/test_background_task_rewind.py
@@ -73,24 +73,23 @@ async def _load_only_record(
 
 class TestCancelLaunchedAfter:
     @pytest.mark.asyncio
-    async def test_kills_only_tasks_above_the_watermark(self) -> None:
+    async def test_cancels_only_tasks_above_the_watermark(self) -> None:
         ctx = SessionContext[None](state=None)
         mgr, _ = _make_manager()
 
         t1 = await _launch(mgr, ctx, "c1")
         watermark = mgr.last_launch_seq
         t2 = await _launch(mgr, ctx, "c2")
-        killed_task = mgr.get(t2).task
+        cancelled_task = mgr._tasks[t2].consumer  # pyright: ignore[reportPrivateUsage]
 
         mgr.cancel_launched_after(watermark)
 
         # t1's launch predates the watermark and keeps running; t2 is gone.
-        assert mgr.get(t1).task.done() is False
-        with pytest.raises(ValueError, match=t2):
-            mgr.get(t2)
+        assert mgr._tasks[t1].consumer.done() is False  # pyright: ignore[reportPrivateUsage]
+        assert t2 not in mgr._tasks  # pyright: ignore[reportPrivateUsage]
         with contextlib.suppress(asyncio.CancelledError):
-            await killed_task
-        assert killed_task.cancelled()
+            await cancelled_task
+        assert cancelled_task.cancelled()
 
         await mgr.cancel_all(ctx=ctx)
 
@@ -131,18 +130,18 @@ class TestCancelLaunchedAfter:
         _, record = await _load_only_record(store, "s1")
         assert record.status == TaskStatus.RUNNING
 
-        await mgr.flush_delivered(ctx=ctx)
+        await mgr.flush_flips(ctx=ctx)
         _, record = await _load_only_record(store, "s1")
         assert record.status == TaskStatus.CANCELLED
         assert record.error is not None
         assert "rolled back" in record.error
 
     @pytest.mark.asyncio
-    async def test_kill_flip_survives_watermark_restore(self) -> None:
+    async def test_cancelled_flip_survives_watermark_restore(self) -> None:
         # A settle/rollback restore wholesale-replaces the deferred DELIVERED
-        # map from the boundary snapshot; a kill recorded alongside must not
-        # be lost with it — the killed launch is gone from the transcript no
-        # matter which boundary is live.
+        # map from the boundary snapshot; a cancellation recorded alongside
+        # must not be lost with it — the cancelled launch is gone from the
+        # transcript no matter which boundary is live.
         store = InMemoryCheckpointStore()
         ctx = SessionContext[None](state=None, checkpoint_store=store, session_key="s1")
         mgr, _ = _make_manager()
@@ -151,7 +150,7 @@ class TestCancelLaunchedAfter:
         mgr.cancel_launched_after(0)
         mgr.restore_deferred_delivered({})
 
-        await mgr.flush_delivered(ctx=ctx)
+        await mgr.flush_flips(ctx=ctx)
         _, record = await _load_only_record(store, "s1")
         assert record.status == TaskStatus.CANCELLED
 
@@ -278,7 +277,7 @@ class TestAgentRewindsTaskPlane:
             await asyncio.wait_for(started.wait(), timeout=2.0)
             mgr = agent._loop.agent_ctx.bg_tasks  # pyright: ignore[reportPrivateUsage]
             assert mgr.has_live_tasks
-            bg_task = mgr.get("bg_1").task
+            bg_task = mgr._tasks["bg_1"].consumer  # pyright: ignore[reportPrivateUsage]
             _, record = await _load_only_record(store, "s1")
             assert record.status == TaskStatus.RUNNING
             assert record.launch_seq == 1
@@ -336,7 +335,7 @@ class TestAgentRewindsTaskPlane:
         assert out.payloads[0] == "done"
         mgr = agent._loop.agent_ctx.bg_tasks  # pyright: ignore[reportPrivateUsage]
         assert mgr.has_live_tasks  # non-blocking task outlives the run
-        bg_task = mgr.get("bg_1").task
+        bg_task = mgr._tasks["bg_1"].consumer  # pyright: ignore[reportPrivateUsage]
 
         await agent.rollback_to_step(1)
 
@@ -390,19 +389,19 @@ class TestUndeliverAfter:
         assert boundary.agent_ctx_state.task_launch_seq == 1
         _, record = await _load_only_record(store, "s1")
         assert record.status == TaskStatus.DELIVERED
-        assert record.delivered_msg_count is not None
-        assert record.delivered_msg_count > boundary.message_count
-        assert str(agent.transcript.messages).count("<status>completed</status>") == 1
+        assert record.note_transcript_pos is not None
+        assert record.note_transcript_pos > boundary.message_count
+        assert str(agent.transcript.messages).count("<status> completed </status>") == 1
 
         await agent.rollback_to_step(2)
 
         # The note is back at the rewind point (once), queued for the next
         # run's event stream, and the record's position moved with it.
-        assert str(agent.transcript.messages).count("<status>completed</status>") == 1
+        assert str(agent.transcript.messages).count("<status> completed </status>") == 1
         assert agent._resume_notifications  # pyright: ignore[reportPrivateUsage]
         _, record = await _load_only_record(store, "s1")
         assert record.status == TaskStatus.DELIVERED
-        assert record.delivered_msg_count == len(agent.transcript.messages)
+        assert record.note_transcript_pos == len(agent.transcript.messages)
 
         # A cold resume injects nothing extra (no duplicate note).
         t2 = LLMAgentTranscript()
@@ -450,7 +449,7 @@ class TestUndeliverAfter:
 
         await agent.rollback_to_step(2)
 
-        assert "<status>completed</status>" not in str(agent.transcript.messages)
+        assert "<status> completed </status>" not in str(agent.transcript.messages)
         assert not agent._resume_notifications  # pyright: ignore[reportPrivateUsage]
 
 
@@ -484,20 +483,71 @@ class TestUndeliverOverlay:
 
         # Without the overlay the COMPLETED record stays buried.
         assert (
-            await mgr.redeliver_after(message_count=4, task_launch_seq=1, ctx=ctx) == []
+            await mgr.redeliver_after(
+                message_count=4,
+                task_launch_seq=1,
+                ctx=ctx,
+                pre_restore_deferred_delivered={},
+            )
+            == []
         )
 
         injected = await mgr.redeliver_after(
             message_count=4,
             task_launch_seq=1,
             ctx=ctx,
-            deferred_delivered={
-                key: {"status": TaskStatus.DELIVERED, "delivered_msg_count": 6}
-            },
+            pre_restore_deferred_delivered={key: {"note_transcript_pos": 6}},
         )
         assert len(injected) == 1
         assert "the outcome" in str(injected[0])
-        assert str(transcript.messages).count("<status>completed</status>") == 1
+        assert str(transcript.messages).count("<status> completed </status>") == 1
+
+
+class TestRestoreFlipPositionRule:
+    @pytest.mark.asyncio
+    async def test_live_flip_survival_follows_note_transcript_pos(self) -> None:
+        # A restore keeps a live unflushed DELIVERED flip iff its completion
+        # note is still inside the surgically-kept transcript: a kept note's
+        # flip survives (else a later resume re-injects a duplicate), a cut
+        # note's flip is dropped (else the flush buries the outcome as
+        # DELIVERED while the model no longer has the note).
+        mgr, transcript = _make_manager()
+        agent_ctx = AgentContext.create(transcript=transcript, tools={}, bg_tasks=mgr)
+        state = agent_ctx.snapshot()
+
+        transcript.update(
+            [InputMessageItem.from_text(f"m{i}", role="user") for i in range(2)]
+        )  # 3 messages
+        mgr.restore_deferred_delivered(
+            {
+                "task/s1/kept": {"note_transcript_pos": 3},
+                "task/s1/cut": {"note_transcript_pos": 6},
+            }
+        )
+
+        agent_ctx.restore(state)
+
+        assert set(mgr.export_deferred_delivered()) == {"task/s1/kept"}
+
+    @pytest.mark.asyncio
+    async def test_live_cancelled_flips_always_survive(self) -> None:
+        # Unlike a DELIVERED flip, a cancellation is a physical fact no
+        # boundary falsifies: every live CANCELLED flip survives a restore,
+        # even one whose task was launched after the restored boundary.
+        store = InMemoryCheckpointStore()
+        ctx = SessionContext[None](state=None, checkpoint_store=store, session_key="s1")
+        mgr, transcript = _make_manager()
+        agent_ctx = AgentContext.create(transcript=transcript, tools={}, bg_tasks=mgr)
+        state = agent_ctx.snapshot()
+
+        await _launch(mgr, ctx, "c1")
+        mgr.cancel_launched_after(0)
+        flips = mgr.export_deferred_cancelled()
+        assert flips
+
+        agent_ctx.restore(state)
+
+        assert mgr.export_deferred_cancelled() == flips
 
 
 class TestKillsSurviveCrashBeforeFlush:
@@ -519,7 +569,7 @@ class TestKillsSurviveCrashBeforeFlush:
         agent_ctx = AgentContext.create(transcript=transcript, tools={}, bg_tasks=mgr)
         state = agent_ctx.snapshot()
         assert state.task_launch_seq == 1
-        assert state.deferred_killed
+        assert state.deferred_cancelled
 
         # Cold resume: fresh manager, state restored from the head.
         t2 = LLMAgentTranscript()
@@ -536,7 +586,7 @@ class TestKillsSurviveCrashBeforeFlush:
         assert injected == []  # no phantom "interrupted" notice, no re-spawn
 
         # The re-armed kill lands at the next flush.
-        await mgr2.flush_delivered(ctx=ctx)
+        await mgr2.flush_flips(ctx=ctx)
         _, record = await _load_only_record(store, "s1")
         assert record.status == TaskStatus.CANCELLED
 
@@ -571,9 +621,7 @@ class TestResumeSkipsRestoredFlips:
             .encode(),
         )
         # The restored head carried this deferred flip.
-        mgr.restore_deferred_delivered(
-            {key: {"status": TaskStatus.DELIVERED, "delivered_msg_count": 2}}
-        )
+        mgr.restore_deferred_delivered({key: {"note_transcript_pos": 2}})
 
         injected = await mgr.resume_durable(ctx=ctx, exec_id="t", task_launch_seq=1)
         assert injected == []
@@ -611,14 +659,17 @@ class TestUndeliverOrder:
                     tool_name=f"tool_{task_id}",
                     status=TaskStatus.DELIVERED,
                     result=f"result of {task_id}",
-                    delivered_msg_count=delivered_at,
+                    note_transcript_pos=delivered_at,
                 )
                 .model_dump_json()
                 .encode(),
             )
 
         injected = await mgr.redeliver_after(
-            message_count=4, task_launch_seq=2, ctx=ctx
+            message_count=4,
+            task_launch_seq=2,
+            ctx=ctx,
+            pre_restore_deferred_delivered={},
         )
 
         assert len(injected) == 2
@@ -652,11 +703,11 @@ class TestFlushDeliveredRetry:
 
         store.fail_next_save = True
         with pytest.raises(RuntimeError, match="store down"):
-            await mgr.flush_delivered(ctx=ctx)
+            await mgr.flush_flips(ctx=ctx)
         _, record = await _load_only_record(store, "s1")
         assert record.status == TaskStatus.RUNNING  # flip not applied yet
 
-        await mgr.flush_delivered(ctx=ctx)  # retried at the next flush
+        await mgr.flush_flips(ctx=ctx)  # retried at the next flush
         _, record = await _load_only_record(store, "s1")
         assert record.status == TaskStatus.CANCELLED
 

--- a/tests/agent/test_background_tools.py
+++ b/tests/agent/test_background_tools.py
@@ -254,39 +254,46 @@ class TestBackgroundToolLaunch:
         assert len(user_msgs) >= 1
         assert "slow: research" in str(user_msgs[0].data)
 
-    @pytest.mark.asyncio
-    async def test_launch_note_guidance_is_uniform(self):
+    def test_launch_note_is_metadata_only(self):
         """
-        The launch-note guidance does not depend on ``blocks_final_answer``:
-        every backgrounded task is told it will get a ``<task_notification>``,
-        not to re-call the tool, and — if all that's left is waiting — to reply
-        tool-free (the loop then waits). Only the opening line differs (it names
-        the tool + task id).
+        The launch note is the bare ``<task_notification>`` block (status
+        RUNNING): the waiting/log/kill guidance lives in the auto-attached
+        ``background_tasks`` system-prompt section, not in every note. The
+        two backgrounding modes share everything but the subject line.
         """
-        from grasp_agents.agent.background_tasks import BackgroundTaskManager
-        from grasp_agents.agent.llm_agent_transcript import LLMAgentTranscript
+        from grasp_agents.agent.background_tasks import (
+            _make_launch_note,  # pyright: ignore[reportPrivateUsage]
+        )
 
-        transcript = LLMAgentTranscript()
-        transcript.messages = [InputMessageItem.from_text("sys", role="system")]
-        mgr = BackgroundTaskManager[None](
-            agent_name="a", transcript=transcript, tools={}, path=[]
+        note_now = _make_launch_note(
+            task_id="bg_1",
+            tool_name="slow",
+            tool_call_id="c1",
+            backgrounded_after=None,
+            log_path=None,
         )
-        blocking, nonblocking = SlowTool(), FireAndForgetTool()
-        assert blocking.blocks_final_answer and not nonblocking.blocks_final_answer
-        note_b = mgr._launch_note(  # pyright: ignore[reportPrivateUsage]
-            blocking, "bg_1", backgrounded_after=None, log_path=None
+        note_deadline = _make_launch_note(
+            task_id="bg_1",
+            tool_name="slow",
+            tool_call_id="c1",
+            backgrounded_after=5.0,
+            log_path=None,
         )
-        note_n = mgr._launch_note(  # pyright: ignore[reportPrivateUsage]
-            nonblocking, "bg_2", backgrounded_after=None, log_path=None
-        )
-        for note in (note_b, note_n):
+        for note in (note_now, note_deadline):
             assert "<task_notification>" in note
-            assert "do NOT call it again" in note
-            assert "WITHOUT calling any tools" in note
-            assert "KillTask" in note
-        # Identical regardless of blocks_final_answer — only the opening line,
-        # which names the tool + id, differs.
-        assert note_b.split("\n", 1)[1] == note_n.split("\n", 1)[1]
+            assert "<status> running </status>" in note
+            assert note.endswith("</task_notification>")
+            assert "KillTask" not in note  # guidance lives in the section
+        # Only the subject line differs between the two modes.
+        diff = [
+            (a, b)
+            for a, b in zip(
+                note_now.split("\n"), note_deadline.split("\n"), strict=True
+            )
+            if a != b
+        ]
+        assert len(diff) == 1
+        assert all("<subject>" in line for line in diff[0])
 
     @pytest.mark.asyncio
     async def test_background_tool_flag_on_base_tool(self):
@@ -295,6 +302,68 @@ class TestBackgroundToolLaunch:
         slow = SlowTool()
         assert echo.auto_background_at is None
         assert slow.auto_background_at == 0
+
+
+class TestBackgroundTasksSection:
+    """
+    The waiting/log/kill guidance is a system-prompt section rendered from the
+    live toolset at prompt-build time — present iff a backgroundable tool is
+    attached, so post-construction tool wiring stays in agreement.
+    """
+
+    @staticmethod
+    def _render(tools: dict[str, BaseTool[Any, Any, Any]]) -> str | None:
+        from grasp_agents.agent.agent_context import AgentContext
+        from grasp_agents.agent.background_tasks import (
+            make_background_tasks_section,
+        )
+
+        agent_ctx = AgentContext.create(transcript=LLMAgentTranscript(), tools=tools)
+        result = make_background_tasks_section().compute(agent_ctx=agent_ctx)
+        assert result is None or isinstance(result, str)
+        return result
+
+    def test_absent_without_backgroundable_tools(self):
+        assert self._render({"echo": EchoTool()}) is None
+
+    def test_present_with_backgroundable_tool(self):
+        text = self._render({"slow": SlowTool()})
+        assert text is not None
+        assert "<background_tasks>" in text
+        assert "do NOT repeat the call" in text
+        assert "WITHOUT calling any tools" in text
+        assert '"interrupted"' in text  # what an interrupted notice means
+        # No KillTask attached → no KillTask guidance to hallucinate on.
+        assert "KillTask" not in text
+
+    def test_kill_task_line_gated_on_tool(self):
+        from grasp_agents.tools.task_tools import KillTask
+
+        text = self._render({"slow": SlowTool(), "KillTask": KillTask()})
+        assert text is not None
+        assert "Stop a task with KillTask" in text
+
+    @pytest.mark.asyncio
+    async def test_agent_prompt_tracks_post_construction_tools(self):
+        # The section is registered unconditionally and computed per run entry
+        # from the live toolset: an agent built without backgroundable tools
+        # renders no guidance, and one wired in afterwards (as a team does
+        # onto its residents) is picked up without re-registration.
+        from grasp_agents.agent.llm_agent import LLMAgent
+
+        agent = LLMAgent[Any, str, None](
+            name="bg_section_agent",
+            llm=MockLLM(model_name="mock", responses_queue=[]),
+            tools=[EchoTool()],
+            sys_prompt="x",
+            env_info=False,
+        )
+        before = str(await agent.preview_initial_context())
+        assert "<background_tasks>" not in before
+
+        agent.tools["slow"] = SlowTool()
+        after = str(await agent.preview_initial_context())
+        assert "<background_tasks>" in after
 
 
 class TestMixedImmediateAndBackground:
@@ -800,7 +869,7 @@ class TestDurableTaskRecords:
 
         # Simulate a crash: drop the in-flight task without finalizing the record.
         for pt in list(mgr._tasks.values()):  # pyright: ignore[reportPrivateUsage]
-            pt.task.cancel()
+            pt.consumer.cancel()
 
         # A fresh manager on the same session = a restart.
         t2 = LLMAgentTranscript()
@@ -826,9 +895,9 @@ class TestDurableTaskRecords:
         recs = [TaskRecord.model_validate_json(await store.load(k)) for k in keys]
         assert all(r.status == TaskStatus.RUNNING for r in recs)
 
-        # flush_delivered (called after the agent checkpoint) makes the
+        # flush_flips (called after the agent checkpoint) makes the
         # record terminal, so a second resume surfaces nothing.
-        await mgr2.flush_delivered(ctx=ctx)
+        await mgr2.flush_flips(ctx=ctx)
         t3 = LLMAgentTranscript()
         t3.messages = [InputMessageItem.from_text("sys", role="system")]
         mgr3 = BackgroundTaskManager[None](
@@ -860,7 +929,7 @@ class TestDurableTaskRecords:
             call, FailingBgTool(), EchoInput(text="x"), ctx=ctx, exec_id="t"
         )
         # Wait for the task to finish so _consume persists the outcome.
-        await mgr.get(event.data.task_id).task
+        await mgr._tasks[event.data.task_id].consumer  # pyright: ignore[reportPrivateUsage]
 
         # A genuine runtime failure is recorded as FAILED with its error (so a
         # crash before drain leaves a terminal record, not a re-runnable PENDING).
@@ -935,7 +1004,7 @@ class TestDurableTaskRecords:
 
         await mgr.resume_durable(ctx=ctx, exec_id="t")
         # The child was re-spawned; drive it to completion.
-        await mgr.get("bg_1").task
+        await mgr._tasks["bg_1"].consumer  # pyright: ignore[reportPrivateUsage]
 
         rec = TaskRecord.model_validate_json(await store.load(task_key))
         assert rec.status == TaskStatus.COMPLETED, rec.status
@@ -1151,7 +1220,7 @@ class TestFrontTrim:
     """
     Drain front-trims a surviving task's buffer: events consumed by both the
     bubble and flush cursors are dropped, bounding memory for a chatty command,
-    while a terminal result event is preserved for ``_result_of``.
+    while a terminal result event is preserved for ``_outcome_from_events``.
     """
 
     @pytest.mark.asyncio
@@ -1170,8 +1239,9 @@ class TestFrontTrim:
         pt = BackgroundTask(
             task_id="bg_1",
             tool_name="x",
+            tool_call_id="c1",
             exec_id="t",
-            task=task,
+            consumer=task,
             blocks_final_answer=False,
         )
         for i in range(10):
@@ -1192,10 +1262,7 @@ class TestFrontTrim:
 
     @pytest.mark.asyncio
     async def test_trim_stops_before_a_terminal_result(self):
-        from grasp_agents.agent.background_tasks import (
-            BackgroundTask,
-            BackgroundTaskManager,
-        )
+        from grasp_agents.agent.background_tasks import BackgroundTask
         from grasp_agents.types.events import ToolOutputEvent, ToolStreamEvent
 
         async def _noop() -> None: ...
@@ -1203,16 +1270,18 @@ class TestFrontTrim:
         task = asyncio.create_task(_noop())
         await task
 
-        pt = BackgroundTask(task_id="bg_1", tool_name="x", exec_id="t", task=task)
+        pt = BackgroundTask(
+            task_id="bg_1", tool_name="x", tool_call_id="c1", exec_id="t", consumer=task
+        )
         pt.events.append(ToolStreamEvent(data="s0", source="x"))
         pt.events.append(ToolOutputEvent(data="RESULT", source="x"))  # terminal
         pt.events.append(ToolStreamEvent(data="s2", source="x"))
         pt.cursor = 3
 
-        BackgroundTaskManager._trim_consumed(pt)  # pyright: ignore[reportPrivateUsage]
+        pt.trim_consumed()
 
         # Trim stops before the terminal result at index 1 → only ``s0`` dropped,
-        # so a later ``_result_of`` still finds the result.
+        # so a later ``_outcome_from_events`` still finds the result.
         assert len(pt.events) == 2
         assert isinstance(pt.events[0], ToolOutputEvent)
         assert pt.cursor == 2

--- a/tests/agent/test_loop_state.py
+++ b/tests/agent/test_loop_state.py
@@ -20,8 +20,8 @@ from grasp_agents.agent.loop_state import (
     NextStep,
     NextStepContinue,
     NextStepForceFinalAnswer,
-    NextStepForceResidentReply,
-    NextStepResidentReply,
+    NextStepForceResidentAnswer,
+    NextStepResidentAnswer,
     NextStepRunTools,
     NextStepStop,
     decide_next_step,
@@ -250,11 +250,11 @@ class TestNextStepContinue:
         assert isinstance(step, NextStepRunTools)
 
 
-# ---------- Resident actor: NextStepResidentReply ----------
+# ---------- Resident actor: NextStepResidentAnswer ----------
 
 
-class TestNextStepResidentReply:
-    def test_final_answer_becomes_resident_reply(self) -> None:
+class TestNextStepResidentAnswer:
+    def test_final_answer_becomes_resident_answer(self) -> None:
         # A resident (open inbox) that produced a reply: the analog of Stop, but
         # the loop recycles instead of ending.
         step = decide_next_step(
@@ -265,10 +265,10 @@ class TestNextStepResidentReply:
             blocking_bg_tasks=False,
             inbox_open=True,
         )
-        assert isinstance(step, NextStepResidentReply)
+        assert isinstance(step, NextStepResidentAnswer)
         assert step.final_answer == "reply"
 
-    def test_tool_calls_still_win_over_resident_reply(self) -> None:
+    def test_tool_calls_still_win_over_resident_answer(self) -> None:
         # Final answer AND tool calls under an open inbox: run the tools first
         # (matching a resident's prior behavior), don't release the message yet.
         step = decide_next_step(
@@ -283,7 +283,7 @@ class TestNextStepResidentReply:
 
     def test_reasoning_turn_continues_not_reply(self) -> None:
         # No final answer yet (a reasoning turn): keep going, don't release the
-        # message — only a produced reply is a ResidentReply.
+        # message — only a produced answer is a ResidentAnswer.
         step = decide_next_step(
             final_answer=None,
             tool_calls=[],
@@ -294,9 +294,11 @@ class TestNextStepResidentReply:
         )
         assert isinstance(step, NextStepContinue)
 
-    def test_resident_reply_suppressed_by_bg_tasks(self) -> None:
-        # The message isn't fully handled while answer-blocking bg work is
-        # pending — defer the reply (and the release) like a lone agent's Stop.
+    def test_resident_answers_despite_blocking_bg_tasks(self) -> None:
+        # Answer-blocking bg work gates only a bounded run's final answer
+        # (ending the run would strand the pending result). A resident's loop
+        # outlives its answer and receives the completion on wake, so it
+        # answers now instead of holding the message open.
         step = decide_next_step(
             final_answer="reply",
             tool_calls=[],
@@ -305,7 +307,8 @@ class TestNextStepResidentReply:
             blocking_bg_tasks=True,
             inbox_open=True,
         )
-        assert isinstance(step, NextStepContinue)
+        assert isinstance(step, NextStepResidentAnswer)
+        assert step.final_answer == "reply"
 
     def test_resident_never_force_finalizes_past_budget(self) -> None:
         # A resident past its budget / deadline must never Stop or
@@ -321,7 +324,7 @@ class TestNextStepResidentReply:
             inbox_open=True,
             turns_on_message=99,
         )
-        assert isinstance(step, NextStepResidentReply)
+        assert isinstance(step, NextStepResidentAnswer)
 
     def test_lifetime_turn_does_not_trip_per_message_budget(self) -> None:
         # A long-lived resident (huge lifetime ``turn``) is bounded per message,
@@ -339,11 +342,11 @@ class TestNextStepResidentReply:
         assert isinstance(step, NextStepRunTools)
 
 
-# ---------- Resident actor: NextStepForceResidentReply ----------
+# ---------- Resident actor: NextStepForceResidentAnswer ----------
 
 
-class TestNextStepForceResidentReply:
-    def test_per_message_budget_without_answer_forces_reply(self) -> None:
+class TestNextStepForceResidentAnswer:
+    def test_per_message_budget_without_answer_forces_one(self) -> None:
         # Stuck in a tool loop on one message past the per-message budget, with no
         # answer: force a reply (and move on) rather than spinning forever.
         step = decide_next_step(
@@ -355,7 +358,7 @@ class TestNextStepForceResidentReply:
             inbox_open=True,
             turns_on_message=10,
         )
-        assert isinstance(step, NextStepForceResidentReply)
+        assert isinstance(step, NextStepForceResidentAnswer)
 
     def test_force_reply_preempts_tools(self) -> None:
         # Over the per-message budget, pending tool calls must NOT run — the cap
@@ -369,9 +372,9 @@ class TestNextStepForceResidentReply:
             inbox_open=True,
             turns_on_message=7,
         )
-        assert isinstance(step, NextStepForceResidentReply)
+        assert isinstance(step, NextStepForceResidentAnswer)
 
-    def test_answer_at_budget_replies_not_forces(self) -> None:
+    def test_answer_at_budget_answers_not_forces(self) -> None:
         # Over the per-message budget but the model produced an answer: deliver it
         # as a normal reply (no need to force-generate one).
         step = decide_next_step(
@@ -383,7 +386,7 @@ class TestNextStepForceResidentReply:
             inbox_open=True,
             turns_on_message=10,
         )
-        assert isinstance(step, NextStepResidentReply)
+        assert isinstance(step, NextStepResidentAnswer)
         assert step.final_answer == "done"
 
     def test_under_budget_no_answer_continues_not_forces(self) -> None:

--- a/tests/agent/test_tool_output_spill.py
+++ b/tests/agent/test_tool_output_spill.py
@@ -78,7 +78,7 @@ class TestExcerptForInline:
 
     def test_over_cap_keeps_head_and_tail_with_pointer(self) -> None:
         text, truncated = excerpt_for_inline(
-            "A" * 1000, 100, output_file="/root/.grasp/tasks/c1.result"
+            "A" * 1000, 100, log_file="/root/.grasp/tasks/c1.result"
         )
         assert truncated is True
         # Head + tail total the cap; the dropped middle is reported.

--- a/tests/agent_team/test_agent_team.py
+++ b/tests/agent_team/test_agent_team.py
@@ -911,7 +911,7 @@ async def test_attach_inbox_uses_session_transport(tmp_path: Path) -> None:
     agent.attach_inbox()
     inbox = agent.agent_ctx.inbox
     assert inbox is not None
-    assert inbox.transport is ctx.transport
+    assert inbox.is_view_of(ctx.transport)
 
 
 @pytest.mark.asyncio

--- a/tests/agent_team/test_resident_spike.py
+++ b/tests/agent_team/test_resident_spike.py
@@ -220,7 +220,7 @@ async def test_bg_completion_while_idle_wakes_resident_loop() -> None:
     assert "<task_notification>" in transcript_text
 
 
-async def test_resident_reply_durable_and_message_released() -> None:
+async def test_resident_answer_durable_and_message_released() -> None:
     # A resident's reply turn is checkpointed (so it survives a restart) and the
     # peer message it consumed is released only once that is durable: acked (gone
     # from the inbox) and recorded processed (so a re-delivery would be deduped).

--- a/tests/durability/test_checkpoint_metadata.py
+++ b/tests/durability/test_checkpoint_metadata.py
@@ -64,10 +64,10 @@ def _make_agent(
 
 class TestSchemaVersion:
     def test_current_schema_version_has_summary(self) -> None:
-        # v14: background-task launch ordering (TaskRecord.launch_seq +
-        # AgentContextState.task_launch_seq) — additive over the v13 floor
+        # v15: AgentCheckpoint.stop_reason + AFTER_FORCED_FINAL_ANSWER
+        # collapsed into AFTER_FINAL_ANSWER — additive over the v13 floor
         # (items dropped the *_parts mirror fields; older logs unreadable).
-        assert CURRENT_SCHEMA_VERSION == 14
+        assert CURRENT_SCHEMA_VERSION == 15
         assert CURRENT_SCHEMA_VERSION in SCHEMA_VERSION_SUMMARIES
 
     def test_new_fields_default_to_none(self) -> None:

--- a/tests/durability/test_loop_durability.py
+++ b/tests/durability/test_loop_durability.py
@@ -31,12 +31,13 @@ from grasp_agents.agent.background_tasks import BackgroundTaskManager
 from grasp_agents.agent.llm_agent import LLMAgent
 from grasp_agents.agent.llm_agent_transcript import LLMAgentTranscript
 from grasp_agents.durability import InMemoryCheckpointStore
+from grasp_agents.durability.checkpoints import AgentCheckpointLocation
 from grasp_agents.durability.task_record import TaskRecord, TaskStatus
 from grasp_agents.processors.processor import Processor
 from grasp_agents.session_context import SessionContext
 from grasp_agents.tools.base import BaseTool
 from grasp_agents.types.errors import ProcRunError
-from grasp_agents.types.events import TurnEndEvent, TurnStartEvent
+from grasp_agents.types.events import StopReason, TurnEndEvent, TurnStartEvent
 from grasp_agents.types.items import (
     FunctionToolCallItem,
     FunctionToolOutputItem,
@@ -246,6 +247,76 @@ class TestForceFinalAnswerSingleCommit:
         # each); the forced call must not be double-counted.
         usage = ctx.usage_tracker.total_usage
         assert usage.input_tokens == 20
+
+
+# ---------------------------------------------------------------------------
+# Persisted head records how the run ended
+# ---------------------------------------------------------------------------
+
+
+class TestHeadStopReason:
+    @pytest.mark.asyncio
+    async def test_clean_stop_persists_final_answer_reason(self) -> None:
+        store = InMemoryCheckpointStore()
+        agent, _ = _make_agent(
+            [_text_response("answer")], session_key="sr1", store=store
+        )
+        await agent.run("question")
+
+        head = await load_agent_checkpoint(store, "sr1/agent/test_agent")
+        assert head is not None
+        assert head.location is AgentCheckpointLocation.AFTER_FINAL_ANSWER
+        assert head.stop_reason is StopReason.FINAL_ANSWER
+
+    @pytest.mark.asyncio
+    async def test_forced_stop_persists_max_turns_reason(self) -> None:
+        store = InMemoryCheckpointStore()
+        # The over-budget turn must NOT be a final answer (a clean stop wins
+        # then): a second tool call forces the answer via a third LLM call.
+        agent, _ = _make_agent(
+            [
+                _tool_call_response("echo", '{"text": "x"}', "c1"),
+                _tool_call_response("echo", '{"text": "y"}', "c2"),
+                _text_response("forced final"),
+            ],
+            tools=[_EchoTool()],
+            max_turns=1,
+            session_key="sr2",
+            store=store,
+        )
+        await agent.run("go")
+
+        head = await load_agent_checkpoint(store, "sr2/agent/test_agent")
+        assert head is not None
+        assert head.location is AgentCheckpointLocation.AFTER_FINAL_ANSWER
+        assert head.stop_reason is StopReason.MAX_TURNS
+
+    @pytest.mark.asyncio
+    async def test_mid_run_head_has_no_stop_reason(self) -> None:
+        store = InMemoryCheckpointStore()
+        agent, _ = _make_agent(
+            [
+                _tool_call_response("echo", '{"text": "x"}', "c1"),
+                _text_response("answer"),
+            ],
+            tools=[_EchoTool()],
+            session_key="sr3",
+            store=store,
+        )
+
+        seen: list[tuple[AgentCheckpointLocation, StopReason | None]] = []
+
+        async for event in agent.run_stream("go"):
+            if isinstance(event, TurnEndEvent):
+                head = await load_agent_checkpoint(store, "sr3/agent/test_agent")
+                assert head is not None
+                seen.append((head.location, head.stop_reason))
+
+        assert (AgentCheckpointLocation.AFTER_TOOL_RESULT, None) in seen
+        assert seen[-1] == (
+            AgentCheckpointLocation.AFTER_FINAL_ANSWER,
+            StopReason.FINAL_ANSWER,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -565,7 +636,7 @@ class TestDeadlineBackgroundedOutcomePersisted:
         # Wait for the sidelined task to finish, without draining.
         pending = list(mgr._tasks.values())
         assert pending
-        await asyncio.gather(*(pt.task for pt in pending))
+        await asyncio.gather(*(pt.consumer for pt in pending))
 
         keys = await store.list_keys("s1/task/")
         assert keys

--- a/tests/integration/test_durable_subagents_live.py
+++ b/tests/integration/test_durable_subagents_live.py
@@ -115,8 +115,8 @@ async def test_two_backgrounded_subagents_respawn_on_resume(
     # them cancelled, and cancelled records are skipped on resume.)
     in_flight = list(manager1._loop.agent_ctx.bg_tasks._tasks.values())
     for pt in in_flight:
-        pt.task.cancel()
-    await asyncio.gather(*(pt.task for pt in in_flight), return_exceptions=True)
+        pt.consumer.cancel()
+    await asyncio.gather(*(pt.consumer for pt in in_flight), return_exceptions=True)
 
     keys = await store.list_keys(task_prefix("subagents"))
     recs = [TaskRecord.model_validate_json(await store.load(k)) for k in keys]

--- a/tests/sandbox/_bg_harness.py
+++ b/tests/sandbox/_bg_harness.py
@@ -109,8 +109,8 @@ async def poll_until_done(
     Leaves the task in place so a later ``drain`` still delivers its note.
     """
     for _ in range(tries):
-        pt = mgr.get(task_id)
-        if pt.task.done():
+        pt = mgr._tasks[task_id]  # pyright: ignore[reportPrivateUsage]
+        if pt.consumer.done():
             text = "".join(
                 str(e.data) for e in pt.events if isinstance(e, ToolStreamEvent)
             )

--- a/tests/sandbox/test_bash_polish.py
+++ b/tests/sandbox/test_bash_polish.py
@@ -459,8 +459,8 @@ async def test_large_result_excerpted_and_deferred(tmp_path: Path) -> None:
     assert result_path.suffix == ".result"
     assert result_path.read_text().count("A") >= 5000
 
-    # ...and <output_file> is the streamed .log, which also holds the full output.
-    log_match = _re.search(r"<output_file>(.+?)</output_file>", note, _re.DOTALL)
+    # ...and <log_file> is the streamed .log, which also holds the full output.
+    log_match = _re.search(r"<log_file>(.+?)</log_file>", note, _re.DOTALL)
     assert log_match is not None
     log_text = _Path(log_match.group(1).strip()).read_text()
     assert log_text.count("A") == 5000
@@ -485,7 +485,7 @@ async def test_progress_log_appends_deltas(tmp_path: Path) -> None:
 
     await asyncio.sleep(0.3)  # AAAA emitted, BBBB not yet
     await _flush(mgr, ctx)
-    log = _Path(mgr.get(task_id).log_path or "")
+    log = _Path(mgr._tasks[task_id].log_path or "")  # pyright: ignore[reportPrivateUsage]
     first = log.read_text()
     assert "AAAA" in first
     assert "BBBB" not in first
@@ -516,7 +516,7 @@ async def test_nonblocking_task_bubbles_stream_events(tmp_path: Path) -> None:
         "echo streamed && sleep 0.4",
     )
     assert task_id is not None
-    assert mgr.get(task_id).blocks_final_answer is False  # non-blocking opt-out
+    assert mgr._tasks[task_id].blocks_final_answer is False  # pyright: ignore[reportPrivateUsage]  # non-blocking opt-out
 
     await mgr.wait_idle()
     events = [e async for e in mgr.drain(exec_id="t", ctx=ctx)]
@@ -538,11 +538,10 @@ async def test_deadline_note_points_at_log(tmp_path: Path) -> None:
     )
     assert task_id is not None
 
-    log_path = loop.agent_ctx.bg_tasks.get(task_id).log_path
+    log_path = loop.agent_ctx.bg_tasks._tasks[task_id].log_path  # pyright: ignore[reportPrivateUsage]
     assert log_path is not None  # resolved eagerly at sideline, before any flush
     assert ".grasp/tasks" in log_path
     assert log_path in note  # the note hands the model the exact path
-    assert "Read or Grep" in note
 
     await loop.agent_ctx.bg_tasks.cancel_all(ctx=ctx)
     """
@@ -893,9 +892,9 @@ async def test_drain_marks_record_delivered(tmp_path: Path) -> None:
     assert recs
     assert all(r.status == TaskStatus.COMPLETED for r in recs)
 
-    # flush_delivered (called after the agent checkpoint) flips the records,
+    # flush_flips (called after the agent checkpoint) flips the records,
     # so a resume won't re-inject a result the agent already saw.
-    await loop.agent_ctx.bg_tasks.flush_delivered(ctx=ctx)
+    await loop.agent_ctx.bg_tasks.flush_flips(ctx=ctx)
     recs = [TaskRecord.model_validate_json(await store.load(k)) for k in keys]
     assert all(r.status == TaskStatus.DELIVERED for r in recs)
 
@@ -978,9 +977,9 @@ async def test_resume_interrupted_points_at_log(tmp_path: Path) -> None:
 
     # Simulate a crash: drop the in-flight task without finalizing the record.
     for pt in list(loop.agent_ctx.bg_tasks._tasks.values()):  # pyright: ignore[reportPrivateUsage]
-        pt.task.cancel()
+        pt.consumer.cancel()
         with _contextlib.suppress(asyncio.CancelledError):
-            await pt.task
+            await pt.consumer
 
     transcript = LLMAgentTranscript()
     transcript.messages = [InputMessageItem.from_text("sys", role="system")]
@@ -992,7 +991,7 @@ async def test_resume_interrupted_points_at_log(tmp_path: Path) -> None:
     joined = "\n".join(str(m) for m in transcript.messages)
     assert "Resumed from a checkpoint" in joined  # framing
     assert "interrupted" in joined
-    assert "output_file" in joined  # points the agent at the log
+    assert "log_file" in joined  # points the agent at the log
     assert ".grasp/tasks" in joined
     assert "ran_for" in joined  # elapsed
 

--- a/tests/sandbox/test_e2b.py
+++ b/tests/sandbox/test_e2b.py
@@ -1176,11 +1176,11 @@ async def test_e2b_live_background_large_result_excerpted() -> None:
         assert len(notes) == 1
         assert "completed" in notes[0]
         assert "chars omitted" in notes[0]  # excerpted
-        assert "<output_file>" in notes[0]  # points at the .grasp log
+        assert "<log_file>" in notes[0]  # points at the .grasp log
         assert mgr._tasks == {}  # pyright: ignore[reportPrivateUsage]
 
         # The full, untruncated output is in the .grasp log (in the remote FS).
-        match = re.search(r"<output_file>(.+?)</output_file>", notes[0], re.DOTALL)
+        match = re.search(r"<log_file>(.+?)</log_file>", notes[0], re.DOTALL)
         assert match is not None
         log_text, _ = await env.file_backend.read_text(Path(match.group(1).strip()))
         assert log_text.count("A") == 5000

--- a/tests/sandbox/test_seatbelt.py
+++ b/tests/sandbox/test_seatbelt.py
@@ -442,11 +442,11 @@ async def test_seatbelt_background_large_result_excerpted(tmp_path: Path) -> Non
     assert len(notes) == 1
     assert "completed" in notes[0]
     assert "chars omitted" in notes[0]
-    assert "<output_file>" in notes[0]
+    assert "<log_file>" in notes[0]
     assert mgr._tasks == {}  # pyright: ignore[reportPrivateUsage]
 
     # The full, untruncated output is in the .grasp log the note points at.
-    match = re.search(r"<output_file>(.+?)</output_file>", notes[0], re.DOTALL)
+    match = re.search(r"<log_file>(.+?)</log_file>", notes[0], re.DOTALL)
     assert match is not None
     log_text, _ = await env.file_backend.read_text(Path(match.group(1).strip()))
     assert log_text.count("A") == 5000

--- a/tests/tui/test_console.py
+++ b/tests/tui/test_console.py
@@ -691,7 +691,7 @@ class TestMessageEvents:
             "<tool_name>Bash</tool_name>\n<status>interrupted</status>\n"
             "<ran_for>2s</ran_for>\n"
             "<error>\nSession restarted before completion\n</error>\n"
-            "<output_file>\n.grasp/tasks/x.log\n</output_file>\n"
+            "<log_file>\n.grasp/tasks/x.log\n</log_file>\n"
             "</task_notification>"
         )
         msg = InputMessageItem.from_text(text, role="user")
@@ -711,10 +711,15 @@ class TestMessageEvents:
 
     @pytest.mark.asyncio
     async def test_resume_framing_shown(self):
+        from grasp_agents.context.system_reminder import (
+            SESSION_RESUMED_SUBJECT,
+            wrap_in_system_reminder,
+        )
+
         ec, buf = _make_console()
-        text = (
-            "<session_resumed>\nSession resumed from a checkpoint — state was "
-            "reconstructed.\n</session_resumed>"
+        text = wrap_in_system_reminder(
+            "Session resumed from a checkpoint — state was reconstructed.",
+            subject=SESSION_RESUMED_SUBJECT,
         )
         msg = InputMessageItem.from_text(text, role="user")
         await _collect(ec, [UserMessageEvent(data=msg, source="agent", exec_id="c")])

--- a/uv.lock
+++ b/uv.lock
@@ -1181,7 +1181,7 @@ wheels = [
 
 [[package]]
 name = "grasp-agents"
-version = "1.0.18"
+version = "1.0.19"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
# Background tasks cleanup

A structural cleanup of the background-task plane (`agent/background_tasks.py`) plus the
rollback/restore machinery it pairs with. One real bug fixed, several naming and API
ambiguities resolved, model-facing guidance moved from per-note boilerplate into an
auto-attached system-prompt section, and the step-rollback protocol consolidated onto
`AgentContext`. Checkpoint schema bumped to v15. Version 1.0.19.

## Core refactor

- `background_tasks.py` reordered by task lifecycle (launch → progress → completion →
  delivery → rewind → resume), with dead surface removed (`BackgroundTaskManager.get()` /
  `remove()`).
- `BackgroundTask.task` → `consumer` (the asyncio task consuming the tool's stream, not
  the background work itself); `_result_of` → `_outcome_from_events`, returning an
  explicit `(result, error)` pair.
- Launch notifications now use the same XML `<task_notification>` block as completion
  notes (subject, task id, tool name/call id, status, optional `<log_file>`), replacing
  the ad-hoc prose note. `<output_file>` → `<log_file>`.

## Bug fixes

- **A failed task's persisted error could be clobbered at flush**: the deferred
  DELIVERED flip built in `drain` serialized the *result* into the error slot, so a
  failed task's record lost its error to a literal `"null"`. Fixed, with the flip shape
  now typed (below) so the slots can't silently swap again.
- `_save_record_outcome` passed raw status strings past validation (pydantic serializer
  warnings); it now uses `TaskStatus` enums.

## Model-facing guidance → system-prompt section

The waiting/log/kill guidance that used to be appended to every launch note is now an
auto-attached system-prompt section (`make_background_tasks_section`), registered by
`LLMAgent` unconditionally and rendered only when the live toolset actually has a
backgroundable tool. The toolset is read off the call's `AgentContext` at each run
entry, so tools wired after construction (e.g. by a multi-agent host) are picked up
automatically; the `KillTask` line renders only when that tool is attached. The section
documents that `<log_file>` is optional and how to handle `interrupted` notifications;
launch notes themselves are now metadata-only. The interrupted-task resume notice is
log-aware ("no output log" vs. "partial output is in the log file").

The resume framing note is now wrapped as
`<system-reminder subject="session resumed">`, with a shared
`match_system_reminder_subject` helper so UIs detect it structurally instead of by
substring.

## Typed deferred flips + naming rules

- Deferred record updates are now two `TypedDict`s — `TaskDeliveredFlip` and
  `TaskCancelledFlip` — with no `status` field: the status is implied by which deferred
  map an entry sits in and stamped at flush. Restores validate through pydantic
  `TypeAdapter`s (coercing older persisted shapes).
- **kill vs. cancel**: "kill" is the model-facing surface only (`KillTask` →
  `kill_task` → `KillTaskResult`); every framework-initiated stop and the terminal
  record status use "cancel(led)". Accordingly `deferred_killed` →
  `deferred_cancelled`.
- `TaskRecord.delivered_msg_count` → `note_transcript_pos`: the field is the completion
  note's 1-based transcript position (equal to the transcript length right after the
  note was appended), not a count of anything — the rewind comparison now reads
  literally (`note_transcript_pos > message_count` = "the note sits past the kept
  prefix").
- `flush_delivered` → `flush_flips` (it flushes both deferred maps; parallels the
  inbox's `flush_acks`).
- Resident naming unified on "answer": `NextStepResidentReply` /
  `NextStepForceResidentReply` → `NextStepResidentAnswer` /
  `NextStepForceResidentAnswer`, matching `AFTER_RESIDENT_ANSWER`.
- The magic inline-cap `8000` is now `_DEFAULT_INLINE_CAP`, shared by rebuilt completion
  notes and `KillTask` excerpts.

## Behavior: residents no longer wait on blocking tasks

`blocks_final_answer` now gates only a *bounded* run's final answer — answering ends
`run()` and would strand pending results. A resident's loop survives its answers and
wakes on task completions, so the gate bought nothing there while withholding **all**
replies behind one unfinished task (residents have no run deadline) and parking the
in-flight message leased. `decide_next_step`'s `wait_for_bg` now requires the inbox to
be closed.

## Restore / rollback consolidation

- **`AgentContext.rewind()`**: the context half of a step rollback (truncate transcript
  → export unflushed flips → `restore` → re-inject orphaned task notes → void consumed
  mail) moved out of `LLMAgent._rollback_to_step_unchecked` onto `AgentContext`, which
  owns all the state involved. `LLMAgent` keeps only the persisted-head / filesystem /
  crash-marker protocol. The "export flips before restore replaces them" hazard is now
  internal, and the mailbox void's dependence on the pre-rollback committed high-water
  is an explicit `committed_mail_seq` parameter instead of a temporal coupling.
- **`keep_deferred_delivered` flag deleted**: `restore` now decides per flip by note
  position — a live unflushed DELIVERED flip survives iff its note is still inside the
  kept transcript. The old flag could be misused to flush a DELIVERED status for a note
  the model no longer had, burying the outcome forever; the position rule makes that
  state unrepresentable. Behavior in both existing paths (settle, rollback) is
  unchanged.
- The CANCELLED keep-rule (all live flips survive — a cancellation is a physical fact no
  transcript boundary falsifies) is hoisted next to the DELIVERED rule in
  `AgentContext.restore`; both `restore_deferred_*` manager methods are now plain
  validated replaces whose post-state equals their argument.
- `redeliver_after`'s overlay parameter is now required and named
  `pre_restore_deferred_delivered` — the post-restore live map was never a valid
  substitute, and the old optional fallback silently produced an empty overlay.
- `AgentInbox` no longer exposes its transport: the only outside question was identity,
  now answered by `is_view_of(transport)`; session code reaches the transport via
  `SessionContext.transport`, the one canonical handle.

## Checkpoint schema v15

- `AgentCheckpoint` gained `stop_reason` (how the run that saved the head ended);
  `AFTER_FORCED_FINAL_ANSWER` collapsed into `AFTER_FINAL_ANSWER` (location names only
  the save-point; forced-ness lives in `stop_reason`).
- Persisted renames: `TaskRecord.delivered_msg_count` → `note_transcript_pos`,
  `AgentContextState.deferred_killed` → `deferred_cancelled`.
- Migration notes (also in `SCHEMA_VERSION_SUMMARIES`): v14 records load fine —
  `stop_reason` defaults `None`; a v14 DELIVERED task record loses its rewind horizon
  (rollbacks no longer re-inject its note); a v14 head's unflushed deferred flips are
  dropped; a head parked at `after_forced_final_answer` needs a rerun or resave.

## Tests

`tests/agent/test_background_tools.py` and `test_background_task_rewind.py` updated for
the new APIs, plus new coverage: the system-prompt section (absence/presence, `KillTask`
gating, post-construction tool changes reflected per run entry), metadata-only launch
notes, the restore keep-rules (`TestRestoreFlipPositionRule`: position-gated DELIVERED
flips, unconditional CANCELLED survival), the undeliver overlay, and resident answers no
longer suppressed by blocking tasks. Full suite: 2657 passed.
