### PR TITLE
rearrange LLM fallbacks and retries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grasp_agents"
-version = "1.0.21"
+version = "1.0.22"
 description = "Grasp Agents Library"
 readme = "README.md"
 requires-python = ">=3.12,<4"

--- a/src/grasp_agents/agent/agent_loop.py
+++ b/src/grasp_agents/agent/agent_loop.py
@@ -1651,12 +1651,7 @@ class AgentLoop[CtxT]:
             # for the view just sent.
             self._cw.note_response_usage(usage.input_tokens)
 
-        self.ctx.usage_tracker.update(
-            agent_name=self.agent_name,
-            responses=[response],
-            model_name=self._llm.model_name,
-            litellm_provider=self._llm.litellm_provider,
-        )
+        self.ctx.usage_tracker.update(agent_name=self.agent_name, responses=[response])
 
         # Mirror generated output (reasoning, text, tool calls) to the raw debug
         # printer (``ctx.printer``), if attached — the counterpart to the input /

--- a/src/grasp_agents/agent/context_window.py
+++ b/src/grasp_agents/agent/context_window.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from grasp_agents.hooks import Compactor, ViewProjector
+    from grasp_agents.llm.llm import LLM
     from grasp_agents.types.folds import FoldSpec
     from grasp_agents.types.items import InputItem
 
@@ -42,20 +43,26 @@ class ContextWindowManager:
     """
 
     def __init__(
-        self, *, transcript: LLMAgentTranscript, model: str, source: str
+        self, *, transcript: LLMAgentTranscript, llm: LLM, source: str
     ) -> None:
         self._transcript = transcript
-        self._model = model  # only used to pick the tokenizer for budget sizing
+
+        self._llm = llm  # budget sizing (capabilities) + tokenizer selection
+
         self._source = source  # agent name, stamped on emitted compaction events
+
         # Ephemeral system-prompt header (+ leading messages), rebuilt per step by
         # ``LLMAgent`` and prepended to the view; never written to the log.
         self.initial_context: list[InputItem] = []
+
         # Stacked projector pipeline + single compactor (set via LLMAgent hooks).
         self.view_projectors: list[ViewProjector] = []
         self.compactor: Compactor | None = None
+
         # Summarized log spans applied to the view; persisted, survive resume,
         # dropped past a rollback rewind.
         self.folds: list[FoldSpec] = []
+
         # Budget anchor: the last response's exact reported input_tokens over the
         # first ``_last_counted_len`` log messages; the turn's new messages are
         # counted on top via litellm. ``_pending_view_count`` is the basis of the
@@ -63,6 +70,7 @@ class ContextWindowManager:
         self._last_input_tokens = 0
         self._last_counted_len = 0
         self._pending_view_count = 0
+
         # Model-derived budget, built lazily and shared into registered strategies
         # that don't bring their own (so the agent never has to construct one).
         self._budget: ContextBudget | None = None
@@ -70,9 +78,16 @@ class ContextWindowManager:
     # --- registration (called by LLMAgent's hooks) ---
 
     def default_budget(self) -> ContextBudget:
-        """The agent's model-derived budget (``ContextBudget.for_model``), cached."""
+        """
+        The agent's model-derived budget, cached. Sized from
+        ``llm.capabilities`` so a composed LLM budgets for its conservative
+        merge (e.g. a fallback cascade's smallest member window), not just
+        the name it reports.
+        """
         if self._budget is None:
-            self._budget = ContextBudget.for_model(self._model)
+            self._budget = ContextBudget.from_capabilities(
+                self._llm.model_name, self._llm.capabilities
+            )
         return self._budget
 
     def add_view_projector(self, projector: ViewProjector) -> None:
@@ -141,7 +156,7 @@ class ContextWindowManager:
         anchor — counts the whole current (folded) view via litellm, which itself
         falls back to a chars-per-token estimate when no tokenizer is available.
         """
-        model = self._model
+        model = self._llm.model_name
         messages = self._transcript.messages
         if self._anchor_valid():
             delta = messages[self._last_counted_len :]
@@ -173,7 +188,7 @@ class ContextWindowManager:
         if self._anchor_valid() or not self.view_projectors:
             return self.effective_input_tokens()
         body = await self._build_view_body(exec_id=exec_id)
-        return count_input_tokens(self._model, [*self.initial_context, *body])
+        return count_input_tokens(self._llm.model_name, [*self.initial_context, *body])
 
     def note_response_usage(self, input_tokens: int) -> None:
         """Promote the budget anchor from a response's reported usage."""

