### PR TITLE
Expose LLM error logs + optional durability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grasp_agents"
-version = "1.0.19"
+version = "1.0.20"
 description = "Grasp Agents Library"
 readme = "README.md"
 requires-python = ">=3.12,<4"

--- a/src/grasp_agents/agent/agent_loop.py
+++ b/src/grasp_agents/agent/agent_loop.py
@@ -54,6 +54,7 @@ from grasp_agents.types.llm_events import (
     ResponseCompleted,
     ResponseRetrying,
 )
+from grasp_agents.utils.errors import format_error_chain
 from grasp_agents.utils.streaming import stream_concurrent
 from grasp_agents.utils.validation import validate_obj_from_json_or_py_string
 
@@ -777,12 +778,15 @@ class AgentLoop[CtxT]:
                 for err in merged.errors:
                     i = immediate[err.index][0]
                     tool_name = immediate[err.index][2].name
-                    outputs[i] = f"Tool '{tool_name}' failed: {err.exception}"
+                    outputs[i] = (
+                        f"Tool '{tool_name}' failed: "
+                        f"{format_error_chain(err.exception)}"
+                    )
                     logger.warning(
-                        "Tool '%s' (call index %d) failed: %r",
+                        "Tool '%s' (call index %d) failed",
                         tool_name,
                         i,
-                        err.exception,
+                        exc_info=err.exception,
                     )
 
             # Collect backgroundable results — each already raced its own

--- a/src/grasp_agents/agent/background_tasks.py
+++ b/src/grasp_agents/agent/background_tasks.py
@@ -45,6 +45,7 @@ from grasp_agents.types.events import (
     UserMessageEvent,
 )
 from grasp_agents.types.items import FunctionToolCallItem, InputMessageItem
