### PR TITLE
robustness fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grasp_agents"
-version = "1.0.20"
+version = "1.0.21"
 description = "Grasp Agents Library"
 readme = "README.md"
 requires-python = ">=3.12,<4"

--- a/src/grasp_agents/agent/llm_agent.py
+++ b/src/grasp_agents/agent/llm_agent.py
@@ -234,6 +234,12 @@ class LLMAgent[InT, OutT, CtxT](
         # re-memorizing the input. Consumed at the next stream entry.
         self._retry_continuation: bool = False
 
+        # True while the session is parked by a rollback (set on rollback and
+        # on loading a ``ROLLED_BACK`` head): the parked step's input was
+        # discarded, so only a fresh delivery may enter — a no-input resume
+        # would generate with nothing to respond to.
+        self._parked_after_rollback: bool = False
+
         # True while a run's stream is live — the window ``rollback_to_step``
         # refuses (rewinding under the loop would race the turn cycle).
         self._run_active: bool = False
@@ -750,6 +756,7 @@ class LLMAgent[InT, OutT, CtxT](
             # Restore the parked step, so the next chat delivery re-mints it
             # (the mint floor) exactly as it would in the rolling-back process.
             self._step = current.step
+            self._parked_after_rollback = True
 
         logger.info(
             "Loaded session %s for agent %s "
@@ -903,9 +910,7 @@ class LLMAgent[InT, OutT, CtxT](
         if self.durability_enabled:
             if self._is_session_writer():
                 await self._ctx.save_checkpoint(fs_snapshot_ref=fs_snapshot_ref)
-            elif (
-                self._ctx.session_writer is None and self._ctx.session_record_enabled
-            ):
+            elif self._ctx.session_writer is None and self._ctx.session_record_enabled:
                 # Every agent is contained and none has claimed: the enabled
                 # session persistence is silently inert — say so, once.
                 self._ctx.warn_unowned_session_record()
@@ -1042,7 +1047,9 @@ class LLMAgent[InT, OutT, CtxT](
         Truncates the transcript and its durable log to ``step``'s boundary
         and reapplies the state captured there; afterwards the agent is
         parked at ``step`` with a ``ROLLED_BACK`` head, so ``run(step=step)``
-        is a fresh delivery, not a cached one.
+        is a fresh delivery, not a cached one. The parked step's input was
+        discarded with it, so a no-input resume is rejected until the step is
+        re-delivered.
 
         A boundary carrying an ``fs_snapshot_ref`` also restores the
         *session-shared* filesystem (crash-safe via
@@ -1147,6 +1154,7 @@ class LLMAgent[InT, OutT, CtxT](
 
         # Parked at the start of ``step``, ready to (re)deliver it.
         self._step = step
+        self._parked_after_rollback = True
 
         # The step's anchor boundary was just destroyed — invalidate the memo
         # so the human's next (replacement) message re-mints and
@@ -1346,8 +1354,9 @@ class LLMAgent[InT, OutT, CtxT](
         The boundary is archived before the input lands, so a rewind returns
         to the prior steps' conversation with no input yet (the header, being
         ephemeral, is never lost with it). Returns the appended input (as a
-        one-item list, empty when the entry carries none) for the run to
-        surface as an event.
+        one-item list) for the run to surface as an event; a delivery that
+        renders no input message is rejected — the step would have nothing to
+        respond to.
 
         Runs outside the run's settle guard: everything fallible (input
         rendering, attachments) happens before the first mutation, so a
@@ -1371,6 +1380,18 @@ class LLMAgent[InT, OutT, CtxT](
                 source=self._current_input_source,
             )
 
+        if input_message is None:
+            raise ProcInputValidationError(
+                proc_name=self.name,
+                exec_id=exec_id,
+                message=(
+                    "A new step was delivered without an input: no chat "
+                    "inputs or input arguments were given, and the agent "
+                    "renders no input message. Deliver the input, or resume "
+                    "the session with no step."
+                ),
+            )
+
         # No mutations above this line.
         if self.reset_transcript_on_run:
             # A reset run starts a new conversation: drop the log (the system
@@ -1380,13 +1401,11 @@ class LLMAgent[InT, OutT, CtxT](
 
         self._archive_step_boundary()
         self._loop.turn = 0
+        self._parked_after_rollback = False
 
-        exposed: list[InputItem] = []
-        if input_message:
-            self.transcript.update([input_message])
-            exposed.append(input_message)
+        self.transcript.update([input_message])
 
-        return exposed
+        return [input_message]
 
     async def _process_stream(
         self,
@@ -1445,6 +1464,17 @@ class LLMAgent[InT, OutT, CtxT](
                 message=(
                     "No inputs were provided and there is no session "
                     "(checkpoint or live transcript) to resume."
+                ),
+            )
+
+        if not resident and pure_resume and self._parked_after_rollback:
+            raise ProcInputValidationError(
+                proc_name=self.name,
+                exec_id=exec_id,
+                message=(
+                    f"The session is parked by a rollback at step {self._step} "
+                    "and holds no input for it; re-deliver the step with its "
+                    f"input: run(..., step={self._step})."
                 ),
             )
 

--- a/src/grasp_agents/llm/fallback_llm.py
+++ b/src/grasp_agents/llm/fallback_llm.py
@@ -9,13 +9,39 @@ from pydantic import BaseModel
 
 from grasp_agents.tools.base import BaseTool, ToolChoice
 from grasp_agents.types.items import InputItem
-from grasp_agents.types.llm_errors import LlmErrorTuple
+from grasp_agents.types.llm_errors import LlmErrorTuple, LlmRateLimitError
 from grasp_agents.types.llm_events import LlmEvent, ResponseCompleted, ResponseFallback
+from grasp_agents.types.recovery import classify_error, is_retryable
 from grasp_agents.types.response import Response
 
 from .llm import LLM
 
 logger = logging.getLogger(__name__)
+
+
+def _select_cascade_error(errors: Sequence[Exception]) -> Exception:
+    """
+    Choose the error a fully-failed cascade pass raises.
+
+    The outer retry layer keys on this error, and a retry pass needs only
+    one member healthy — so prefer a retryable member error, ensuring the
+    cascade is retried whenever *any* member failed retryably, not just
+    when the last one did. Among retryable errors, prefer one without a
+    server-imposed backoff floor (shortest wait wins); among floored rate
+    limits, the smallest ``retry_after``.
+    """
+    retryable = [e for e in errors if is_retryable(classify_error(e))]
+    if not retryable:
+        return errors[-1]
+    no_floor = [
+        e for e in retryable if not (isinstance(e, LlmRateLimitError) and e.retry_after)
+    ]
+    if no_floor:
+        return no_floor[0]
+    return min(
+        (e for e in retryable if isinstance(e, LlmRateLimitError)),
+        key=lambda e: e.retry_after or 0.0,
+    )
 
 
 @dataclass(frozen=True)
@@ -26,6 +52,9 @@ class FallbackLLM(LLM):
     The public ``generate_response(_stream)`` entrypoints validate and retry
     (per this instance's ``retry_policy``) around the whole cascade; member
     retry policies are bypassed — the cascade itself is the API-retry layer.
+    A pass where every member fails raises the member error most worth
+    retrying, so one member's deterministic failure (e.g. a misconfigured
+    fallback) cannot mask another's transient error.
     ``model_name`` defaults to the primary's and is used for logging, cost
     attribution and context-budget resolution. ``llm_settings`` is inert
     here: settings live on the member LLMs.
@@ -49,7 +78,7 @@ class FallbackLLM(LLM):
         **extra_llm_settings: Any,
     ) -> Response:
         candidates = [self.primary, *self.fallbacks]
-        last_error: Exception | None = None
+        errors: list[Exception] = []
 
         for llm in candidates:
             try:
@@ -68,7 +97,7 @@ class FallbackLLM(LLM):
                 llm._stamp_cost(response)  # noqa: SLF001
                 return response
             except LlmErrorTuple as e:
-                last_error = e
+                errors.append(e)
                 logger.warning(
                     "Model %s failed (%s: %s), trying next fallback",
                     llm.model_name,
@@ -76,8 +105,8 @@ class FallbackLLM(LLM):
                     e,
                 )
 
-        assert last_error is not None
-        raise last_error
+        assert errors
+        raise _select_cascade_error(errors)
 
     async def _generate_response_stream_once(
         self,
@@ -89,7 +118,7 @@ class FallbackLLM(LLM):
         **extra_llm_settings: Any,
     ) -> AsyncIterator[LlmEvent]:
         candidates = [self.primary, *self.fallbacks]
-        last_error: Exception | None = None
+        errors: list[Exception] = []
         seq = 0
         attempt = 0
 
@@ -109,7 +138,7 @@ class FallbackLLM(LLM):
                 return
 
             except LlmErrorTuple as e:
-                last_error = e
+                errors.append(e)
                 attempt += 1
 
                 idx = candidates.index(llm)
@@ -132,5 +161,5 @@ class FallbackLLM(LLM):
                     e,
                 )
 
-        assert last_error is not None
-        raise last_error
+        assert errors
+        raise _select_cascade_error(errors)

--- a/src/grasp_agents/processors/parallel_processor.py
+++ b/src/grasp_agents/processors/parallel_processor.py
@@ -1,21 +1,31 @@
 import logging
 from collections.abc import AsyncIterator, Sequence
 from itertools import chain
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 from grasp_agents.durability.checkpoints import CheckpointKind, ParallelCheckpoint
 from grasp_agents.session_context import SessionContext
 from grasp_agents.types.errors import ProcInputValidationError, ProcRunError
 from grasp_agents.types.events import Event, ProcPacketOutEvent, ProcPayloadOutEvent
 from grasp_agents.types.io import ProcName
-from grasp_agents.types.packet import Packet
+from grasp_agents.types.packet import BranchError, Packet
 from grasp_agents.utils.callbacks import is_method_overridden
-from grasp_agents.utils.errors import format_error_chain
+from grasp_agents.utils.errors import format_error_chain, root_cause
 from grasp_agents.utils.streaming import stream_concurrent
 
 from .processor import Processor
 
 logger = logging.getLogger(__name__)
+
+type OnError = Literal["raise", "drop", "keep"]
+"""How a fan-out reacts to a failed branch:
+
+- ``"raise"`` — fail the whole run on the first failed branch (default).
+- ``"drop"`` — drop failed branches; successful payloads are emitted compactly.
+- ``"keep"`` — keep a ``None`` at each failed slot so payloads stay aligned to
+  the inputs; the output packet's ``failed`` maps the failed indices to their
+  :class:`BranchError`.
+"""
 
 
 class ParallelProcessor[InT, OutT, CtxT](Processor[InT, OutT, CtxT]):
@@ -26,7 +36,8 @@ class ParallelProcessor[InT, OutT, CtxT](Processor[InT, OutT, CtxT]):
         subproc: Processor[InT, OutT, CtxT],
         *,
         ctx: SessionContext[CtxT] | None = None,
-        drop_failed: bool = False,
+        on_error: OnError | None = None,
+        drop_failed: bool | None = None,
         path: list[str] | None = None,
     ) -> None:
         # Need to set _subproc before __init__ because it
@@ -47,7 +58,23 @@ class ParallelProcessor[InT, OutT, CtxT](Processor[InT, OutT, CtxT]):
         self._in_type = subproc.in_type
         self._out_type = subproc.out_type
 
-        self._drop_failed = drop_failed
+        self._on_error: OnError = self._resolve_on_error(on_error, drop_failed)
+        self._keep_failed: dict[int, BranchError] = {}
+
+    @staticmethod
+    def _resolve_on_error(
+        on_error: OnError | None, drop_failed: bool | None
+    ) -> OnError:
+        if on_error is not None and drop_failed is not None:
+            raise ValueError(
+                "Pass on_error or drop_failed, not both (drop_failed is deprecated: "
+                "False -> on_error='raise', True -> on_error='drop')."
+            )
+        if on_error is not None:
+            return on_error
+        if drop_failed:
+            return "drop"
+        return "raise"
 
     # --- Checkpointing ---
 
@@ -95,8 +122,12 @@ class ParallelProcessor[InT, OutT, CtxT](Processor[InT, OutT, CtxT]):
         return self._subproc
 
     @property
+    def on_error(self) -> OnError:
+        return self._on_error
+
+    @property
     def drop_failed(self) -> bool:
-        return self._drop_failed
+        return self._on_error == "drop"
 
     def select_recipients_impl(
         self, output: OutT, *, exec_id: str
@@ -152,6 +183,32 @@ class ParallelProcessor[InT, OutT, CtxT](Processor[InT, OutT, CtxT]):
             )
         )
 
+    def _build_packet(self, outputs: list[OutT], exec_id: str) -> Packet[OutT]:
+        if self._on_error != "keep":
+            return super()._build_packet(outputs, exec_id)
+
+        for output in outputs:
+            self.validate_output(output, exec_id=exec_id)
+
+        routing: list[Sequence[ProcName]] | None = None
+        if self.recipients is not None:
+            routing = []
+            for output in outputs:
+                # A failed (None) slot routes nowhere; successes route as usual.
+                recipients: Sequence[ProcName] = (
+                    self.select_recipients(output=output, exec_id=exec_id)
+                    if output is not None
+                    else []
+                )
+                routing.append(recipients)
+
+        return Packet(
+            sender=self.name,
+            payloads=outputs,
+            routing=routing,
+            failed=self._keep_failed,
+        )
+
     async def _process_stream(
         self,
         chat_inputs: Any | None = None,
@@ -160,6 +217,8 @@ class ParallelProcessor[InT, OutT, CtxT](Processor[InT, OutT, CtxT]):
         exec_id: str,
         step: int | None = None,  # noqa: ARG002
     ) -> AsyncIterator[Event[Any]]:
+        self._keep_failed = {}
+
         # --- Resume from checkpoint ---
         checkpoint = await self.load_checkpoint()
         completed_map: dict[int, Packet[Any]] = {}
@@ -239,9 +298,7 @@ class ParallelProcessor[InT, OutT, CtxT](Processor[InT, OutT, CtxT]):
 
             if merged.errors:
                 failed = [pending_indices[e.index] for e in merged.errors]
-                if not self.drop_failed:
-                    # Failures must surface, not flow downstream as ``None``
-                    # payloads; opting into ``drop_failed`` drops them instead.
+                if self._on_error == "raise":
                     detail = "; ".join(
                         f"index {pending_indices[e.index]}: "
                         f"{format_error_chain(e.exception)}"
@@ -253,9 +310,11 @@ class ParallelProcessor[InT, OutT, CtxT](Processor[InT, OutT, CtxT]):
                         message=(
                             f"{len(merged.errors)}/{len(all_in_args)} parallel "
                             f"copies of '{self._subproc.name}' failed ({detail}). "
-                            "Set drop_failed=True to drop failed copies instead."
+                            "Set on_error='drop' to drop failed copies, or "
+                            "on_error='keep' to keep them as aligned None payloads."
                         ),
                     ) from merged.errors[0].exception
+
                 logger.warning(
                     "ParallelProcessor %s: %d/%d copies failed (indices %s)",
                     self.name,
@@ -265,19 +324,28 @@ class ParallelProcessor[InT, OutT, CtxT](Processor[InT, OutT, CtxT]):
                 )
                 for e in merged.errors:
                     logger.warning(
-                        "ParallelProcessor %s: dropped failed copy %d",
+                        "ParallelProcessor %s: %s failed copy %d",
                         self.name,
+                        "keeping" if self._on_error == "keep" else "dropped",
                         pending_indices[e.index],
                         exc_info=e.exception,
                     )
 
-        # Emit results in input order; failed copies are either raised above
-        # (default) or dropped here (drop_failed=True), never ``None`` payloads.
-        out_packets = [
-            p
-            for p in (out_packets_map[i] for i in sorted(out_packets_map))
-            if p is not None
-        ]
+                if self._on_error == "keep":
+                    self._keep_failed = {
+                        pending_indices[e.index]: BranchError(
+                            error=format_error_chain(e.exception),
+                            error_type=type(root_cause(e.exception)).__qualname__,
+                        )
+                        for e in merged.errors
+                    }
 
-        for p in self._join_payloads_from_packets(out_packets):
+        # Emit results in input order. In ``keep`` mode a failed copy stays a
+        # ``None`` slot so payloads line up 1:1 with the inputs; ``raise`` never
+        # reaches here and ``drop`` compacts the failed slots out.
+        ordered = [out_packets_map[i] for i in sorted(out_packets_map)]
+        if self._on_error != "keep":
+            ordered = [p for p in ordered if p is not None]
+
+        for p in self._join_payloads_from_packets(ordered):
             yield ProcPayloadOutEvent(data=p, source=self.name, exec_id=exec_id)

--- a/src/grasp_agents/types/__init__.py
+++ b/src/grasp_agents/types/__init__.py
@@ -95,7 +95,7 @@ from .llm_events import (
     WebSearchCallInProgress,
     WebSearchCallSearching,
 )
-from .packet import Packet
+from .packet import BranchError, Packet
 from .recovery import (
     RecoveryHint,
     classify_error,
@@ -118,6 +118,7 @@ __all__ = [
     "BackgroundTaskCompletedEvent",
     "BackgroundTaskInfo",
     "BackgroundTaskLaunchedEvent",
+    "BranchError",
     "CompactionEvent",
     "CompactionInfo",
     "Event",

--- a/src/grasp_agents/types/packet.py
+++ b/src/grasp_agents/types/packet.py
@@ -23,11 +23,29 @@ def is_uniform_routing(routing: PacketRouting | None) -> Sequence[ProcName] | No
     return first_recipients
 
 
+class BranchError(BaseModel):
+    """
+    Why a fan-out payload slot failed. Referenced by :attr:`Packet.failed`.
+
+    The message is a formatted string (not the live exception) so the packet
+    stays JSON-serializable through checkpoints and routing.
+    """
+
+    error: str
+    error_type: str
+
+    model_config = ConfigDict(extra="forbid")
+
+
 class Packet[PayloadT](BaseModel):
     id: str = Field(default_factory=lambda: str(uuid4())[:8])
     payloads: Sequence[PayloadT]
     sender: ProcName
     routing: PacketRouting | None = None
+    # Payload-slot index -> why it failed. Populated by ``ParallelProcessor`` in
+    # ``on_error="keep"`` mode, where a failed branch leaves a ``None`` at its
+    # slot so ``payloads`` stays aligned 1:1 with the inputs. Empty otherwise.
+    failed: dict[int, BranchError] = Field(default_factory=dict[int, BranchError])
 
     @property
     def uniform_routing(self) -> Sequence[ProcName] | None:

--- a/src/grasp_agents/utils/errors.py
+++ b/src/grasp_agents/utils/errors.py
@@ -1,4 +1,12 @@
-__all__ = ["format_error_chain"]
+__all__ = ["format_error_chain", "root_cause"]
+
+
+def _next_in_chain(err: BaseException) -> BaseException | None:
+    if err.__cause__ is not None:
+        return err.__cause__
+    if not err.__suppress_context__:
+        return err.__context__
+    return None
 
 
 def format_error_chain(error: BaseException) -> str:
@@ -13,10 +21,24 @@ def format_error_chain(error: BaseException) -> str:
         seen.add(id(err))
         text = str(err)
         parts.append(f"{type(err).__name__}: {text}" if text else type(err).__name__)
-        if err.__cause__ is not None:
-            err = err.__cause__
-        elif not err.__suppress_context__:
-            err = err.__context__
-        else:
-            err = None
+        err = _next_in_chain(err)
     return "\nCaused by: ".join(parts)
+
+
+def root_cause(error: BaseException) -> BaseException:
+    """
+    Walk an exception's cause chain to its deepest cause.
+
+    Framework wrappers (e.g. a processor's retry ``ProcRunError``) sit at the
+    top of the chain; the root is usually the error a caller actually cares to
+    branch on.
+    """
+    seen: set[int] = set()
+    err = error
+    while id(err) not in seen:
+        seen.add(id(err))
+        nxt = _next_in_chain(err)
+        if nxt is None:
+            return err
+        err = nxt
+    return err

--- a/tests/durability/test_rollback.py
+++ b/tests/durability/test_rollback.py
@@ -18,14 +18,16 @@ from unittest.mock import patch
 
 import pytest
 
+from grasp_agents.agent.llm_agent import LLMAgent
 from grasp_agents.agent.llm_agent_transcript import LLMAgentTranscript
 from grasp_agents.durability import AgentContextState, InMemoryCheckpointStore
 from grasp_agents.durability.checkpoints import AgentCheckpointLocation
-from grasp_agents.inbox import AgentInbox
 from grasp_agents.mailbox import CheckpointMailboxTransport
+from grasp_agents.session_context import SessionContext
+from grasp_agents.types.errors import ProcRunError
 from grasp_agents.types.items import InputMessageItem
 from grasp_agents.types.message import TeamMessage
-from tests._helpers import _text_response
+from tests._helpers import MockLLM, _text_response
 from tests.durability.test_sessions import _make_agent, load_agent_checkpoint
 
 _KEY = "s1/agent/test_agent"
@@ -350,8 +352,6 @@ async def test_interrupted_rollback_completes_on_resume() -> None:
     await agent.run("q1", step=1)
     await agent.run("q2", step=2)
 
-    from grasp_agents.agent.llm_agent import LLMAgent
-
     with (
         patch.object(LLMAgent, "_persist_rollback", side_effect=RuntimeError("crash")),
         pytest.raises(RuntimeError, match="crash"),
@@ -373,3 +373,79 @@ async def test_interrupted_rollback_completes_on_resume() -> None:
     blob = str(agent2.transcript.messages)
     assert "q2-new" in blob
     assert "q2'" not in blob  # the rolled-back turn's input is gone
+
+
+# --- Parked-session entry guards ---
+
+
+@pytest.mark.asyncio
+async def test_pure_resume_while_parked_raises() -> None:
+    """
+    A rollback discards the parked step's input, so a no-input resume has
+    nothing to respond to — it is refused (live and cold) instead of
+    generating on a transcript that ends with the previous step's answer.
+    """
+    store = InMemoryCheckpointStore()
+    agent, _ = _make_agent(
+        [_text_response(a) for a in ("a0", "a1")], session_key="s1", store=store
+    )
+    await agent.run("q0", step=0)
+    await agent.run("q1", step=1)
+    await agent.rollback_to_step(1)
+
+    with pytest.raises(ProcRunError) as excinfo:
+        await agent.run()
+    assert "parked by a rollback at step 1" in str(excinfo.value.__cause__)
+
+    # Cold: a fresh instance rehydrates the ROLLED_BACK head and refuses too.
+    agent2, _ = _make_agent([_text_response("a1_new")], session_key="s1", store=store)
+    with pytest.raises(ProcRunError) as excinfo:
+        await agent2.run()
+    assert "parked by a rollback at step 1" in str(excinfo.value.__cause__)
+
+    # Re-delivering the step with its input enters as a fresh delivery.
+    r1b = await agent2.run("q1_edited", step=1)
+    assert r1b.payloads[0] == "a1_new"
+
+    # The delivery un-parked the session: a cold no-input resume is valid
+    # again and replays the completed step's output.
+    agent3, _ = _make_agent([], session_key="s1", store=store)
+    r1c = await agent3.run()
+    assert r1c.payloads[0] == "a1_new"
+
+
+@pytest.mark.asyncio
+async def test_stepped_delivery_without_input_raises() -> None:
+    """
+    A step delivery that renders no input message (``InT=None``, no chat
+    inputs) is refused — onto a parked head and onto a fresh session alike —
+    instead of committing an input-less step and generating.
+    """
+    store = InMemoryCheckpointStore()
+    ctx: SessionContext[None] = SessionContext(session_key="s1", checkpoint_store=store)
+    agent = LLMAgent[None, str, None](
+        name="test_agent",
+        ctx=ctx,
+        llm=MockLLM(responses_queue=[_text_response("a0"), _text_response("a1")]),
+        stream_llm=True,
+    )
+    await agent.run("q0", step=0)
+    await agent.run("q1", step=1)
+    await agent.rollback_to_step(1)
+
+    with pytest.raises(ProcRunError) as excinfo:
+        await agent.run(step=1)
+    assert "delivered without an input" in str(excinfo.value.__cause__)
+
+    # A fresh session: an explicit step bypasses the pure-resume entry, but
+    # the delivery still carries no input — refused before any mutation.
+    ctx2: SessionContext[None] = SessionContext(
+        session_key="s2", checkpoint_store=InMemoryCheckpointStore()
+    )
+    agent2 = LLMAgent[None, str, None](
+        name="test_agent", ctx=ctx2, llm=MockLLM(responses_queue=[]), stream_llm=True
+    )
+    with pytest.raises(ProcRunError) as excinfo:
+        await agent2.run(step=0)
+    assert "delivered without an input" in str(excinfo.value.__cause__)
+    assert agent2.transcript.is_empty  # refused before any mutation

--- a/tests/durability/test_workflow_durability.py
+++ b/tests/durability/test_workflow_durability.py
@@ -528,6 +528,69 @@ class TestParallelProcessorCheckpoint:
         assert None not in result
 
     @pytest.mark.asyncio
+    async def test_on_error_drop_matches_drop_failed(self) -> None:
+        """on_error='drop' compacts failures, like the deprecated drop_failed=True."""
+        subproc = InputFailProcessor("worker", fail_input="FAIL")
+        par = ParallelProcessor[str, str, None](subproc=subproc, on_error="drop")
+        ctx: SessionContext[None] = SessionContext(state=None)
+
+        result = await run_parallel(par, ctx, in_args=["ok", "FAIL"])
+
+        assert result == ["ok->worker_0"]
+
+    @pytest.mark.asyncio
+    async def test_on_error_keep_aligns_failed_slots(self) -> None:
+        """on_error='keep' keeps a None at each failed slot and records why."""
+        subproc = InputFailProcessor("worker", fail_input="FAIL")
+        par = ParallelProcessor[str, str, None](subproc=subproc, on_error="keep")
+        ctx: SessionContext[None] = SessionContext(state=None)
+        par.on_adopted(ctx=ctx)
+
+        out_packet: Packet[str] | None = None
+        async for event in par.run_stream(
+            in_args=["ok", "FAIL", "also_ok"], exec_id="test", step=0
+        ):
+            if isinstance(event, ProcPacketOutEvent) and event.source == par.name:
+                out_packet = event.data
+
+        assert out_packet is not None
+        # Payloads stay aligned 1:1 with the inputs; the failed slot is None,
+        # so zip(inputs, payloads, strict=True) still lines up.
+        assert list(out_packet.payloads) == ["ok->worker_0", None, "also_ok->worker_2"]
+        # The failure map travels on the packet.
+        assert set(out_packet.failed) == {1}
+        assert "FAIL" in out_packet.failed[1].error
+        # error_type is the root cause (RuntimeError), not the retry wrapper.
+        assert out_packet.failed[1].error_type == "RuntimeError"
+
+    @pytest.mark.asyncio
+    async def test_on_error_keep_no_failures_has_empty_map(self) -> None:
+        """on_error='keep' with no failures returns aligned payloads, empty map."""
+        subproc = InputFailProcessor("worker", fail_input="FAIL")
+        par = ParallelProcessor[str, str, None](subproc=subproc, on_error="keep")
+        ctx: SessionContext[None] = SessionContext(state=None)
+        par.on_adopted(ctx=ctx)
+
+        out_packet: Packet[str] | None = None
+        async for event in par.run_stream(
+            in_args=["ok", "also_ok"], exec_id="test", step=0
+        ):
+            if isinstance(event, ProcPacketOutEvent) and event.source == par.name:
+                out_packet = event.data
+
+        assert out_packet is not None
+        assert list(out_packet.payloads) == ["ok->worker_0", "also_ok->worker_1"]
+        assert out_packet.failed == {}
+
+    def test_on_error_and_drop_failed_conflict(self) -> None:
+        """Passing both on_error and drop_failed is rejected."""
+        subproc = InputFailProcessor("worker")
+        with pytest.raises(ValueError, match="not both"):
+            ParallelProcessor[str, str, None](
+                subproc=subproc, on_error="keep", drop_failed=True
+            )
+
+    @pytest.mark.asyncio
     async def test_checkpoint_stores_input_packet(self) -> None:
         """Checkpoint correctly round-trips the input packet."""
         store = InMemoryCheckpointStore()

--- a/tests/llm/test_resilience.py
+++ b/tests/llm/test_resilience.py
@@ -2,7 +2,7 @@
 Tests for resilience primitives: FallbackLLM, API retry loop, RetryPolicy.
 
 Focuses on real pain points:
-- FallbackLLM: mid-stream failure recovery, error propagation, last-error-wins
+- FallbackLLM: mid-stream failure recovery, cascade error selection
 - API retries: deterministic vs transient classification, retry_after floor
 - RetryPolicy: exponential backoff math, error classification correctness
 """
@@ -18,7 +18,7 @@ import pytest
 from pydantic import BaseModel
 
 from grasp_agents.llm.cloud_llm import ApiCallParams, CloudLLM
-from grasp_agents.llm.fallback_llm import FallbackLLM
+from grasp_agents.llm.fallback_llm import FallbackLLM, _select_cascade_error
 from grasp_agents.llm.llm import LLM
 from grasp_agents.llm.resilience import RetryPolicy
 from grasp_agents.tools.base import BaseTool
@@ -386,24 +386,49 @@ class TestFallbackLLM:
         assert result.output_text == "recovered"
 
     @pytest.mark.asyncio
-    async def test_all_candidates_fail_raises_last_error(self) -> None:
-        """All fail → last error raised, not first. Matters for debugging."""
+    async def test_all_fail_retryable_error_wins_over_deterministic(self) -> None:
+        """
+        Primary fails transiently, last fallback fails deterministically →
+        the transient error is raised, so the outer retry layer still
+        retries the cascade (the primary deserves another shot).
+        """
         primary = ErrorLLM(
             model_name="primary",
-            error_to_raise=LlmRateLimitError(
-                "rate limited", response=_resp(429), body=None
+            error_to_raise=LlmInternalServerError(
+                "overloaded", response=_resp(503), body=None
             ),
         )
         fallback = ErrorLLM(
             model_name="fallback",
-            error_to_raise=LlmInternalServerError(
-                "server down", response=_resp(500), body=None
+            error_to_raise=LlmAuthenticationError(
+                "bad key", response=_resp(401), body=None
             ),
         )
 
         llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
 
-        with pytest.raises(LlmInternalServerError, match="server down"):
+        with pytest.raises(LlmInternalServerError, match="overloaded"):
+            await llm._generate_response_once(_USER_MSG)
+
+    @pytest.mark.asyncio
+    async def test_all_fail_deterministically_raises_last_error(self) -> None:
+        """No retryable member error → last error raised, as before."""
+        primary = ErrorLLM(
+            model_name="primary",
+            error_to_raise=LlmAuthenticationError(
+                "bad key", response=_resp(401), body=None
+            ),
+        )
+        fallback = ErrorLLM(
+            model_name="fallback",
+            error_to_raise=LlmContextWindowError(
+                "too long", response=_resp(400), body=None
+            ),
+        )
+
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
+
+        with pytest.raises(LlmContextWindowError, match="too long"):
             await llm._generate_response_once(_USER_MSG)
 
     @pytest.mark.asyncio
@@ -468,17 +493,21 @@ class TestFallbackLLM:
 
     @pytest.mark.asyncio
     async def test_stream_all_fail_yields_fallback_events_then_raises(self) -> None:
-        """All candidates fail → ResponseFallback events, then last error raised."""
+        """
+        All candidates fail → ResponseFallback events, then the selected
+        error raised (here the primary's transient error wins over the
+        fallback's deterministic one).
+        """
         primary = ErrorLLM(
             model_name="primary",
-            error_to_raise=LlmRateLimitError(
-                "rate limited", response=_resp(429), body=None
+            error_to_raise=LlmInternalServerError(
+                "overloaded", response=_resp(503), body=None
             ),
         )
         fallback = ErrorLLM(
             model_name="fallback",
-            error_to_raise=LlmInternalServerError(
-                "down", response=_resp(500), body=None
+            error_to_raise=LlmAuthenticationError(
+                "bad key", response=_resp(401), body=None
             ),
         )
 
@@ -490,13 +519,141 @@ class TestFallbackLLM:
             async for event in llm._generate_response_stream_once(_USER_MSG):
                 events.append(event)
 
-        with pytest.raises(LlmInternalServerError, match="down"):
+        with pytest.raises(LlmInternalServerError, match="overloaded"):
             await _collect()
 
         fallbacks = [e for e in events if isinstance(e, ResponseFallback)]
         assert len(fallbacks) == 2
         assert fallbacks[0].fallback_model == "fallback"
         assert fallbacks[1].fallback_model == "none"
+
+
+# ---------- Cascade error selection ----------
+
+
+def _transient(msg: str = "500") -> LlmInternalServerError:
+    return LlmInternalServerError(msg, response=_resp(500), body=None)
+
+
+def _auth(msg: str = "401") -> LlmAuthenticationError:
+    return LlmAuthenticationError(msg, response=_resp(401), body=None)
+
+
+def _rate_limited(retry_after: float | None) -> LlmRateLimitError:
+    return LlmRateLimitError(
+        "429", response=_resp(429), body=None, retry_after=retry_after
+    )
+
+
+class TestCascadeErrorSelection:
+    """_select_cascade_error: which member error a failed pass raises."""
+
+    def test_retryable_wins_over_deterministic_regardless_of_order(self) -> None:
+        transient = _transient()
+        assert _select_cascade_error([transient, _auth()]) is transient
+        assert _select_cascade_error([_auth(), transient]) is transient
+
+    def test_all_deterministic_returns_last(self) -> None:
+        last = _auth("second")
+        assert _select_cascade_error([_auth("first"), last]) is last
+
+    def test_transient_preferred_over_floored_rate_limit(self) -> None:
+        """A retry pass needs one healthy member — don't park on retry_after."""
+        transient = _transient()
+        assert _select_cascade_error([_rate_limited(60.0), transient]) is transient
+
+    def test_rate_limit_without_floor_preferred_over_floored(self) -> None:
+        no_floor = _rate_limited(None)
+        assert _select_cascade_error([_rate_limited(60.0), no_floor]) is no_floor
+
+    def test_smallest_retry_after_among_floored_rate_limits(self) -> None:
+        smallest = _rate_limited(5.0)
+        errors = [_rate_limited(60.0), smallest, _rate_limited(30.0)]
+        assert _select_cascade_error(errors) is smallest
+
+
+class TestFallbackRetryGate:
+    """Cascade + outer retry layer: retry fires if ANY member failed retryably."""
+
+    @pytest.mark.asyncio
+    @patch("grasp_agents.llm.llm.asyncio.sleep", new_callable=AsyncMock)
+    async def test_cascade_retried_when_last_member_fails_deterministically(
+        self, mock_sleep: AsyncMock
+    ) -> None:
+        """
+        Primary blips (503), fallback is misconfigured (401). The 401 from
+        the last member must not suppress the retry pass: the cascade is
+        retried and the primary succeeds on the second pass.
+        """
+        primary = FailThenSucceedLLM(
+            model_name="primary",
+            error=LlmInternalServerError("blip", response=_resp(503), body=None),
+            fail_count=1,
+            success_response=_text_response("recovered"),
+        )
+        fallback = ErrorLLM(model_name="fallback", error_to_raise=_auth("bad key"))
+        llm = FallbackLLM(
+            primary=primary,
+            fallbacks=(fallback,),
+            retry_policy=RetryPolicy(api_retries=1),
+        )
+
+        result = await llm.generate_response(_USER_MSG)
+
+        assert result.output_text == "recovered"
+        assert primary.call_count == 2
+        assert fallback.call_count == 1
+        assert mock_sleep.call_count == 1
+
+    @pytest.mark.asyncio
+    @patch("grasp_agents.llm.llm.asyncio.sleep", new_callable=AsyncMock)
+    async def test_stream_cascade_retried_when_last_member_fails_deterministically(
+        self, mock_sleep: AsyncMock
+    ) -> None:
+        primary = FailThenSucceedLLM(
+            model_name="primary",
+            error=LlmInternalServerError("blip", response=_resp(503), body=None),
+            fail_count=1,
+            success_response=_text_response("recovered"),
+        )
+        fallback = ErrorLLM(model_name="fallback", error_to_raise=_auth("bad key"))
+        llm = FallbackLLM(
+            primary=primary,
+            fallbacks=(fallback,),
+            retry_policy=RetryPolicy(api_retries=1),
+        )
+
+        events: list[LlmEvent] = []
+        async for event in llm.generate_response_stream(_USER_MSG):
+            events.append(event)
+
+        retrying = [e for e in events if isinstance(e, ResponseRetrying)]
+        assert len(retrying) == 1
+        completed = [e for e in events if isinstance(e, ResponseCompleted)]
+        assert len(completed) == 1
+        assert completed[0].response.output_text == "recovered"
+        assert fallback.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_no_retry_when_all_members_fail_deterministically(self) -> None:
+        """Deterministic failures across the board → no retry passes."""
+        primary = ErrorLLM(model_name="primary", error_to_raise=_auth("bad key"))
+        fallback = ErrorLLM(
+            model_name="fallback",
+            error_to_raise=LlmContextWindowError(
+                "too long", response=_resp(400), body=None
+            ),
+        )
+        llm = FallbackLLM(
+            primary=primary,
+            fallbacks=(fallback,),
+            retry_policy=RetryPolicy(api_retries=3),
+        )
+
+        with pytest.raises(LlmContextWindowError, match="too long"):
+            await llm.generate_response(_USER_MSG)
+        assert primary.call_count == 1
+        assert fallback.call_count == 1
 
 
 # ---------- API Retry Loop ----------

--- a/tests/test_utils_errors.py
+++ b/tests/test_utils_errors.py
@@ -1,6 +1,6 @@
 import pytest
 
-from grasp_agents.utils.errors import format_error_chain
+from grasp_agents.utils.errors import format_error_chain, root_cause
 
 
 def _raise_root() -> None:
@@ -83,3 +83,37 @@ def test_cyclic_chain_terminates() -> None:
     a.__cause__ = b
     b.__cause__ = a
     assert format_error_chain(a) == "ValueError: a\nCaused by: RuntimeError: b"
+
+
+def test_root_cause_no_chain_returns_self() -> None:
+    err = ValueError("boom")
+    assert root_cause(err) is err
+
+
+def test_root_cause_walks_to_deepest() -> None:
+    with pytest.raises(RuntimeError) as exc_info:
+        _raise_wrapped()
+    root = root_cause(exc_info.value)
+    assert type(root) is ValueError
+    assert str(root) == "bad request"
+
+
+def test_root_cause_stops_at_suppressed_context() -> None:
+    def raise_clean() -> None:
+        try:
+            _raise_root()
+        except ValueError:
+            msg = "clean"
+            raise RuntimeError(msg) from None
+
+    with pytest.raises(RuntimeError) as exc_info:
+        raise_clean()
+    assert type(root_cause(exc_info.value)) is RuntimeError
+
+
+def test_root_cause_cyclic_chain_terminates() -> None:
+    a = ValueError("a")
+    b = RuntimeError("b")
+    a.__cause__ = b
+    b.__cause__ = a
+    assert root_cause(a) in {a, b}

--- a/uv.lock
+++ b/uv.lock
@@ -1181,7 +1181,7 @@ wheels = [
 
 [[package]]
 name = "grasp-agents"
-version = "1.0.20"
+version = "1.0.21"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
# Robustness fixes: partial-failure fan-out, fallback error selection, rollback resume guard

Three independent reliability improvements — to concurrent fan-out, multi-model
fallback, and session rollback — plus supporting error utilities. Fully backward
compatible; version bumped to `1.0.21`.

## 1. `ParallelProcessor`: partial-failure fan-out (`on_error`)

A fan-out previously had only two behaviors: fail the whole run on the first
failed branch, or drop failed branches entirely. Dropping collapses the output
list, so results can no longer be mapped back to their inputs (a positional
`zip(inputs, outputs)` breaks). There was no way to tolerate a failed branch
*and* still know which input it belonged to.

`drop_failed: bool` is generalized to **`on_error: "raise" | "drop" | "keep"`**:

| mode | behavior |
| --- | --- |
| `"raise"` (default) | first failed branch fails the whole run |
| `"drop"` | failed branches dropped; successful payloads emitted compactly |
| `"keep"` | failed branch leaves a `None` at its slot, so payloads stay aligned 1:1 with the inputs; the output packet's `failed` maps each failed index to why |

`"keep"` keeps the input→result mapping recoverable under partial failure:

```python
out = await ParallelProcessor(sub, ctx=ctx, on_error="keep").run(in_args=inputs)
for inp, payload in zip(inputs, out.payloads, strict=True):  # lengths always match
    if payload is None:
        ...  # this input's branch failed; out.failed[i] carries the reason
```

Supporting API:

- **`Packet.failed: dict[int, BranchError]`** — payload-slot index → failure.
  Empty on every non-fan-out packet; populated only in `keep` mode. It lives on
  the packet (not on the processor) so the failure map travels with the data and
  survives being nested inside a runner, workflow, or `.as_tool()` wrapper.
- **`BranchError(error: str, error_type: str)`** (exported from
  `grasp_agents.types`) — the formatted cause chain plus the **root-cause**
  exception type (not the per-branch retry wrapper), so callers can branch on
  the underlying error kind. Stored as strings, so the packet stays
  JSON-serializable through checkpoints and routing.
- **`root_cause(exc)`** added to `grasp_agents.utils.errors`, next to
  `format_error_chain`.

Backward compatibility: `drop_failed=True/False` still works, mapped to
`"drop"`/`"raise"`. Passing both `on_error` and `drop_failed` raises.

## 2. `FallbackLLM`: raise the most-retryable error when a cascade fully fails

When every member of a fallback cascade failed, the cascade raised the *last*
member's error. If that last member failed deterministically (e.g. a
misconfigured fallback), it masked an earlier member's transient error — and the
outer retry layer, which keys on the raised error, would decline to retry a pass
that was actually worth retrying.

A fully-failed pass now raises the member error **most worth retrying**:

1. a retryable error, if any member produced one (a retry pass needs only one
   member healthy — so retry whenever *any* member failed retryably, not only
   when the last one did);
2. among retryable errors, prefer one with no server-imposed backoff floor
   (shortest wait wins);
3. among floored rate limits, the smallest `retry_after`.

It falls back to the last error only when every failure is deterministic. Applies
to both `generate_response` and the streaming entrypoint.

## 3. Rollback: reject a no-input resume of a parked step

After `rollback_to_step` (or loading a rolled-back head), the session is *parked*
at the target step: that step's input was discarded along with its boundary, so
the step must be re-delivered with a fresh input. A no-input resume at that point
would generate a response with nothing to respond to.

Two guards turn this into an explicit, actionable error instead of silently
generating against an empty turn:

- a stepped delivery that renders no input message is rejected;
- a pure (no-input) resume while the session is parked by a rollback is rejected.

Both errors tell the caller to re-deliver the step with its input
(`run(..., step=<n>)`). Tracked by an internal parked flag set on rollback and on
loading a rolled-back head, and cleared once the step is re-delivered.

## Testing

- `tests/durability/test_workflow_durability.py` — `keep` / `drop` / `raise`,
  conflicting-args rejection, and the no-failure case.
- `tests/test_utils_errors.py` — `root_cause` chain walking, including suppressed
  context and cyclic chains.
- `tests/llm/test_resilience.py` — cascade error selection (retryable wins over
  deterministic regardless of order; backoff-floor and `retry_after` ordering)
  and the outer retry gate.
- `tests/durability/test_rollback.py` — pure-resume-while-parked and
  stepped-delivery-without-input.

Full suite: **2694 passed, 1 skipped**. Type-checked (pyright strict) and linted
(ruff) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