--- a/src/grasp_agents/agent/llm_agent.py
+++ b/src/grasp_agents/agent/llm_agent.py
@@ -429,7 +429,7 @@ class LLMAgent[InT, OutT, CtxT](
         # (checkpoint folds, rollback, hook registration) are single-hop rather
         # than reached through the loop.
         self._cw = ContextWindowManager(
-            transcript=self._transcript, model=llm.model_name, source=self.name
+            transcript=self._transcript, llm=llm, source=self.name
         )
 
         # Agent loop

--- a/src/grasp_agents/context/compaction.py
+++ b/src/grasp_agents/context/compaction.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass
 from typing import Any, Protocol, Self, runtime_checkable
 
 from grasp_agents.llm.llm import LLM
-from grasp_agents.llm.model_info import get_model_capabilities
+from grasp_agents.llm.model_info import ModelCapabilities, get_model_capabilities
 from grasp_agents.llm.token_counting import count_input_tokens
 from grasp_agents.types.folds import FoldSpec
 from grasp_agents.types.items import (
@@ -100,10 +100,31 @@ class ContextBudget:
         token buffer defaults to the model's max output tokens (room for the
         response), or :data:`DEFAULT_BUFFER_TOKENS` when unknown.
         """
-        caps = get_model_capabilities(model, provider)
-        window = caps.max_input_tokens or default_max_input_tokens
+        return cls.from_capabilities(
+            model,
+            get_model_capabilities(model, provider),
+            buffer_tokens=buffer_tokens,
+            default_max_input_tokens=default_max_input_tokens,
+        )
+
+    @classmethod
+    def from_capabilities(
+        cls,
+        model: str,
+        capabilities: ModelCapabilities,
+        *,
+        buffer_tokens: int | None = None,
+        default_max_input_tokens: int | None = DEFAULT_MAX_INPUT_TOKENS,
+    ) -> Self:
+        """
+        Build a budget from already-resolved capabilities — same fallbacks as
+        :meth:`for_model`. Preferred when an :class:`~grasp_agents.llm.llm.LLM`
+        is at hand: ``llm.capabilities`` reflects composition (a fallback
+        cascade reports its conservative merge), a by-name lookup doesn't.
+        """
+        window = capabilities.max_input_tokens or default_max_input_tokens
         if buffer_tokens is None:
-            buffer_tokens = caps.max_output_tokens or DEFAULT_BUFFER_TOKENS
+            buffer_tokens = capabilities.max_output_tokens or DEFAULT_BUFFER_TOKENS
         return cls(model=model, max_input_tokens=window, buffer_tokens=buffer_tokens)
 
     @property

--- a/src/grasp_agents/llm/cloud_llm.py
+++ b/src/grasp_agents/llm/cloud_llm.py
@@ -20,6 +20,7 @@ from grasp_agents.types.llm_errors import (
 )
 from grasp_agents.types.llm_events import LlmEvent, ResponseCompleted, ResponseFailed
 from grasp_agents.types.response import Response
+from grasp_agents.usage_tracker import add_cost_to_usage
 
 from .llm import LLM, LLMSettings
 
@@ -156,6 +157,28 @@ class CloudLLM(LLM):
         if mapped is not None:
             raise mapped from err
         raise err
+
+    # --- Cost stamping ---
+
+    def _stamp_cost(self, response: Response) -> None:
+        """
+        Stamp the response's cost with THIS model's pricing identity.
+
+        Called at response-production time, so cost attribution is correct
+        however the LLM is composed: under a FallbackLLM, the serving
+        member prices its own response — never the ``model_name`` the
+        composite reports. Cost is an API-provider concern, which is why
+        stamping lives here and not on the base ``LLM`` (a local or mock
+        LLM with token usage has no price, and looking one up would warn
+        on every call).
+        """
+        usage = response.usage
+        if usage is not None and usage.cost is None and self.model_name:
+            add_cost_to_usage(
+                usage,
+                model_name=self.model_name,
+                litellm_provider=self.litellm_provider,
+            )
 
     # --- LLM interface implementation ---
 

--- a/src/grasp_agents/llm/fallback_llm.py
+++ b/src/grasp_agents/llm/fallback_llm.py
@@ -3,6 +3,7 @@
 import logging
 from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass, field
+from functools import cached_property
 from typing import Any
 
 from pydantic import BaseModel
@@ -10,25 +11,26 @@ from pydantic import BaseModel
 from grasp_agents.tools.base import BaseTool, ToolChoice
 from grasp_agents.types.items import InputItem
 from grasp_agents.types.llm_errors import LlmErrorTuple, LlmRateLimitError
-from grasp_agents.types.llm_events import LlmEvent, ResponseCompleted, ResponseFallback
+from grasp_agents.types.llm_events import LlmEvent, ResponseFallback
 from grasp_agents.types.recovery import classify_error, is_retryable
 from grasp_agents.types.response import Response
 
 from .llm import LLM
+from .model_info import ModelCapabilities
+from .resilience import RetryPolicy
 
 logger = logging.getLogger(__name__)
 
 
 def _select_cascade_error(errors: Sequence[Exception]) -> Exception:
     """
-    Choose the error a fully-failed cascade pass raises.
+    Choose the error a fully-failed cascade raises.
 
-    The outer retry layer keys on this error, and a retry pass needs only
-    one member healthy — so prefer a retryable member error, ensuring the
-    cascade is retried whenever *any* member failed retryably, not just
-    when the last one did. Among retryable errors, prefer one without a
-    server-imposed backoff floor (shortest wait wins); among floored rate
-    limits, the smallest ``retry_after``.
+    Prefer a retryable member error: it tells the caller the cascade may
+    succeed later, and must not be masked by another member's deterministic
+    failure (e.g. a misconfigured fallback). Among retryable errors, prefer
+    one without a server-imposed backoff floor (shortest implied wait);
+    among floored rate limits, the smallest ``retry_after``.
     """
     retryable = [e for e in errors if is_retryable(classify_error(e))]
     if not retryable:
@@ -49,24 +51,99 @@ class FallbackLLM(LLM):
     """
     Tries LLMs in order until one succeeds.
 
-    The public ``generate_response(_stream)`` entrypoints validate and retry
-    (per this instance's ``retry_policy``) around the whole cascade; member
-    retry policies are bypassed — the cascade itself is the API-retry layer.
-    A pass where every member fails raises the member error most worth
-    retrying, so one member's deterministic failure (e.g. a misconfigured
-    fallback) cannot mask another's transient error.
-    ``model_name`` defaults to the primary's and is used for logging, cost
-    attribution and context-budget resolution. ``llm_settings`` is inert
-    here: settings live on the member LLMs.
+    Each member runs its full pipeline — API retries per its own
+    ``retry_policy``, response validation, and validation retries that
+    re-sample the same member — before the cascade advances. A transient
+    blip on the primary is retried on the primary, and a malformed response
+    is re-sampled from the member that produced it: models are never
+    swapped over a validation failure (validation errors propagate instead
+    of cascading). Deterministic member errors (auth, bad request, context
+    window) skip that member's retries and advance the cascade immediately.
+
+    ``retry_policy`` must be ``None`` here: all retry behavior (API and
+    validation) is member-level, and a composite policy would silently
+    multiply member retries. ``llm_settings`` and ``litellm_provider``
+    must be ``None`` too: settings live on the member LLMs, and cost /
+    capability resolution uses each member's own identity.
+
+    ``capabilities`` is the conservative merge across members — the
+    smallest known token windows, and a feature only if every member
+    supports it — so context budgeting and feature gating hold for
+    whichever member ends up serving. ``model_name`` defaults to the
+    primary's and is used for logging and tokenizer selection.
     """
 
     model_name: str = ""
+    retry_policy: RetryPolicy | None = None
     primary: LLM = field(kw_only=True)
     fallbacks: tuple[LLM, ...] = ()
 
     def __post_init__(self) -> None:
         if not self.model_name:
             object.__setattr__(self, "model_name", self.primary.model_name)
+        if self.retry_policy is not None:
+            raise ValueError(
+                "FallbackLLM takes no retry_policy: API and validation "
+                "retries are configured per member (set retry_policy on "
+                "each member LLM)."
+            )
+        if self.llm_settings is not None:
+            raise ValueError(
+                "FallbackLLM takes no llm_settings: settings live on the member LLMs."
+            )
+        if self.litellm_provider is not None:
+            raise ValueError(
+                "FallbackLLM takes no litellm_provider: cost and capability "
+                "resolution use each member's own identity (set "
+                "litellm_provider on the member LLMs)."
+            )
+
+    @cached_property
+    def capabilities(self) -> ModelCapabilities:
+        """
+        Conservative merge across members: the smallest known token
+        windows, and a feature only if every member supports it — valid
+        for whichever member serves. Members with unknown windows are
+        skipped (unknown models also report permissive feature defaults).
+        """
+        caps = [m.capabilities for m in (self.primary, *self.fallbacks)]
+        input_windows = [
+            c.max_input_tokens for c in caps if c.max_input_tokens is not None
+        ]
+        output_windows = [
+            c.max_output_tokens for c in caps if c.max_output_tokens is not None
+        ]
+        return ModelCapabilities(
+            function_calling=all(c.function_calling for c in caps),
+            vision=all(c.vision for c in caps),
+            output_schema=all(c.output_schema for c in caps),
+            prompt_caching=all(c.prompt_caching for c in caps),
+            reasoning=all(c.reasoning for c in caps),
+            web_search=all(c.web_search for c in caps),
+            audio_input=all(c.audio_input for c in caps),
+            max_input_tokens=min(input_windows) if input_windows else None,
+            max_output_tokens=min(output_windows) if output_windows else None,
+        )
+
+    def _validate_response(
+        self,
+        response: Response,
+        *,
+        tools: Mapping[str, BaseTool[BaseModel, Any, Any]] | None = None,
+        output_schema: Any | None = None,
+    ) -> None:
+        """
+        No-op: members validate their own responses (and run their own
+        validation retries); re-validating here would double the work and
+        the refusal warnings.
+        """
+
+    def _validate_tool_calls(
+        self,
+        response: Response,
+        tools: Mapping[str, BaseTool[BaseModel, Any, Any]],
+    ) -> None:
+        """No-op: tool calls are validated by the serving member."""
 
     async def _generate_response_once(
         self,
@@ -82,20 +159,18 @@ class FallbackLLM(LLM):
 
         for llm in candidates:
             try:
-                # Call the un-retried core on purpose: the cascade is the
-                # retry layer here.
-                response = await llm._generate_response_once(  # noqa: SLF001
+                # The member's full pipeline: its own API retries,
+                # validation, and validation retries. The cascade advances
+                # only on exhausted or deterministic API errors; validation
+                # errors are not LlmErrorTuple and propagate.
+                return await llm.generate_response(
                     input,
                     tools=tools,
                     output_schema=output_schema,
                     tool_choice=tool_choice,
                     **extra_llm_settings,
                 )
-                # CloudLLM members stamp at the source; this covers members
-                # that don't (so cost is attributed to the SERVING member,
-                # never to the primary's name reported by this wrapper).
-                llm._stamp_cost(response)  # noqa: SLF001
-                return response
+
             except LlmErrorTuple as e:
                 errors.append(e)
                 logger.warning(
@@ -124,15 +199,15 @@ class FallbackLLM(LLM):
 
         for llm in candidates:
             try:
-                async for event in llm._generate_response_stream_once(  # noqa: SLF001
+                # Member-internal retries (API and validation) surface as
+                # ResponseRetrying events within this member's segment.
+                async for event in llm.generate_response_stream(
                     input,
                     tools=tools,
                     output_schema=output_schema,
                     tool_choice=tool_choice,
                     **extra_llm_settings,
                 ):
-                    if isinstance(event, ResponseCompleted):
-                        llm._stamp_cost(event.response)  # noqa: SLF001
                     seq = event.sequence_number
                     yield event
                 return

--- a/src/grasp_agents/llm/llm.py
+++ b/src/grasp_agents/llm/llm.py
@@ -29,7 +29,6 @@ from grasp_agents.types.llm_events import (
     ResponseRetrying,
 )
 from grasp_agents.types.response import Response
-from grasp_agents.usage_tracker import add_cost_to_usage
 from grasp_agents.utils.validation import validate_obj_from_json_or_py_string
 
 from .model_info import ModelCapabilities, get_model_capabilities
@@ -90,25 +89,6 @@ class LLM(ABC):
         **extra_llm_settings: Any,
     ) -> AsyncIterator[LlmEvent]:
         yield NotImplemented
-
-    # --- Cost stamping ---
-
-    def _stamp_cost(self, response: Response) -> None:
-        """
-        Stamp the response's cost with THIS model's pricing identity.
-
-        Called by implementations at response-production time, so cost
-        attribution is correct however the LLM is composed — a FallbackLLM
-        member's response is priced as that member, not as whatever
-        ``model_name`` the outer layer reports.
-        """
-        usage = response.usage
-        if usage is not None and usage.cost is None and self.model_name:
-            add_cost_to_usage(
-                usage,
-                model_name=self.model_name,
-                litellm_provider=self.litellm_provider,
-            )
 
     # --- API retry layer ---
 

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -263,9 +263,7 @@ def _make_agent_loop(
     )
     loop_kwargs.setdefault(
         "context_window",
-        ContextWindowManager(
-            transcript=transcript, model=llm.model_name, source=agent_name
-        ),
+        ContextWindowManager(transcript=transcript, llm=llm, source=agent_name),
     )
     return AgentLoop[None](
         agent_name=agent_name,

--- a/tests/llm/test_llm_core.py
+++ b/tests/llm/test_llm_core.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import math
 from collections.abc import AsyncIterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import anthropic.types as anthropic_types
@@ -54,7 +54,7 @@ from grasp_agents.types.llm_events import (
     ResponseFailed,
     ResponseRetrying,
 )
-from grasp_agents.types.response import ResponseUsage
+from grasp_agents.types.response import Response, ResponseUsage
 from grasp_agents.usage_tracker import add_cost_to_usage
 from tests.llm.test_resilience import (  # type: ignore[attr-defined]
     _USER_MSG,
@@ -218,25 +218,48 @@ class TestApiKeyNotInRepr:
         assert "sk-super-secret-key" not in str(llm)
 
 
+@dataclass(frozen=True)
+class _ServingCloudLLM(LazyStreamCloudLLM):
+    """CloudLLM stub serving a fixed response on the non-stream path."""
+
+    served: Response = field(default_factory=lambda: _text_response("ok"))
+
+    async def _get_api_response(
+        self,
+        api_input: list[Any],
+        *,
+        api_tools: list[Any] | None = None,
+        api_tool_choice: Any | None = None,
+        api_output_schema: type | None = None,
+        **api_llm_settings: Any,
+    ) -> Any:
+        return self.served
+
+    def _convert_api_response(self, raw: Any) -> Response:
+        return raw  # type: ignore[no-any-return]
+
+
+def _served_with_usage(text: str) -> Response:
+    return _text_response(text).model_copy(
+        update={
+            "usage": ResponseUsage(input_tokens=100, output_tokens=10, total_tokens=110)
+        }
+    )
+
+
 class TestFallbackCostAttribution:
     @pytest.mark.asyncio
     async def test_fallback_response_costed_with_serving_model(self) -> None:
-        primary = ErrorLLM(model_name="primary")
-        served = _text_response("recovered").model_copy(
-            update={
-                "usage": ResponseUsage(
-                    input_tokens=100, output_tokens=10, total_tokens=110
-                )
-            }
-        )
-        fallback = StubLLM(
+        """The serving CloudLLM member stamps at source with its own identity."""
+        primary = ErrorLLM(model_name="primary", retry_policy=None)
+        fallback = _ServingCloudLLM(
             model_name="gpt-4o-mini",
             litellm_provider="openai",
-            response=served,
+            served=_served_with_usage("recovered"),
         )
         llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
 
-        result = await llm._generate_response_once(_USER_MSG)
+        result = await llm.generate_response(_USER_MSG)
 
         usage = result.usage
         assert usage is not None
@@ -244,6 +267,24 @@ class TestFallbackCostAttribution:
         # (an unknown model, which would silently yield no cost at all).
         assert usage.cost is not None
         assert usage.cost > 0
+
+    @pytest.mark.asyncio
+    async def test_non_cloud_member_cost_left_unstamped(self) -> None:
+        """
+        A non-cloud serving member has no pricing identity: cost stays None.
+        Neither the composite (reporting the primary's known name) nor the
+        base LLM layer may price it.
+        """
+        primary = ErrorLLM(model_name="gpt-4o", retry_policy=None)
+        fallback = StubLLM(
+            model_name="my-custom-model", response=_served_with_usage("recovered")
+        )
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
+
+        result = await llm.generate_response(_USER_MSG)
+
+        assert result.usage is not None
+        assert result.usage.cost is None
 
 
 class TestAnthropicDefaults:

--- a/tests/llm/test_recovery_hints.py
+++ b/tests/llm/test_recovery_hints.py
@@ -243,9 +243,7 @@ class TestRetryPolicyAlignment:
             (lambda: LlmApiTimeoutError(request=_fake_request()), True),
             (lambda: LlmApiConnectionError(request=_fake_request()), True),
             (
-                lambda: LlmRateLimitError(
-                    "x", response=_fake_response(), body=None
-                ),
+                lambda: LlmRateLimitError("x", response=_fake_response(), body=None),
                 True,
             ),
             (
@@ -272,9 +270,7 @@ class TestRetryPolicyAlignment:
                 False,
             ),
             (
-                lambda: LlmBadRequestError(
-                    "x", response=_fake_response(), body=None
-                ),
+                lambda: LlmBadRequestError("x", response=_fake_response(), body=None),
                 False,
             ),
             (

--- a/tests/llm/test_resilience.py
+++ b/tests/llm/test_resilience.py
@@ -9,6 +9,7 @@ Focuses on real pain points:
 
 from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass, field
+from functools import cached_property
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -20,9 +21,14 @@ from pydantic import BaseModel
 from grasp_agents.llm.cloud_llm import ApiCallParams, CloudLLM
 from grasp_agents.llm.fallback_llm import FallbackLLM, _select_cascade_error
 from grasp_agents.llm.llm import LLM
+from grasp_agents.llm.model_info import ModelCapabilities
 from grasp_agents.llm.resilience import RetryPolicy
 from grasp_agents.tools.base import BaseTool
 from grasp_agents.types.content import OutputMessageText
+from grasp_agents.types.errors import (
+    LLMResponseValidationError,
+    LLMToolCallValidationError,
+)
 from grasp_agents.types.items import InputItem, InputMessageItem, OutputMessageItem
 from grasp_agents.types.llm_errors import (
     LlmAuthenticationError,
@@ -41,6 +47,9 @@ from grasp_agents.types.llm_events import (
     ResponseRetrying,
 )
 from grasp_agents.types.response import Response
+from tests._helpers import MockLLM as HelperMockLLM
+from tests._helpers import _tool_call_response
+from tests.llm.test_llm_validation import AddTool
 
 _REQ = httpx.Request("POST", "https://test")
 
@@ -371,12 +380,13 @@ class TestFallbackLLM:
 
     @pytest.mark.asyncio
     async def test_primary_fails_fallback_succeeds(self) -> None:
-        """Primary error → first fallback tried and succeeds."""
+        """Primary error (member retries disabled) → first fallback succeeds."""
         primary = ErrorLLM(
             model_name="primary",
             error_to_raise=LlmInternalServerError(
                 "overloaded", response=_resp(503), body=None
             ),
+            retry_policy=None,
         )
         fallback = StubLLM(model_name="fallback", response=_text_response("recovered"))
 
@@ -389,14 +399,15 @@ class TestFallbackLLM:
     async def test_all_fail_retryable_error_wins_over_deterministic(self) -> None:
         """
         Primary fails transiently, last fallback fails deterministically →
-        the transient error is raised, so the outer retry layer still
-        retries the cascade (the primary deserves another shot).
+        the transient error is raised: callers see that the cascade may
+        succeed later, not the misconfigured fallback's config error.
         """
         primary = ErrorLLM(
             model_name="primary",
             error_to_raise=LlmInternalServerError(
                 "overloaded", response=_resp(503), body=None
             ),
+            retry_policy=None,
         )
         fallback = ErrorLLM(
             model_name="fallback",
@@ -450,10 +461,13 @@ class TestFallbackLLM:
 
     @pytest.mark.asyncio
     async def test_model_name_defaults_to_primary(self) -> None:
-        """FallbackLLM.model_name inherits from primary when empty."""
-        primary = StubLLM(model_name="gpt-4o")
+        """model_name inherits from the primary; explicit override wins."""
+        primary = StubLLM(model_name="gpt-4o", litellm_provider="openai")
         llm = FallbackLLM(primary=primary)
         assert llm.model_name == "gpt-4o"
+
+        override = FallbackLLM(model_name="my-cascade", primary=primary)
+        assert override.model_name == "my-cascade"
 
     @pytest.mark.asyncio
     async def test_stream_mid_failure_emits_fallback_marker(self) -> None:
@@ -467,6 +481,7 @@ class TestFallbackLLM:
             error_to_raise=LlmInternalServerError(
                 "mid-stream crash", response=_resp(502), body=None
             ),
+            retry_policy=None,
         )
         fallback = StubLLM(model_name="fallback", response=_text_response("recovered"))
 
@@ -503,6 +518,7 @@ class TestFallbackLLM:
             error_to_raise=LlmInternalServerError(
                 "overloaded", response=_resp(503), body=None
             ),
+            retry_policy=None,
         )
         fallback = ErrorLLM(
             model_name="fallback",
@@ -558,7 +574,7 @@ class TestCascadeErrorSelection:
         assert _select_cascade_error([_auth("first"), last]) is last
 
     def test_transient_preferred_over_floored_rate_limit(self) -> None:
-        """A retry pass needs one healthy member — don't park on retry_after."""
+        """Surface the shortest implied wait, not a retry_after park."""
         transient = _transient()
         assert _select_cascade_error([_rate_limited(60.0), transient]) is transient
 
@@ -572,71 +588,78 @@ class TestCascadeErrorSelection:
         assert _select_cascade_error(errors) is smallest
 
 
-class TestFallbackRetryGate:
-    """Cascade + outer retry layer: retry fires if ANY member failed retryably."""
+class TestFallbackMemberRetries:
+    """Retries-first cascade: members exhaust their own retries before failover."""
 
     @pytest.mark.asyncio
     @patch("grasp_agents.llm.llm.asyncio.sleep", new_callable=AsyncMock)
-    async def test_cascade_retried_when_last_member_fails_deterministically(
+    async def test_primary_blip_retried_on_primary_not_swapped(
         self, mock_sleep: AsyncMock
     ) -> None:
-        """
-        Primary blips (503), fallback is misconfigured (401). The 401 from
-        the last member must not suppress the retry pass: the cascade is
-        retried and the primary succeeds on the second pass.
-        """
+        """A transient blip is retried on the primary; the fallback stays cold."""
         primary = FailThenSucceedLLM(
             model_name="primary",
             error=LlmInternalServerError("blip", response=_resp(503), body=None),
             fail_count=1,
-            success_response=_text_response("recovered"),
-        )
-        fallback = ErrorLLM(model_name="fallback", error_to_raise=_auth("bad key"))
-        llm = FallbackLLM(
-            primary=primary,
-            fallbacks=(fallback,),
+            success_response=_text_response("from primary"),
             retry_policy=RetryPolicy(api_retries=1),
         )
+        fallback = StubLLM(model_name="fallback", response=_text_response("wrong"))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
 
         result = await llm.generate_response(_USER_MSG)
 
-        assert result.output_text == "recovered"
+        assert result.output_text == "from primary"
         assert primary.call_count == 2
-        assert fallback.call_count == 1
+        assert fallback.call_count == 0
         assert mock_sleep.call_count == 1
 
     @pytest.mark.asyncio
     @patch("grasp_agents.llm.llm.asyncio.sleep", new_callable=AsyncMock)
-    async def test_stream_cascade_retried_when_last_member_fails_deterministically(
+    async def test_primary_retries_exhausted_then_fallback(
         self, mock_sleep: AsyncMock
     ) -> None:
-        primary = FailThenSucceedLLM(
+        primary = ErrorLLM(
             model_name="primary",
-            error=LlmInternalServerError("blip", response=_resp(503), body=None),
-            fail_count=1,
-            success_response=_text_response("recovered"),
-        )
-        fallback = ErrorLLM(model_name="fallback", error_to_raise=_auth("bad key"))
-        llm = FallbackLLM(
-            primary=primary,
-            fallbacks=(fallback,),
+            error_to_raise=LlmInternalServerError(
+                "down", response=_resp(503), body=None
+            ),
             retry_policy=RetryPolicy(api_retries=1),
         )
+        fallback = StubLLM(model_name="fallback", response=_text_response("rescued"))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
 
-        events: list[LlmEvent] = []
-        async for event in llm.generate_response_stream(_USER_MSG):
-            events.append(event)
+        result = await llm.generate_response(_USER_MSG)
 
-        retrying = [e for e in events if isinstance(e, ResponseRetrying)]
-        assert len(retrying) == 1
-        completed = [e for e in events if isinstance(e, ResponseCompleted)]
-        assert len(completed) == 1
-        assert completed[0].response.output_text == "recovered"
+        assert result.output_text == "rescued"
+        assert primary.call_count == 2  # 1 initial + 1 retry, then failover
         assert fallback.call_count == 1
 
     @pytest.mark.asyncio
-    async def test_no_retry_when_all_members_fail_deterministically(self) -> None:
-        """Deterministic failures across the board → no retry passes."""
+    @patch("grasp_agents.llm.llm.asyncio.sleep", new_callable=AsyncMock)
+    async def test_deterministic_primary_error_fails_over_without_retries(
+        self, mock_sleep: AsyncMock
+    ) -> None:
+        """Deterministic errors skip the member's retries — no pointless waits."""
+        primary = ErrorLLM(
+            model_name="primary",
+            error_to_raise=LlmContextWindowError(
+                "too long", response=_resp(400), body=None
+            ),
+            retry_policy=RetryPolicy(api_retries=3),
+        )
+        fallback = StubLLM(model_name="fallback", response=_text_response("rescued"))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
+
+        result = await llm.generate_response(_USER_MSG)
+
+        assert result.output_text == "rescued"
+        assert primary.call_count == 1
+        assert mock_sleep.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_all_members_exhausted_raises(self) -> None:
+        """Every member fails deterministically → selected error, one call each."""
         primary = ErrorLLM(model_name="primary", error_to_raise=_auth("bad key"))
         fallback = ErrorLLM(
             model_name="fallback",
@@ -644,16 +667,265 @@ class TestFallbackRetryGate:
                 "too long", response=_resp(400), body=None
             ),
         )
-        llm = FallbackLLM(
-            primary=primary,
-            fallbacks=(fallback,),
-            retry_policy=RetryPolicy(api_retries=3),
-        )
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
 
         with pytest.raises(LlmContextWindowError, match="too long"):
             await llm.generate_response(_USER_MSG)
         assert primary.call_count == 1
         assert fallback.call_count == 1
+
+    @pytest.mark.asyncio
+    @patch("grasp_agents.llm.llm.asyncio.sleep", new_callable=AsyncMock)
+    async def test_stream_primary_blip_retried_within_member(
+        self, mock_sleep: AsyncMock
+    ) -> None:
+        """Stream: member-internal retry → ResponseRetrying, no ResponseFallback."""
+        primary = FailThenSucceedLLM(
+            model_name="primary",
+            error=LlmInternalServerError("blip", response=_resp(503), body=None),
+            fail_count=1,
+            success_response=_text_response("from primary"),
+            retry_policy=RetryPolicy(api_retries=1),
+        )
+        fallback = StubLLM(model_name="fallback", response=_text_response("wrong"))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
+
+        events: list[LlmEvent] = []
+        async for event in llm.generate_response_stream(_USER_MSG):
+            events.append(event)
+
+        assert len([e for e in events if isinstance(e, ResponseRetrying)]) == 1
+        assert not [e for e in events if isinstance(e, ResponseFallback)]
+        completed = [e for e in events if isinstance(e, ResponseCompleted)]
+        assert len(completed) == 1
+        assert completed[0].response.output_text == "from primary"
+        assert fallback.call_count == 0
+
+    def test_retry_policy_forbidden_on_composite(self) -> None:
+        """All retry behavior is member-level — any composite policy is rejected."""
+        primary = StubLLM(model_name="primary")
+
+        with pytest.raises(ValueError, match="member"):
+            FallbackLLM(primary=primary, retry_policy=RetryPolicy(api_retries=3))
+        with pytest.raises(ValueError, match="member"):
+            FallbackLLM(
+                primary=primary,
+                retry_policy=RetryPolicy(api_retries=0, validation_retries=2),
+            )
+
+        FallbackLLM(primary=primary, retry_policy=None)  # the only allowed value
+
+    def test_llm_settings_forbidden_on_composite(self) -> None:
+        """Settings live on members — a composite llm_settings is rejected."""
+        primary = StubLLM(model_name="primary")
+
+        with pytest.raises(ValueError, match="member"):
+            FallbackLLM(primary=primary, llm_settings={"temperature": 0.2})
+
+    def test_litellm_provider_forbidden_on_composite(self) -> None:
+        """Cost/capability resolution is per member — composite provider rejected."""
+        primary = StubLLM(model_name="primary", litellm_provider="openai")
+
+        with pytest.raises(ValueError, match="member"):
+            FallbackLLM(primary=primary, litellm_provider="openai")
+
+
+class TestFallbackValidationRetries:
+    """Validation retries are member-level: re-sample the serving member only."""
+
+    @pytest.mark.asyncio
+    async def test_malformed_output_resampled_from_primary_not_swapped(self) -> None:
+        class M(BaseModel):
+            x: int
+
+        primary = HelperMockLLM(
+            model_name="primary",
+            responses_queue=[_text_response("not json"), _text_response('{"x": 1}')],
+            retry_policy=RetryPolicy(validation_retries=1),
+        )
+        fallback = StubLLM(model_name="fallback", response=_text_response('{"x": 9}'))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
+
+        result = await llm.generate_response(_USER_MSG, output_schema=M)
+
+        assert result.output_text == '{"x": 1}'
+        assert primary.call_count == 2
+        assert fallback.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_fallback_validation_retry_does_not_reenter_cascade(self) -> None:
+        """
+        Primary fails on the API plane; the fallback's malformed response
+        is re-sampled from the FALLBACK — the primary is not re-paid.
+        """
+
+        class M(BaseModel):
+            x: int
+
+        primary = ErrorLLM(
+            model_name="primary",
+            error_to_raise=LlmInternalServerError(
+                "down", response=_resp(503), body=None
+            ),
+            retry_policy=None,
+        )
+        fallback = HelperMockLLM(
+            model_name="fallback",
+            responses_queue=[_text_response("not json"), _text_response('{"x": 1}')],
+            retry_policy=RetryPolicy(validation_retries=1),
+        )
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
+
+        result = await llm.generate_response(_USER_MSG, output_schema=M)
+
+        assert result.output_text == '{"x": 1}'
+        assert primary.call_count == 1
+        assert fallback.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_validation_exhaustion_raises_without_model_swap(self) -> None:
+        class M(BaseModel):
+            x: int
+
+        primary = HelperMockLLM(
+            model_name="primary",
+            responses_queue=[_text_response("not json"), _text_response("still bad")],
+            retry_policy=RetryPolicy(validation_retries=1),
+        )
+        fallback = StubLLM(model_name="fallback", response=_text_response('{"x": 9}'))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
+
+        with pytest.raises(LLMResponseValidationError):
+            await llm.generate_response(_USER_MSG, output_schema=M)
+        assert primary.call_count == 2
+        assert fallback.call_count == 0
+
+
+class TestFallbackToolCallValidation:
+    """Tool-call arg validation is member-level; exhaustion pierces the cascade."""
+
+    @pytest.mark.asyncio
+    async def test_bad_tool_args_resampled_from_serving_member(self) -> None:
+        primary = HelperMockLLM(
+            model_name="primary",
+            responses_queue=[
+                _tool_call_response("add", '{"a": 1, "b": "x"}', "call-1"),
+                _tool_call_response("add", '{"a": 1, "b": 2}', "call-2"),
+            ],
+            retry_policy=RetryPolicy(validation_retries=1),
+        )
+        fallback = StubLLM(model_name="fallback")
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
+
+        result = await llm.generate_response(_USER_MSG, tools={"add": AddTool()})
+
+        assert result.tool_call_items[0].call_id == "call-2"
+        assert primary.call_count == 2
+        assert fallback.call_count == 0
+
+    @pytest.mark.asyncio
+    async def test_exhausted_tool_call_validation_pierces_with_payload(self) -> None:
+        """
+        The agent loop recovers from this error by synthesizing tool_results
+        from ``failed_calls`` + ``response`` — both must survive the cascade
+        unchanged, and no fallback model may answer in between.
+        """
+        primary = HelperMockLLM(
+            model_name="primary",
+            responses_queue=[
+                _tool_call_response("add", '{"a": 1, "b": "x"}', "call-1")
+            ],
+        )
+        fallback = StubLLM(model_name="fallback")
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
+
+        with pytest.raises(LLMToolCallValidationError) as exc_info:
+            await llm.generate_response(_USER_MSG, tools={"add": AddTool()})
+
+        err = exc_info.value
+        assert err.response is not None
+        assert [call_id for call_id, _, _ in err.failed_calls] == ["call-1"]
+        assert fallback.call_count == 0
+
+
+# ---------- Capabilities merge ----------
+
+
+def _caps(
+    max_in: int | None,
+    max_out: int | None = None,
+    *,
+    vision: bool = True,
+) -> ModelCapabilities:
+    return ModelCapabilities(
+        function_calling=True,
+        vision=vision,
+        output_schema=True,
+        prompt_caching=True,
+        reasoning=True,
+        web_search=True,
+        audio_input=True,
+        max_input_tokens=max_in,
+        max_output_tokens=max_out,
+    )
+
+
+@dataclass(frozen=True)
+class CapsStubLLM(StubLLM):
+    """StubLLM with fixed capabilities (bypasses the litellm lookup)."""
+
+    caps: ModelCapabilities = field(default_factory=lambda: _caps(None))
+
+    @cached_property
+    def capabilities(self) -> ModelCapabilities:
+        return self.caps
+
+
+class TestFallbackCapabilities:
+    """Composite capabilities = conservative merge across members."""
+
+    def test_smallest_known_windows_win(self) -> None:
+        primary = CapsStubLLM(model_name="big", caps=_caps(1_000_000, 64_000))
+        fallback = CapsStubLLM(model_name="small", caps=_caps(200_000, 8_192))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
+
+        assert llm.capabilities.max_input_tokens == 200_000
+        assert llm.capabilities.max_output_tokens == 8_192
+
+    def test_unknown_windows_skipped(self) -> None:
+        primary = CapsStubLLM(model_name="unknown", caps=_caps(None, None))
+        fallback = CapsStubLLM(model_name="known", caps=_caps(128_000, 16_384))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
+
+        assert llm.capabilities.max_input_tokens == 128_000
+        assert llm.capabilities.max_output_tokens == 16_384
+
+        all_unknown = FallbackLLM(primary=primary)
+        assert all_unknown.capabilities.max_input_tokens is None
+
+    def test_features_require_every_member(self) -> None:
+        primary = CapsStubLLM(model_name="sighted", caps=_caps(None, vision=True))
+        fallback = CapsStubLLM(model_name="blind", caps=_caps(None, vision=False))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
+
+        assert llm.capabilities.vision is False
+        assert llm.capabilities.function_calling is True
+
+    def test_default_budget_sized_to_smallest_member(self) -> None:
+        """The agent's context budget holds for whichever member serves."""
+        from grasp_agents.agent.context_window import ContextWindowManager
+        from grasp_agents.agent.llm_agent_transcript import LLMAgentTranscript
+
+        primary = CapsStubLLM(model_name="big", caps=_caps(1_000_000, 64_000))
+        fallback = CapsStubLLM(model_name="small", caps=_caps(200_000, 8_192))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
+
+        cw = ContextWindowManager(transcript=LLMAgentTranscript(), llm=llm, source="A")
+        budget = cw.default_budget()
+
+        assert budget.max_input_tokens == 200_000
+        assert budget.buffer_tokens == 8_192
+        assert budget.soft_limit == 200_000 - 8_192
 
 
 # ---------- API Retry Loop ----------
@@ -885,7 +1157,9 @@ class TestStreamErrorMapping:
     @pytest.mark.asyncio
     async def test_fallback_engages_on_lazy_sdk_error(self) -> None:
         """429 during primary's stream iteration → cascade to the fallback."""
-        primary = LazyStreamCloudLLM(model_name="primary", fail_attempts=99)
+        primary = LazyStreamCloudLLM(
+            model_name="primary", fail_attempts=99, retry_policy=None
+        )
         fallback = StubLLM(model_name="fallback", response=_text_response("rescued"))
         llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
 

--- a/tests/tools/file_edit/test_agent_state_isolation.py
+++ b/tests/tools/file_edit/test_agent_state_isolation.py
@@ -26,14 +26,17 @@ def _make_loop():
         model_name = "stub"
         litellm_provider = "stub"
 
+    stub_llm = _StubLLM()
     transcript = LLMAgentTranscript()
     agent_ctx = AgentContext.create(transcript=transcript, tools={}, agent_name="A")
     return AgentLoop[BaseModel](
         agent_name="A",
-        llm=_StubLLM(),  # type: ignore[arg-type]
+        llm=stub_llm,  # type: ignore[arg-type]
         agent_ctx=agent_ctx,
         context_window=ContextWindowManager(
-            transcript=transcript, model="stub", source="A"
+            transcript=transcript,
+            llm=stub_llm,  # type: ignore[arg-type]
+            source="A",
         ),
         ctx=SessionContext[BaseModel](),  # type: ignore[call-arg]
         max_turns=1,

--- a/uv.lock
+++ b/uv.lock
@@ -1181,7 +1181,7 @@ wheels = [
 
 [[package]]
 name = "grasp-agents"
-version = "1.0.21"
+version = "1.0.22"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
# Retries-first fallbacks: member-owned resilience, cost, and capabilities

## Motivation

`FallbackLLM` previously treated the cascade itself as the API-retry layer: each
member was tried exactly once per pass (bypassing its own `retry_policy`), and the
composite's retry policy re-ran the whole cascade with backoff. In practice this
meant a single transient 503 on the primary immediately demoted the call to a
fallback model — per-member retries never fired while any fallback was healthy.
For workloads with prompts tuned to a specific model, silently swapping models on
a random blip is the wrong default; retrying the same model first is almost always
preferable, with failover reserved for genuine outages. This aligns with how
LiteLLM's Router layers retries inside fallbacks.

Two adjacent issues fell out of the same review:

- Cost stamping was split across layers (provider code, the cascade, and the agent
  loop passing a model name to the usage tracker) — and the agent-loop path priced
  fallback-served responses with the wrong model identity.
- The context budget was sized to the composite's reported `model_name` (the
  primary), so compaction could produce views too large for a smaller-window
  fallback to serve.

## What changed

### `FallbackLLM`: retries first, then failover

- The cascade now calls each member's **public** `generate_response(_stream)` —
  the member's full pipeline. A member exhausts its own API retries (backoff,
  `retry_after` floors) and its own validation retries before the cascade
  advances. Deterministic errors (auth, bad request, context window) skip that
  member's retries and fail over immediately, so nothing sleeps on an error that
  retrying cannot fix.
- Validation failures never swap models: a malformed response is re-sampled from
  the member that produced it, and validation errors propagate out of the cascade
  rather than triggering failover. Tool-call validation behaves the same, and on
  exhaustion the error's `failed_calls` / `response` payload survives intact for
  the agent loop's synthesized tool-result recovery.
- Composite configuration is locked down: `retry_policy`, `llm_settings`, and
  `litellm_provider` must be `None` on `FallbackLLM` (`ValueError` otherwise).
  All resilience, sampling settings, and pricing/capability identity are
  member-level; a composite retry policy would silently multiply member retries.
- Response validation and cost stamping are no-ops / absent at the composite
  level — the serving member is authoritative.
- When every member fails, the cascade raises the member error most worth
  retrying (transient preferred over deterministic; among rate limits, the
  smallest `retry_after`) instead of whichever member happened to fail last — a
  misconfigured fallback's 401 can no longer mask the primary's transient error.
  Per-member failures remain visible via warning logs and streaming
  `ResponseFallback` events.

### Cost stamping owned by `CloudLLM`

- `_stamp_cost` (definition and both call sites) now lives on `CloudLLM`, at
  response-production time. Under a cascade, the serving member prices its own
  response — never the `model_name` the composite reports.
- The base `LLM` class has no pricing logic: a local or mock LLM that reports
  token usage has no price, and a base-level pricing lookup would warn on every
  call. Non-cloud responses now carry `cost=None` instead of being priced by
  name.
- The agent loop no longer passes `model_name` / `litellm_provider` to
  `UsageTracker.update`; responses arrive already costed. The tracker keeps its
  optional identity parameters for standalone use.

### Conservative capability merge for context budgeting

- `FallbackLLM.capabilities` returns the conservative merge across members: the
  smallest known `max_input_tokens` / `max_output_tokens` (members with unknown
  windows are skipped), and feature flags AND-ed — a capability is advertised
  only if every member supports it.
- `ContextBudget.from_capabilities(...)` added; `for_model` delegates to it.
- `ContextWindowManager` now takes the agent's `llm` (previously a bare model
  name) and sizes its default budget from `llm.capabilities` — so an agent on a
  fallback cascade compacts to a view servable by whichever member answers.
  An explicit `budget=` on a compaction strategy still overrides the derived
  default for callers who prefer to budget for the primary.

## Breaking changes

- `FallbackLLM(retry_policy=...)`, `FallbackLLM(llm_settings=...)`, and
  `FallbackLLM(litellm_provider=...)` now raise `ValueError` — configure these on
  the member LLMs.
- Cascade behavior: members retry internally before failover (previously one
  attempt per member per pass, with composite-level retry passes).
- `ContextWindowManager(transcript=..., model=...)` →
  `ContextWindowManager(transcript=..., llm=...)`.
- Responses from non-cloud LLMs are no longer priced by the agent loop's usage
  tracking (`cost` stays `None`).

## Tests

- `tests/llm/test_resilience.py`: new suites for member-owned retries
  (`TestFallbackMemberRetries`), validation re-sampling and no-model-swap
  guarantees (`TestFallbackValidationRetries`, `TestFallbackToolCallValidation`),
  all-fail error selection (`TestCascadeErrorSelection`), forbidden composite
  config, and the capability merge + budget seam (`TestFallbackCapabilities`).
- `tests/llm/test_llm_core.py`: cost attribution pinned at the serving-member
  level (`_ServingCloudLLM` stub), including the non-cloud-member-stays-unpriced
  case.

Full suite: 2709 passed. Pyright clean on the touched packages.