+from grasp_agents.utils.errors import format_error_chain
 
 from .llm_agent_transcript import LLMAgentTranscript
 from .task_progress import (
@@ -424,8 +425,10 @@ async def _consume(
         # The task errored (e.g. a sub-agent that could not resume). Record it as
         # a clean failure: don't leak a dangling task exception, and don't leave
         # a RUNNING record that a later resume would re-spawn forever.
-        logger.warning("Background task errored: %r", exc)
-        err = ToolErrorEvent(data=ToolErrorInfo(tool_name="", error=f"{exc}"))
+        logger.warning("Background task errored", exc_info=exc)
+        err = ToolErrorEvent(
+            data=ToolErrorInfo(tool_name="", error=format_error_chain(exc))
+        )
         events.append(err)
         error = err.data
 
@@ -545,6 +548,10 @@ class BackgroundTaskManager[CtxT]:
     ) -> None:
         self._agent_name = agent_name
 
+        # Stamped by the owning agent (with ``path``): False opts this
+        # agent's ``TaskRecord``s out of the checkpoint store.
+        self.durability_enabled: bool = True
+
         self._transcript = transcript
         self._tools = tools
         self._tasks: dict[str, BackgroundTask] = {}
@@ -625,7 +632,11 @@ class BackgroundTaskManager[CtxT]:
     def _task_store_key(self, ctx: SessionContext[CtxT], call_id: str) -> str | None:
         """Store key for a backgrounded call's ``TaskRecord`` (``None`` if none)."""
         child_path = make_tool_call_path(self.path, call_id)
-        if ctx.checkpoint_store is None or child_path is None:
+        if (
+            ctx.checkpoint_store is None
+            or child_path is None
+            or not self.durability_enabled
+        ):
             return None
         return make_store_key(ctx.session_key, CheckpointKind.TASK, child_path)
 

--- a/src/grasp_agents/agent/llm_agent.py
+++ b/src/grasp_agents/agent/llm_agent.py
@@ -201,6 +201,11 @@ class LLMAgent[InT, OutT, CtxT](
         tracing_enabled: bool = True,
         # Fields to exclude from tracing input events
         tracing_exclude_input_fields: set[str] | None = None,
+        # Durable persistence on/off (this agent and its descendants). When
+        # False, the agent writes nothing to the session's checkpoint store:
+        # no transcript log, no checkpoint heads, no task records — e.g. for
+        # throwaway replicas fanned out by a ParallelProcessor.
+        durability_enabled: bool = True,
     ) -> None:
         super().__init__(
             name=name,
@@ -210,6 +215,7 @@ class LLMAgent[InT, OutT, CtxT](
             path=path,
             tracing_enabled=tracing_enabled,
             tracing_exclude_input_fields=tracing_exclude_input_fields,
+            durability_enabled=durability_enabled,
         )
 
         # Session persistence
@@ -517,6 +523,7 @@ class LLMAgent[InT, OutT, CtxT](
             return
 
         self._agent_ctx.bg_tasks.path = self.path
+        self._agent_ctx.bg_tasks.durability_enabled = self.durability_enabled
         loop.path = self.path
         loop.ctx = self._ctx
 
@@ -847,7 +854,11 @@ class LLMAgent[InT, OutT, CtxT](
 
     def _fs_snapshot_due(self, location: AgentCheckpointLocation) -> bool:
         mode = self._ctx.fs_snapshot_policy
-        if mode == "off" or not self._is_session_writer():
+        if (
+            mode == "off"
+            or not self.durability_enabled
+            or not self._is_session_writer()
+        ):
             return False
 
         if not isinstance(self._ctx.environment, SnapshotCapable):
@@ -889,12 +900,15 @@ class LLMAgent[InT, OutT, CtxT](
         # boundary under ``"final"``); a cold resume detects that and injects
         # a filesystem-restored notice (see ``load_checkpoint``). Written by
         # the session's owner only (see ``_is_session_writer``).
-        if self._is_session_writer():
-            await self._ctx.save_checkpoint(fs_snapshot_ref=fs_snapshot_ref)
-        elif self._ctx.session_writer is None and self._ctx.session_record_enabled:
-            # Every agent is contained and none has claimed: the enabled
-            # session persistence is silently inert — say so, once.
-            self._ctx.warn_unowned_session_record()
+        if self.durability_enabled:
+            if self._is_session_writer():
+                await self._ctx.save_checkpoint(fs_snapshot_ref=fs_snapshot_ref)
+            elif (
+                self._ctx.session_writer is None and self._ctx.session_record_enabled
+            ):
+                # Every agent is contained and none has claimed: the enabled
+                # session persistence is silently inert — say so, once.
+                self._ctx.warn_unowned_session_record()
 
         agent_ctx_state = self._agent_ctx.snapshot()
         if fs_snapshot_ref is None:

--- a/src/grasp_agents/durability/checkpoint_mixin.py
+++ b/src/grasp_agents/durability/checkpoint_mixin.py
@@ -20,16 +20,24 @@ class CheckpointPersistMixin:
     Adds checkpoint key composition + load/save to a session-scoped object.
 
     Subclasses set ``_checkpoint_kind`` (``None`` disables persistence)
-    and maintain ``_path`` / ``_checkpoint_number``.
+    and maintain ``_path`` / ``_checkpoint_number``. Setting
+    ``durability_enabled`` to False opts the object out of the checkpoint
+    store entirely — every load/save below no-ops.
     """
 
     _checkpoint_kind: ClassVar[CheckpointKind | None] = None
+
+    durability_enabled: bool = True
 
     _path: list[str]
     _checkpoint_number: int
 
     def _checkpoint_store_key(self, ctx: SessionContext[Any]) -> str | None:
-        if ctx.checkpoint_store is None or self._checkpoint_kind is None:
+        if (
+            ctx.checkpoint_store is None
+            or self._checkpoint_kind is None
+            or not self.durability_enabled
+        ):
             return None
         return make_store_key(ctx.session_key, self._checkpoint_kind, self._path)
 

--- a/src/grasp_agents/processors/parallel_processor.py
+++ b/src/grasp_agents/processors/parallel_processor.py
@@ -10,6 +10,7 @@ from grasp_agents.types.events import Event, ProcPacketOutEvent, ProcPayloadOutE
 from grasp_agents.types.io import ProcName
 from grasp_agents.types.packet import Packet
 from grasp_agents.utils.callbacks import is_method_overridden
+from grasp_agents.utils.errors import format_error_chain
 from grasp_agents.utils.streaming import stream_concurrent
 
 from .processor import Processor
@@ -40,6 +41,7 @@ class ParallelProcessor[InT, OutT, CtxT](Processor[InT, OutT, CtxT]):
             path=path,
             tracing_enabled=subproc.tracing_enabled,
             tracing_exclude_input_fields=subproc.tracing_exclude_input_fields,
+            durability_enabled=subproc.durability_enabled,
         )
 
         self._in_type = subproc.in_type
@@ -241,7 +243,8 @@ class ParallelProcessor[InT, OutT, CtxT](Processor[InT, OutT, CtxT]):
                     # Failures must surface, not flow downstream as ``None``
                     # payloads; opting into ``drop_failed`` drops them instead.
                     detail = "; ".join(
-                        f"index {pending_indices[e.index]}: {e.exception!r}"
+                        f"index {pending_indices[e.index]}: "
+                        f"{format_error_chain(e.exception)}"
                         for e in merged.errors
                     )
                     raise ProcRunError(
@@ -260,6 +263,13 @@ class ParallelProcessor[InT, OutT, CtxT](Processor[InT, OutT, CtxT]):
                     len(all_in_args),
                     failed,
                 )
+                for e in merged.errors:
+                    logger.warning(
+                        "ParallelProcessor %s: dropped failed copy %d",
+                        self.name,
+                        pending_indices[e.index],
+                        exc_info=e.exception,
+                    )
 
         # Emit results in input order; failed copies are either raised above
         # (default) or dropped here (drop_failed=True), never ``None`` payloads.

--- a/src/grasp_agents/processors/processor.py
+++ b/src/grasp_agents/processors/processor.py
@@ -80,7 +80,9 @@ def with_retry[F: Callable[..., AsyncIterator[Event[Any]]]](func: F) -> F:
                     raise ProcRunError(
                         proc_name=self.name,
                         exec_id=exec_id,
-                        message=err_message + f" after {n_attempt - 1} retries",
+                        message=err_message
+                        + f" after {n_attempt - 1} retries"
+                        + f" (caused by {type(err).__name__})",
                     ) from err
 
                 logger.warning(
@@ -117,6 +119,7 @@ class Processor[InT, OutT, CtxT](
     recipients: Sequence[ProcName] | None
     tracing_enabled: bool
     tracing_exclude_input_fields: set[str] | None
+    durability_enabled: bool
 
     def __init__(
         self,
@@ -128,6 +131,7 @@ class Processor[InT, OutT, CtxT](
         path: list[str] | None = None,
         tracing_enabled: bool = True,
         tracing_exclude_input_fields: set[str] | None = None,
+        durability_enabled: bool = True,
     ) -> None:
         self._in_type: type[InT]
         self._out_type: type[OutT]
@@ -146,6 +150,7 @@ class Processor[InT, OutT, CtxT](
         self.recipients = recipients
         self.tracing_enabled = tracing_enabled
         self.tracing_exclude_input_fields = tracing_exclude_input_fields
+        self.durability_enabled = durability_enabled
 
         self._checkpoint_number: int = 0
         self._ctx: SessionContext[CtxT] = (
@@ -224,8 +229,11 @@ class Processor[InT, OutT, CtxT](
 
     @property
     def is_resumable(self) -> bool:
-        """True if the bound ``ctx`` has a checkpoint store wired up."""
-        return self._ctx.checkpoint_store is not None
+        """
+        True if the bound ``ctx`` has a checkpoint store wired up and this
+        processor participates in it (``durability_enabled``).
+        """
+        return self._ctx.checkpoint_store is not None and self.durability_enabled
 
     def on_adopted(
         self,
@@ -252,6 +260,7 @@ class Processor[InT, OutT, CtxT](
         """
         if parent is not None:
             self._inherit_tracing(parent)
+            self._inherit_durability(parent)
             if ctx is None:
                 ctx = getattr(parent, "ctx", None)
             if path is None:
@@ -286,6 +295,13 @@ class Processor[InT, OutT, CtxT](
             self.tracing_exclude_input_fields = (
                 self.tracing_exclude_input_fields or set()
             ) | set(parent_fields)
+
+    def _inherit_durability(self, parent: Any) -> None:
+        # Same downward restriction as tracing: a parent that opted out of
+        # the checkpoint store forces the same on every descendant (a child
+        # can't re-enable what an ancestor disabled).
+        if not getattr(parent, "durability_enabled", True):
+            self.durability_enabled = False
 
     def _propagate_to_children(self) -> None:
         """

--- a/src/grasp_agents/tools/base.py
+++ b/src/grasp_agents/tools/base.py
@@ -27,6 +27,7 @@ from grasp_agents.types.events import (
     ToolErrorInfo,
     ToolStreamEvent,
 )
+from grasp_agents.utils.errors import format_error_chain
 from grasp_agents.utils.generics import AutoInstanceAttributesMixin
 
 if TYPE_CHECKING:
@@ -154,6 +155,7 @@ class BaseTool[InT: BaseModel, OutT, CtxT](AutoInstanceAttributesMixin, ABC):
             self.untrusted_output = untrusted_output
         self.tracing_enabled = tracing_enabled
         self.tracing_exclude_input_fields = tracing_exclude_input_fields
+        self.durability_enabled = True
         self._llm_in_type: type[BaseModel] | None = None
 
     def on_adopted(self, parent: "Any") -> None:
@@ -161,9 +163,11 @@ class BaseTool[InT: BaseModel, OutT, CtxT](AutoInstanceAttributesMixin, ABC):
         Lifecycle hook fired when this tool is attached to a parent
         :class:`Processor`.
 
-        Inherits the parent's tracing settings (downward restriction): if the
-        parent disables tracing the tool's spans are disabled too, and a field
-        the parent masks stays masked in the tool's spans (union). Subclasses
+        Inherits the parent's tracing and durability settings (downward
+        restriction): if the parent disables tracing the tool's spans are
+        disabled too, a field the parent masks stays masked in the tool's
+        spans (union), and a parent that opted out of the checkpoint store
+        forces the same on any processor this tool dispatches. Subclasses
         like :class:`ProcessorTool` override to additionally forward adoption
         onto a wrapped processor.
         """
@@ -174,6 +178,8 @@ class BaseTool[InT: BaseModel, OutT, CtxT](AutoInstanceAttributesMixin, ABC):
             self.tracing_exclude_input_fields = (
                 self.tracing_exclude_input_fields or set()
             ) | set(parent_fields)
+        if not getattr(parent, "durability_enabled", True):
+            self.durability_enabled = False
 
     @property
     def in_type(self) -> type[InT]:
@@ -232,9 +238,11 @@ class BaseTool[InT: BaseModel, OutT, CtxT](AutoInstanceAttributesMixin, ABC):
     # --- Error handling ---
 
     def _on_error_impl(self, error: Exception) -> ToolErrorInfo:
-        logger.warning("Tool '%s' failed: %s", self.name, error)
+        logger.warning("Tool '%s' failed: %s", self.name, error, exc_info=error)
 
-        return ToolErrorInfo(tool_name=self.name, error=str(error), timed_out=False)
+        return ToolErrorInfo(
+            tool_name=self.name, error=format_error_chain(error), timed_out=False
+        )
 
     def _on_error(self, error: Exception) -> ToolErrorInfo:
         if isinstance(error, asyncio.TimeoutError):

--- a/src/grasp_agents/utils/errors.py
+++ b/src/grasp_agents/utils/errors.py
@@ -1,0 +1,22 @@
+__all__ = ["format_error_chain"]
+
+
+def format_error_chain(error: BaseException) -> str:
+    """
+    Format an exception together with its cause chain, which ``str()`` alone
+    drops — a wrapper error's string would otherwise hide the root cause.
+    """
+    parts: list[str] = []
+    seen: set[int] = set()
+    err: BaseException | None = error
+    while err is not None and id(err) not in seen:
+        seen.add(id(err))
+        text = str(err)
+        parts.append(f"{type(err).__name__}: {text}" if text else type(err).__name__)
+        if err.__cause__ is not None:
+            err = err.__cause__
+        elif not err.__suppress_context__:
+            err = err.__context__
+        else:
+            err = None
+    return "\nCaused by: ".join(parts)

--- a/src/grasp_agents/workflow/looped_workflow.py
+++ b/src/grasp_agents/workflow/looped_workflow.py
@@ -30,6 +30,7 @@ class LoopedWorkflow[InT, OutT, CtxT](WorkflowProcessor[InT, OutT, CtxT]):
         path: list[str] | None = None,
         tracing_enabled: bool = True,
         tracing_exclude_input_fields: set[str] | None = None,
+        durability_enabled: bool = True,
     ) -> None:
         super().__init__(
             subprocs=subprocs,
@@ -41,6 +42,7 @@ class LoopedWorkflow[InT, OutT, CtxT](WorkflowProcessor[InT, OutT, CtxT]):
             path=path,
             tracing_enabled=tracing_enabled,
             tracing_exclude_input_fields=tracing_exclude_input_fields,
+            durability_enabled=durability_enabled,
         )
 
         for prev_proc, proc in pairwise(subprocs):

--- a/src/grasp_agents/workflow/sequential_workflow.py
+++ b/src/grasp_agents/workflow/sequential_workflow.py
@@ -26,6 +26,7 @@ class SequentialWorkflow[InT, OutT, CtxT](WorkflowProcessor[InT, OutT, CtxT]):
         path: list[str] | None = None,
         tracing_enabled: bool = True,
         tracing_exclude_input_fields: set[str] | None = None,
+        durability_enabled: bool = True,
     ) -> None:
         super().__init__(
             subprocs=subprocs,
@@ -37,6 +38,7 @@ class SequentialWorkflow[InT, OutT, CtxT](WorkflowProcessor[InT, OutT, CtxT]):
             path=path,
             tracing_enabled=tracing_enabled,
             tracing_exclude_input_fields=tracing_exclude_input_fields,
+            durability_enabled=durability_enabled,
         )
 
         for prev_proc, proc in pairwise(subprocs):

--- a/src/grasp_agents/workflow/workflow_processor.py
+++ b/src/grasp_agents/workflow/workflow_processor.py
@@ -31,6 +31,7 @@ class WorkflowProcessor[InT, OutT, CtxT](Processor[InT, OutT, CtxT], ABC):
         path: list[str] | None = None,
         tracing_enabled: bool = True,
         tracing_exclude_input_fields: set[str] | None = None,
+        durability_enabled: bool = True,
     ) -> None:
         if len(subprocs) < 2:
             raise WorkflowConstructionError("At least two subprocessors are required")
@@ -72,6 +73,7 @@ class WorkflowProcessor[InT, OutT, CtxT](Processor[InT, OutT, CtxT], ABC):
             path=path,
             tracing_enabled=tracing_enabled,
             tracing_exclude_input_fields=tracing_exclude_input_fields,
+            durability_enabled=durability_enabled,
         )
 
         self._in_type = start_proc.in_type

--- a/tests/durability/test_durability_opt_out.py
+++ b/tests/durability/test_durability_opt_out.py
@@ -1,0 +1,200 @@
+"""
+Selective persistence opt-out: ``durability_enabled=False`` on a processor
+keeps it (and everything it contains or dispatches) out of the checkpoint
+store — e.g. throwaway replicas fanned out by a ParallelProcessor.
+"""
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from grasp_agents.agent.llm_agent import LLMAgent
+from grasp_agents.durability import InMemoryCheckpointStore
+from grasp_agents.processors.parallel_processor import ParallelProcessor
+from grasp_agents.processors.processor import Processor
+from grasp_agents.session_context import SessionContext
+from grasp_agents.types.events import Event, ProcPayloadOutEvent
+from grasp_agents.workflow.sequential_workflow import SequentialWorkflow
+from tests._helpers import MockLLM, _text_response
+
+
+class AppendProcessor(Processor[str, str, None]):
+    def __init__(self, name: str, **kwargs: Any) -> None:
+        super().__init__(name=name, **kwargs)
+
+    async def _process_stream(
+        self,
+        chat_inputs: Any | None = None,
+        *,
+        in_args: list[str] | None = None,
+        exec_id: str,
+        step: int | None = None,
+    ) -> AsyncIterator[Event[Any]]:
+        for inp in in_args or []:
+            yield ProcPayloadOutEvent(
+                data=f"{inp}->{self.name}", source=self.name, exec_id=exec_id
+            )
+
+
+def _make_agent(
+    name: str,
+    responses: list[Any],
+    *,
+    ctx: SessionContext[None] | None = None,
+    **agent_kwargs: Any,
+) -> LLMAgent[str, str, None]:
+    return LLMAgent[str, str, None](
+        name,
+        ctx=ctx,
+        llm=MockLLM(responses_queue=responses),
+        **agent_kwargs,
+    )
+
+
+class TestAgentOptOut:
+    @pytest.mark.asyncio
+    async def test_disabled_agent_writes_nothing(self) -> None:
+        store = InMemoryCheckpointStore()
+        ctx: SessionContext[None] = SessionContext(
+            checkpoint_store=store, session_key="s1"
+        )
+        agent = _make_agent(
+            "worker", [_text_response("ok")], ctx=ctx, durability_enabled=False
+        )
+        out = await agent.run("hi")
+
+        assert out.payloads[0] == "ok"
+        assert store._data == {}
+        assert store._logs == {}
+
+    @pytest.mark.asyncio
+    async def test_enabled_agent_writes(self) -> None:
+        store = InMemoryCheckpointStore()
+        ctx: SessionContext[None] = SessionContext(
+            checkpoint_store=store, session_key="s2"
+        )
+        agent = _make_agent("worker", [_text_response("ok")], ctx=ctx)
+        await agent.run("hi")
+
+        assert any("/agent/" in key for key in store._data)
+
+    @pytest.mark.asyncio
+    async def test_disabled_agent_does_not_resume(self) -> None:
+        """A persisted session is invisible once durability is off."""
+        store = InMemoryCheckpointStore()
+        ctx1: SessionContext[None] = SessionContext(
+            checkpoint_store=store, session_key="s3"
+        )
+        agent1 = _make_agent("worker", [_text_response("answer")], ctx=ctx1)
+        await agent1.run("question")
+        assert await agent1.has_checkpoint(ctx1)
+
+        ctx2: SessionContext[None] = SessionContext(
+            checkpoint_store=store, session_key="s3"
+        )
+        agent2 = _make_agent("worker", [], ctx=ctx2, durability_enabled=False)
+        assert not agent2.is_resumable
+        assert not await agent2.has_checkpoint(ctx2)
+
+
+class TestParallelFanOut:
+    @pytest.mark.asyncio
+    async def test_disabled_replicas_write_nothing(self) -> None:
+        store = InMemoryCheckpointStore()
+        # Replicas share the template's LLM (and so its queue): one response each.
+        template = _make_agent(
+            "worker", [_text_response("done")] * 3, durability_enabled=False
+        )
+        par = ParallelProcessor[str, str, None](subproc=template)
+        assert par.durability_enabled is False  # mirrored from the subproc
+
+        ctx: SessionContext[None] = SessionContext(
+            checkpoint_store=store, session_key="par-off"
+        )
+        par.on_adopted(ctx=ctx)
+        out = await par.run(in_args=["a", "b", "c"])
+
+        assert len(out.payloads) == 3
+        assert store._data == {}
+        assert store._logs == {}
+
+    @pytest.mark.asyncio
+    async def test_enabled_replicas_write(self) -> None:
+        store = InMemoryCheckpointStore()
+        template = _make_agent("worker", [_text_response("done")] * 2)
+        par = ParallelProcessor[str, str, None](subproc=template)
+        ctx: SessionContext[None] = SessionContext(
+            checkpoint_store=store, session_key="par-on"
+        )
+        par.on_adopted(ctx=ctx)
+        await par.run(in_args=["a", "b"])
+
+        assert any("/parallel/" in key for key in store._data)
+        assert any("/agent/" in key for key in store._data)
+
+
+class TestDownwardCascade:
+    def test_container_disables_descendants(self) -> None:
+        a = AppendProcessor("A")
+        b = AppendProcessor("B")
+        wf = SequentialWorkflow[str, str, None](
+            name="wf", subprocs=[a, b], durability_enabled=False
+        )
+        assert wf.durability_enabled is False
+        assert a.durability_enabled is False
+        assert b.durability_enabled is False
+
+    def test_child_cannot_reenable(self) -> None:
+        disabled_parent = AppendProcessor("P", durability_enabled=False)
+        child = AppendProcessor("C")
+        child.on_adopted(disabled_parent)
+        assert child.durability_enabled is False
+
+        enabled_parent = AppendProcessor("P2")
+        opted_out_child = AppendProcessor("C2", durability_enabled=False)
+        opted_out_child.on_adopted(enabled_parent)
+        assert opted_out_child.durability_enabled is False
+
+
+class _TaskInput(BaseModel):
+    text: str
+
+
+class TestToolConduit:
+    def test_as_tool_inherits_host_opt_out(self) -> None:
+        sub = LLMAgent[_TaskInput, str, None]("sub", llm=MockLLM(responses_queue=[]))
+        tool = sub.as_tool(tool_name="Sub", tool_description="d")
+        host = _make_agent("host", [], tools=[tool], durability_enabled=False)
+
+        assert tool.durability_enabled is False
+        assert tool.processor.durability_enabled is False
+        clone = tool._resolve_processor(ctx=host.ctx, path=["host", "c1", "Sub"])
+        assert clone.durability_enabled is False
+
+    def test_disabled_subproc_stays_disabled_under_enabled_host(self) -> None:
+        sub = LLMAgent[_TaskInput, str, None](
+            "sub", llm=MockLLM(responses_queue=[]), durability_enabled=False
+        )
+        tool = sub.as_tool(tool_name="Sub", tool_description="d")
+        host = _make_agent("host", [], tools=[tool])
+
+        assert host.durability_enabled is True
+        assert tool.processor.durability_enabled is False
+        clone = tool._resolve_processor(ctx=host.ctx, path=["host", "c1", "Sub"])
+        assert clone.durability_enabled is False
+
+
+class TestTaskRecordGate:
+    def test_bg_task_store_key_gated(self) -> None:
+        store = InMemoryCheckpointStore()
+        ctx: SessionContext[None] = SessionContext(
+            checkpoint_store=store, session_key="bg"
+        )
+        disabled = _make_agent("a", [], ctx=ctx, durability_enabled=False)
+        assert disabled.agent_ctx.bg_tasks.durability_enabled is False
+        assert disabled.agent_ctx.bg_tasks._task_store_key(ctx, "call_1") is None
+
+        enabled = _make_agent("b", [], ctx=ctx)
+        assert enabled.agent_ctx.bg_tasks._task_store_key(ctx, "call_1") is not None

--- a/tests/test_utils_errors.py
+++ b/tests/test_utils_errors.py
@@ -1,0 +1,85 @@
+import pytest
+
+from grasp_agents.utils.errors import format_error_chain
+
+
+def _raise_root() -> None:
+    msg = "bad request"
+    raise ValueError(msg)
+
+
+def _raise_wrapped() -> None:
+    try:
+        _raise_root()
+    except ValueError as err:
+        msg = "run failed"
+        raise RuntimeError(msg) from err
+
+
+def test_single_error() -> None:
+    assert format_error_chain(ValueError("boom")) == "ValueError: boom"
+
+
+def test_empty_message_shows_type_only() -> None:
+    assert format_error_chain(ValueError()) == "ValueError"
+
+
+def test_explicit_cause_chain() -> None:
+    with pytest.raises(RuntimeError) as exc_info:
+        _raise_wrapped()
+    assert format_error_chain(exc_info.value) == (
+        "RuntimeError: run failed\nCaused by: ValueError: bad request"
+    )
+
+
+def test_three_level_chain() -> None:
+    def raise_outer() -> None:
+        try:
+            _raise_wrapped()
+        except RuntimeError as err:
+            msg = "outer"
+            raise OSError(msg) from err
+
+    with pytest.raises(OSError) as exc_info:
+        raise_outer()
+    assert format_error_chain(exc_info.value) == (
+        "OSError: outer"
+        "\nCaused by: RuntimeError: run failed"
+        "\nCaused by: ValueError: bad request"
+    )
+
+
+def test_implicit_context_is_included() -> None:
+    def raise_during_handling() -> None:
+        try:
+            _raise_root()
+        except ValueError:
+            msg = "during handling"
+            raise RuntimeError(msg)  # noqa: B904 — implicit context is the point
+
+    with pytest.raises(RuntimeError) as exc_info:
+        raise_during_handling()
+    assert format_error_chain(exc_info.value) == (
+        "RuntimeError: during handling\nCaused by: ValueError: bad request"
+    )
+
+
+def test_suppressed_context_is_excluded() -> None:
+    def raise_clean() -> None:
+        try:
+            _raise_root()
+        except ValueError:
+            msg = "clean"
+            raise RuntimeError(msg) from None
+
+    with pytest.raises(RuntimeError) as exc_info:
+        raise_clean()
+    assert format_error_chain(exc_info.value) == "RuntimeError: clean"
+
+
+def test_cyclic_chain_terminates() -> None:
+    a = ValueError("a")
+    b = RuntimeError("b")
+    a.__cause__ = b
+    b.__cause__ = a
+    assert format_error_chain(a) == "ValueError: a\nCaused by: RuntimeError: b"

--- a/tests/tools/test_tool_errors.py
+++ b/tests/tools/test_tool_errors.py
@@ -1,7 +1,7 @@
 """Tool error handling: timeout, on_error hook, concurrent failure isolation."""
 
 import asyncio
-from typing import Any
+from typing import Any, NoReturn
 
 import pytest
 from pydantic import BaseModel
@@ -51,6 +51,33 @@ class FailingTool(BaseTool[AddInput, int, Any]):
     ) -> int:
         msg = "Intentional failure"
         raise RuntimeError(msg)
+
+
+class ChainedFailureTool(BaseTool[AddInput, int, Any]):
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(
+            name="chained", description="Fails with a cause chain", **kwargs
+        )
+
+    async def _run(
+        self,
+        inp: AddInput,
+        *,
+        ctx: SessionContext[Any] | None = None,
+        exec_id: str | None = None,
+        progress_callback: ToolProgressCallback | None = None,
+        path: list[str] | None = None,
+        agent_ctx: Any = None,
+    ) -> int:
+        def boom() -> NoReturn:
+            msg = "bad request"
+            raise ValueError(msg)
+
+        try:
+            boom()
+        except ValueError as err:
+            msg = "run failed"
+            raise RuntimeError(msg) from err
 
 
 class SlowTool(BaseTool[AddInput, int, Any]):
@@ -146,6 +173,15 @@ class TestToolErrorHandling:
         assert result.timed_out is True
         assert "Timed out" in result.error
         assert "0.01s" in result.error
+
+    @pytest.mark.asyncio
+    async def test_error_info_includes_cause_chain(self) -> None:
+        """A wrapper error's root cause survives into ToolErrorInfo.error."""
+        tool = ChainedFailureTool()
+        result = await tool(a=1, b=2)
+        assert isinstance(result, ToolErrorInfo)
+        assert "run failed" in result.error
+        assert "Caused by: ValueError: bad request" in result.error
 
     @pytest.mark.asyncio
     async def test_no_timeout_waits_normally(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1181,7 +1181,7 @@ wheels = [
 
 [[package]]
 name = "grasp-agents"
-version = "1.0.19"
+version = "1.0.20"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
# Surface root-cause errors + selective persistence opt-out

## Expose underlying errors in logs and tool results

A terminal LLM error (e.g. a non-retryable 400) was visible in traces but never
reached the logs: no layer logged it on the way up, and the places that swallow
exceptions (tool failures, background tasks, dropped parallel copies) logged only
`str()`/`repr()` of the wrapper — losing the `__cause__` chain. The agent saw the
same opaque `Processor run failed [...]` string in its tool results.

Policy applied: **a layer that swallows or translates an exception logs it with
`exc_info`; layers that re-raise don't log** — every failure is recorded exactly
once, with its full chain, where it stops propagating.

- New `utils/errors.py: format_error_chain()` — renders an exception with its
  `__cause__` / unsuppressed `__context__` chain (cycle-safe).
- `BaseTool._on_error_impl` logs with `exc_info` and puts the chain into the
  model-facing `ToolErrorInfo.error`, so the agent can react to the real cause.
- Same treatment for agent-loop tool-batch failures, background-task errors, and
  `ParallelProcessor` (chain-formatted raise detail; each dropped copy now logs
  its traceback instead of vanishing).
- Terminal `ProcRunError`s name their root cause: `... after 0 retries (caused by
  LlmBadRequestError)`.

## `durability_enabled`: opt a processor (and its descendants) out of persistence

Fanning out tens of replicas via a `ParallelProcessor` produced a durable write
per replica per boundary. New `durability_enabled: bool = True` ctor flag on
`Processor` / `LLMAgent` / workflows lets a subtree opt out entirely:

- Single gate in `CheckpointPersistMixin._checkpoint_store_key`: when disabled,
  all checkpoint heads, transcript logs, task records, session records, fs
  snapshots, and resume reads no-op. Disabled = the durability plane is
  invisible (`is_resumable` is False).
- Cascades downward exactly like `tracing_enabled`: containers, `.as_tool()`
  dispatch clones, and parallel replicas inherit it; a child can't re-enable
  under a disabled ancestor. `ParallelProcessor` mirrors its subproc's flag.
- Task records follow the *owning* agent: a durable coordinator that backgrounds
  a non-durable sub-agent still records the task; on resume the child
  cold-restarts from the spawning input.

## Tests

- `tests/test_utils_errors.py` — chain-formatting semantics.
- `tests/tools/test_tool_errors.py` — root cause survives into tool results.
- `tests/durability/test_durability_opt_out.py` — no store writes from disabled
  agents / parallel fan-outs (with enabled controls), cascade and re-enable
  rules, tool-conduit inheritance, task-record gating.

Full suite: 2675 passed. Pyright clean on `src/`.
