### PR TITLE
update openai

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -47,10 +47,12 @@
         "getpgid",
         "Ghostty",
         "halfcell",
+        "Includable",
         "iopub",
         "ipykernel",
         "ipynb",
         "iTerm",
+        "jsonable",
         "jupyter",
         "kernelspec",
         "killpg",
@@ -92,6 +94,7 @@
         "unsandboxed",
         "unwedges",
         "WezTerm",
+        "xhigh",
         "zmq"
     ],
     "patterns": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grasp_agents"
-version = "1.0.23"
+version = "1.0.24"
 description = "Grasp Agents Library"
 readme = "README.md"
 requires-python = ">=3.12,<4"
@@ -15,7 +15,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    "openai>=2.23,<3",
+    "openai>=2.47,<3",
     "litellm>=1.82,<2",
     "httpx>=0.27.0,<1",
     "pyyaml>=6.0.2,<7",

--- a/src/grasp_agents/agent/agent_loop.py
+++ b/src/grasp_agents/agent/agent_loop.py
@@ -47,6 +47,7 @@ from grasp_agents.types.items import (
     OutputItem,
     OutputMessageItem,
     ReasoningItem,
+    WebSearchCallItem,
 )
 from grasp_agents.types.llm_errors import LlmContextWindowError
 from grasp_agents.types.llm_events import (
@@ -623,13 +624,14 @@ class AgentLoop[CtxT]:
                 yield OutputMessageItemEvent(
                     source=self.agent_name, exec_id=exec_id, data=item
                 )
-            else:
-                # The only remaining OutputItem kind — a server-side web
-                # search/fetch call (web_search_call). Surface it so consoles
+            elif isinstance(item, WebSearchCallItem):
+                # A server-side web search/fetch call — surface it so consoles
                 # show what the model searched, instead of dropping it.
                 yield WebSearchCallItemEvent(
                     source=self.agent_name, exec_id=exec_id, data=item
                 )
+            # UnknownItem: kept in the transcript for round-trip fidelity but
+            # has no dedicated event.
 
     @traced(name="generate")
     async def query_llm(

--- a/src/grasp_agents/examples/notebooks/orchestration_durability.ipynb
+++ b/src/grasp_agents/examples/notebooks/orchestration_durability.ipynb
@@ -105,7 +105,7 @@
     "    the records cancelled, and cancelled records are skipped on resume.) The\n",
     "    checkpoints + task records persist on disk; that's what resume works from.\n",
     "    \"\"\"\n",
-    "    tasks = [bt.task for bt in agent.agent_ctx.bg_tasks._tasks.values()]  # noqa: SLF001\n",
+    "    tasks = [bt.consumer for bt in agent.agent_ctx.bg_tasks._tasks.values()]  # noqa: SLF001\n",
     "    for t in tasks:\n",
     "        t.cancel()\n",
     "    await asyncio.gather(*tasks, return_exceptions=True)"

--- a/src/grasp_agents/llm_providers/anthropic/provider_output_to_response.py
+++ b/src/grasp_agents/llm_providers/anthropic/provider_output_to_response.py
@@ -25,10 +25,6 @@ from anthropic.types.web_search_tool_result_error import (
 )
 from openai.types.responses import ResponseStatus
 from openai.types.responses.response import IncompleteDetails
-from openai.types.responses.response_usage import (
-    InputTokensDetails,
-    OutputTokensDetails,
-)
 
 from grasp_agents.types.content import (
     Annotation,
@@ -47,6 +43,8 @@ from grasp_agents.types.items import (
     WebSearchCallItem,
 )
 from grasp_agents.types.response import (
+    InputTokensDetails,
+    OutputTokensDetails,
     Response,
     ResponseUsage,
 )
@@ -287,8 +285,10 @@ def convert_usage(usage: AnthropicUsage) -> ResponseUsage:
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         total_tokens=input_tokens + output_tokens,
-        input_tokens_details=InputTokensDetails(cached_tokens=cache_read),
-        cache_creation_tokens=cache_write,
+        input_tokens_details=InputTokensDetails(
+            cached_tokens=cache_read, cache_write_tokens=cache_write
+        ),
+        # Anthropic does not report reasoning tokens, so we default to 0.
         output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
     )
 

--- a/src/grasp_agents/llm_providers/anthropic/response_to_provider_inputs.py
+++ b/src/grasp_agents/llm_providers/anthropic/response_to_provider_inputs.py
@@ -51,6 +51,7 @@ from grasp_agents.types.content import (
 from grasp_agents.types.items import (
     FunctionToolCallItem,
     FunctionToolOutputItem,
+    InputItem,
     InputMessageItem,
     OpenPageAction,
     OutputItem,
@@ -58,6 +59,7 @@ from grasp_agents.types.items import (
     ReasoningItem,
     SearchAction,
     SearchSource,
+    UnknownItem,
     WebSearchCallItem,
 )
 
@@ -80,17 +82,20 @@ def _to_cache_control(
 
 
 def items_to_provider_inputs(
-    items: Sequence[InputMessageItem | OutputItem | FunctionToolOutputItem],
+    items: Sequence[InputItem],
 ) -> tuple[str | list[TextBlockParam] | None, list[MessageParam]]:
     """
     Convert memory items to Anthropic message format.
 
-    Returns ``(system, messages)`` where *system* is extracted from
-    system/developer role items. Each system-role text part becomes its
-    own :class:`TextBlockParam` (Anthropic accepts a block array for
-    ``system``), so per-block :class:`CacheControl` checkpoints reach the
-    API and multi-part prompts are never flattened. The payload collapses
-    to a plain string only in the trivial single-part, no-cache case.
+    Returns ``(system, messages)`` where *system* holds the leading run of
+    system/developer role items; later ones become system-role messages at
+    their position (the item order is passed through as-is — the API
+    enforces the placement rules and model support). Each system-role text
+    part becomes its own :class:`TextBlockParam` (Anthropic accepts a block
+    array for ``system``), so per-block :class:`CacheControl` checkpoints
+    reach the API and multi-part prompts are never flattened. The payload
+    collapses to a plain string only in the trivial single-part, no-cache
+    case.
     """
     system_blocks: list[TextBlockParam] = []
     messages: list[MessageParam] = []
@@ -102,16 +107,24 @@ def items_to_provider_inputs(
 
         if isinstance(item, InputMessageItem):
             if item.role in {"system", "developer"}:
-                for part in item.content:
-                    if not isinstance(part, InputText):
-                        continue
-                    system_blocks.append(
-                        TextBlockParam(
-                            type="text",
-                            text=part.text,
-                            cache_control=_to_cache_control(part.cache_control),
-                        )
+                blocks = [
+                    TextBlockParam(
+                        type="text",
+                        text=part.text,
+                        cache_control=_to_cache_control(part.cache_control),
                     )
+                    for part in item.content
+                    if isinstance(part, InputText)
+                ]
+                if messages:
+                    # Mid-conversation system/developer instructions become
+                    # system-role messages at their position; only the leading
+                    # run is hoisted into the top-level ``system``. The item
+                    # order is passed through as-is — the API enforces the
+                    # placement rules and model support (Opus 4.8+).
+                    messages.append(MessageParam(role="system", content=blocks))
+                else:
+                    system_blocks.extend(blocks)
                 i += 1
             else:
                 messages.append(
@@ -146,6 +159,10 @@ def items_to_provider_inputs(
                 )
                 i += 1
             messages.append(MessageParam(role="user", content=tool_results))
+
+        elif isinstance(item, UnknownItem):
+            # Only the OpenAI Responses provider can round-trip these.
+            i += 1
 
         else:
             # Collect consecutive assistant-side items into one message
@@ -302,6 +319,10 @@ def _output_group_to_message_param(output_items: Sequence[OutputItem]) -> Messag
                 content.extend(_web_fetch_to_blocks(item))
             else:
                 content.extend(_web_search_to_blocks(item))
+
+        elif isinstance(item, UnknownItem):
+            # Only the OpenAI Responses provider can round-trip these.
+            continue
 
         else:
             # Tolerate empty arguments from older transcripts (a no-arg

--- a/src/grasp_agents/llm_providers/gemini/llm_event_converters.py
+++ b/src/grasp_agents/llm_providers/gemini/llm_event_converters.py
@@ -13,14 +13,14 @@ import time
 from typing import TYPE_CHECKING
 
 from openai.types.responses.response import IncompleteDetails
-from openai.types.responses.response_usage import (
-    InputTokensDetails,
-    OutputTokensDetails,
-)
 
 from grasp_agents.llm.llm_stream_converter import BaseLlmStreamConverter
 from grasp_agents.types.items import prefixed_id
-from grasp_agents.types.response import ResponseUsage
+from grasp_agents.types.response import (
+    InputTokensDetails,
+    OutputTokensDetails,
+    ResponseUsage,
+)
 
 from . import GeminiResponse
 from .provider_output_to_response import (

--- a/src/grasp_agents/llm_providers/gemini/provider_output_to_response.py
+++ b/src/grasp_agents/llm_providers/gemini/provider_output_to_response.py
@@ -26,10 +26,6 @@ from google.genai.types import GenerateContentResponse as GeminiResponse
 from openai.types.responses import ResponseStatus
 from openai.types.responses.response import IncompleteDetails
 from openai.types.responses.response_output_text import Logprob, LogprobTopLogprob
-from openai.types.responses.response_usage import (
-    InputTokensDetails,
-    OutputTokensDetails,
-)
 
 from grasp_agents.types.content import (
     AnnotationUrlCitation,
@@ -48,6 +44,8 @@ from grasp_agents.types.items import (
     prefixed_id,
 )
 from grasp_agents.types.response import (
+    InputTokensDetails,
+    OutputTokensDetails,
     Response,
     ResponseUsage,
 )

--- a/src/grasp_agents/llm_providers/gemini/response_to_provider_inputs.py
+++ b/src/grasp_agents/llm_providers/gemini/response_to_provider_inputs.py
@@ -22,10 +22,12 @@ from grasp_agents.types.content import (
 from grasp_agents.types.items import (
     FunctionToolCallItem,
     FunctionToolOutputItem,
+    InputItem,
     InputMessageItem,
     OutputItem,
     OutputMessageItem,
     ReasoningItem,
+    UnknownItem,
     WebSearchCallItem,
 )
 
@@ -45,7 +47,7 @@ if TYPE_CHECKING:
 
 
 def items_to_provider_inputs(
-    items: Sequence[InputMessageItem | OutputItem | FunctionToolOutputItem],
+    items: Sequence[InputItem],
 ) -> tuple[str | GeminiContent | None, list[GeminiContent]]:
     """
     Convert response items to Gemini content format.
@@ -78,6 +80,10 @@ def items_to_provider_inputs(
             contents.append(
                 _tool_output_to_content(item, call_id_to_name=call_id_to_name)
             )
+            i += 1
+
+        elif isinstance(item, UnknownItem):
+            # Only the OpenAI Responses provider can round-trip these.
             i += 1
 
         else:

--- a/src/grasp_agents/llm_providers/openai_completions/completions_llm.py
+++ b/src/grasp_agents/llm_providers/openai_completions/completions_llm.py
@@ -11,6 +11,12 @@ from openai.lib.streaming.chat import (
     AsyncChatCompletionStreamManager as OpenAIAsyncChatCompletionStreamManager,
 )
 from openai.lib.streaming.chat import ChunkEvent as OpenAIChunkEvent
+from openai.types.chat.completion_create_params import (
+    Moderation as CompletionsModeration,
+)
+from openai.types.chat.completion_create_params import (
+    PromptCacheOptions as CompletionsPromptCacheOptions,
+)
 from pydantic import BaseModel, ConfigDict, with_config
 
 from grasp_agents.llm.cloud_llm import (
@@ -76,7 +82,7 @@ _COMPAT_LITELLM_PROVIDERS = {
 }
 
 CompletionsReasoningEffort = Literal[
-    "none", "disable", "minimal", "low", "medium", "high"
+    "none", "disable", "minimal", "low", "medium", "high", "xhigh", "max"
 ]
 
 
@@ -116,6 +122,8 @@ class OpenAILLMSettings(CloudLLMSettings, total=False):
     verbosity: Literal["low", "medium", "high"] | None
     prompt_cache_key: str
     prompt_cache_retention: Literal["in_memory", "24h"] | None
+    prompt_cache_options: CompletionsPromptCacheOptions | None
+    moderation: CompletionsModeration | None
     safety_identifier: str
 
     # TODO: support audio

--- a/src/grasp_agents/llm_providers/openai_completions/provider_output_to_response.py
+++ b/src/grasp_agents/llm_providers/openai_completions/provider_output_to_response.py
@@ -16,10 +16,6 @@ from openai.types.chat.chat_completion_message_function_tool_call import (
 )
 from openai.types.responses.response import IncompleteDetails
 from openai.types.responses.response_status import ResponseStatus
-from openai.types.responses.response_usage import (
-    InputTokensDetails,
-    OutputTokensDetails,
-)
 from pydantic import TypeAdapter, ValidationError
 
 from grasp_agents.types.content import (
@@ -37,7 +33,12 @@ from grasp_agents.types.items import (
     ReasoningItem,
 )
 from grasp_agents.types.reasoning import OpenRouterReasoningDetails
-from grasp_agents.types.response import Response, ResponseUsage
+from grasp_agents.types.response import (
+    InputTokensDetails,
+    OutputTokensDetails,
+    Response,
+    ResponseUsage,
+)
 
 from .logprob_converters import convert_logprobs
 from .utils import validate_completion
@@ -186,10 +187,14 @@ def _extract_tool_call_items(
 
 def convert_usage(raw_usage: CompletionUsage) -> ResponseUsage:
     cached_tokens = 0
+    cache_write_tokens = 0
     reasoning_tokens = 0
 
     if raw_usage.prompt_tokens_details is not None:
         cached_tokens = raw_usage.prompt_tokens_details.cached_tokens or 0
+        cache_write_tokens = (
+            getattr(raw_usage.prompt_tokens_details, "cache_write_tokens", None) or 0
+        )
 
     if raw_usage.completion_tokens_details is not None:
         reasoning_tokens = raw_usage.completion_tokens_details.reasoning_tokens or 0
@@ -198,7 +203,9 @@ def convert_usage(raw_usage: CompletionUsage) -> ResponseUsage:
         input_tokens=raw_usage.prompt_tokens,
         output_tokens=raw_usage.completion_tokens,
         total_tokens=raw_usage.total_tokens,
-        input_tokens_details=InputTokensDetails(cached_tokens=cached_tokens),
+        input_tokens_details=InputTokensDetails(
+            cached_tokens=cached_tokens, cache_write_tokens=cache_write_tokens
+        ),
         output_tokens_details=OutputTokensDetails(reasoning_tokens=reasoning_tokens),
     )
 

--- a/src/grasp_agents/llm_providers/openai_completions/response_to_provider_inputs.py
+++ b/src/grasp_agents/llm_providers/openai_completions/response_to_provider_inputs.py
@@ -29,6 +29,7 @@ from openai.types.chat.chat_completion_content_part_param import (
 )
 from openai.types.chat.chat_completion_content_part_text_param import (
     ChatCompletionContentPartTextParam,
+    PromptCacheBreakpoint,
 )
 from openai.types.chat.chat_completion_developer_message_param import (
     ChatCompletionDeveloperMessageParam,
@@ -50,7 +51,7 @@ from openai.types.chat.chat_completion_user_message_param import (
     ChatCompletionUserMessageParam,
 )
 
-from grasp_agents.types.content import InputImage, InputText
+from grasp_agents.types.content import InputFile, InputImage, InputText
 from grasp_agents.types.items import (
     FunctionToolCallItem,
     FunctionToolOutputItem,
@@ -59,6 +60,7 @@ from grasp_agents.types.items import (
     OutputItem,
     OutputMessageItem,
     ReasoningItem,
+    UnknownItem,
 )
 from grasp_agents.types.reasoning import (
     OpenRouterReasoningDetails,
@@ -107,6 +109,10 @@ def items_to_provider_inputs(
             messages.append(_tool_output_to_message_param(item))
             i += 1
 
+        elif isinstance(item, UnknownItem):
+            # Only the OpenAI Responses provider can round-trip these.
+            i += 1
+
         else:
             # Collect consecutive assistant-side items into one message
             group: list[OutputItem] = [item]
@@ -123,18 +129,58 @@ def items_to_provider_inputs(
     return messages
 
 
+def _apply_cache_breakpoint(
+    param: ChatCompletionContentPartTextParam
+    | ChatCompletionContentPartImageParam
+    | ChatCompletionContentPartFileParam,
+    part: InputText | InputImage | InputFile,
+) -> None:
+    """
+    Attach an explicit prompt-cache breakpoint (gpt-5.6+) to a content-part
+    param when the source part carries a ``CacheControl``. The TTL comes from
+    the request-level ``prompt_cache_options``, so ``CacheControl.ttl`` is
+    ignored here.
+    """
+    if part.cache_control is not None:
+        param["prompt_cache_breakpoint"] = PromptCacheBreakpoint(mode="explicit")
+
+
+def _text_content(
+    item: InputMessageItem,
+) -> str | list[ChatCompletionContentPartTextParam]:
+    # Text parts carrying a CacheControl stay structured so the explicit
+    # prompt-cache breakpoint reaches the API; otherwise flatten to a string.
+    if all(
+        not isinstance(part, InputText) or part.cache_control is None
+        for part in item.content
+    ):
+        return item.text
+
+    params: list[ChatCompletionContentPartTextParam] = []
+    for part in item.content:
+        if isinstance(part, InputText):
+            param = ChatCompletionContentPartTextParam(type="text", text=part.text)
+            _apply_cache_breakpoint(param, part)
+            params.append(param)
+    return params
+
+
 def _input_message_to_message_param(
     item: InputMessageItem,
 ) -> ChatCompletionMessageParam:
     """Convert an InputMessageItem to a user/system/developer message param."""
     if item.role == "system":
-        return ChatCompletionSystemMessageParam(role="system", content=item.text)
+        return ChatCompletionSystemMessageParam(
+            role="system", content=_text_content(item)
+        )
     if item.role == "developer":
-        return ChatCompletionDeveloperMessageParam(role="developer", content=item.text)
+        return ChatCompletionDeveloperMessageParam(
+            role="developer", content=_text_content(item)
+        )
 
     text_only = all(isinstance(part, InputText) for part in item.content)
     if text_only:
-        return ChatCompletionUserMessageParam(role="user", content=item.text)
+        return ChatCompletionUserMessageParam(role="user", content=_text_content(item))
 
     content: list[
         ChatCompletionContentPartTextParam
@@ -144,16 +190,16 @@ def _input_message_to_message_param(
 
     for part in item.content:
         if isinstance(part, InputText):
-            content.append(
-                ChatCompletionContentPartTextParam(type="text", text=part.text)
-            )
+            text_param = ChatCompletionContentPartTextParam(type="text", text=part.text)
+            _apply_cache_breakpoint(text_param, part)
+            content.append(text_param)
         elif isinstance(part, InputImage):
-            content.append(
-                ChatCompletionContentPartImageParam(
-                    type="image_url",
-                    image_url=ImageURL(url=part.to_str(), detail=part.detail),  # type: ignore[call-arg]
-                )
+            image_param = ChatCompletionContentPartImageParam(
+                type="image_url",
+                image_url=ImageURL(url=part.to_str(), detail=part.detail),  # type: ignore[call-arg]
             )
+            _apply_cache_breakpoint(image_param, part)
+            content.append(image_param)
         else:  # InputFile — the remaining InputPart member
             file_param: ChatCompletionFileFileParam = {}
             if part.file_data:
@@ -162,9 +208,9 @@ def _input_message_to_message_param(
                 file_param["file_id"] = part.file_id
             if part.filename:
                 file_param["filename"] = part.filename
-            content.append(
-                ChatCompletionContentPartFileParam(type="file", file=file_param)
-            )
+            file_part = ChatCompletionContentPartFileParam(type="file", file=file_param)
+            _apply_cache_breakpoint(file_part, part)
+            content.append(file_part)
 
     return ChatCompletionUserMessageParam(role="user", content=content)
 

--- a/src/grasp_agents/llm_providers/openai_responses/response_to_provider_inputs.py
+++ b/src/grasp_agents/llm_providers/openai_responses/response_to_provider_inputs.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, cast
 
 from openai.types.responses.response_function_web_search_param import (
+    ActionFind as ActionFindParam,
+)
+from openai.types.responses.response_function_web_search_param import (
     ActionOpenPage as ActionOpenPageParam,
 )
 from openai.types.responses.response_function_web_search_param import (
@@ -20,7 +23,14 @@ from openai.types.responses.response_input_item_param import (
     ResponseInputItemParam,
 )
 
-from grasp_agents.types.items import InputItem, SearchAction, WebSearchCallItem
+from grasp_agents.types.items import (
+    FindInPageAction,
+    FunctionToolOutputItem,
+    InputItem,
+    InputMessageItem,
+    SearchAction,
+    WebSearchCallItem,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -30,6 +40,7 @@ _GRASP_EXTENSION_FIELDS = {
     "redacted",
     "provider_specific_fields",
     "is_error",
+    "cache_control",
 }
 
 # Same, on content/output/summary parts and their annotations — the API rejects
@@ -49,6 +60,24 @@ def _iter_part_dicts(dumped: dict[str, Any]) -> Iterator[dict[str, Any]]:
         for part in cast("list[object]", parts):
             if isinstance(part, dict):
                 yield cast("dict[str, Any]", part)
+
+
+def _reapply_part_cache_breakpoints(item: InputItem, dumped: dict[str, Any]) -> None:
+    """
+    Attach an explicit prompt-cache breakpoint (gpt-5.6+) to each part param
+    whose source part carries a ``CacheControl``. The TTL comes from the
+    request-level ``prompt_cache_options``, so ``CacheControl.ttl`` is
+    ignored here.
+    """
+    if isinstance(item, InputMessageItem):
+        parts, part_params = item.content, dumped["content"]
+    elif isinstance(item, FunctionToolOutputItem) and isinstance(item.output, list):
+        parts, part_params = item.output, dumped["output"]
+    else:
+        return
+    for part, part_param in zip(parts, part_params, strict=True):
+        if part.cache_control is not None:
+            part_param["prompt_cache_breakpoint"] = {"mode": "explicit"}
 
 
 def _scrub_part_fields(dumped: dict[str, Any]) -> None:
@@ -71,16 +100,17 @@ def items_to_provider_inputs(
         if isinstance(item, WebSearchCallItem):
             result.append(_web_search_item_to_param(item))
             continue
-        dumped = item.model_dump(  # type: ignore[arg-type]
+        dumped = item.model_dump(
             exclude=_GRASP_EXTENSION_FIELDS, exclude_none=True, mode="json"
         )
         _scrub_part_fields(dumped)
+        _reapply_part_cache_breakpoints(item, dumped)
         # The Responses API reads a client-sent message ``id`` as a reference to a
         # stored item and 404s on it (fatally when the message carries an image);
         # our ``msg_`` ids are internal bookkeeping, so don't echo them back.
         if dumped.get("type") == "message":
             dumped.pop("id", None)
-        result.append(dumped)  # type: ignore[arg-type]
+        result.append(cast("ResponseInputItemParam", dumped))
     return result
 
 
@@ -89,19 +119,25 @@ def _web_search_item_to_param(
 ) -> ResponseFunctionWebSearchParam:
     """Convert WebSearchCallItem to Responses API input param."""
     action = item.action
-    api_action: ActionSearchParam | ActionOpenPageParam
+    api_action: ActionSearchParam | ActionOpenPageParam | ActionFindParam
     if isinstance(action, SearchAction):
-        api_action = ActionSearchParam(
-            type="search",
-            query=action.queries[0] if action.queries else "",
-            queries=action.queries or [],
-            sources=[
+        api_action = ActionSearchParam(type="search")
+        if action.queries:
+            api_action["query"] = action.queries[0]
+            api_action["queries"] = action.queries
+        if action.sources:
+            api_action["sources"] = [
                 ActionSearchSourceParam(type="url", url=s.url)
-                for s in (action.sources or [])
-            ],
+                for s in action.sources
+            ]
+
+    elif isinstance(action, FindInPageAction):
+        api_action = ActionFindParam(
+            type="find_in_page", url=action.url or "", pattern=action.pattern or ""
         )
     else:
         api_action = ActionOpenPageParam(type="open_page", url=action.url)
+
     return ResponseFunctionWebSearchParam(
         type="web_search_call",
         id=item.id,

--- a/src/grasp_agents/llm_providers/openai_responses/responses_llm.py
+++ b/src/grasp_agents/llm_providers/openai_responses/responses_llm.py
@@ -24,6 +24,12 @@ from openai.types.responses.response_create_params import (
     Conversation as ResponsesConversation,
 )
 from openai.types.responses.response_create_params import (
+    Moderation as ResponsesModeration,
+)
+from openai.types.responses.response_create_params import (
+    PromptCacheOptions as ResponsesPromptCacheOptions,
+)
+from openai.types.responses.response_create_params import (
     StreamOptions as ResponsesStreamOptionsParam,
 )
 from openai.types.responses.response_create_params import (
@@ -34,6 +40,9 @@ from openai.types.responses.response_input_item_param import (
 )
 from openai.types.responses.tool_param import (
     ToolParam as ResponsesToolParam,
+)
+from openai.types.responses.web_search_preview_tool_param import (
+    WebSearchPreviewToolParam,
 )
 from openai.types.responses.web_search_tool_param import WebSearchToolParam
 from openai.types.shared import Reasoning
@@ -101,6 +110,8 @@ def _items_after_last_response(
 
 VerbosityLevel = Literal["low", "medium", "high"]
 PromptCacheRetention = Literal["in_memory", "24h"]
+Truncation = Literal["auto", "disabled"]
+ServiceTier = Literal["auto", "default", "flex", "scale", "priority"]
 
 
 @with_config(ConfigDict(extra="allow"))
@@ -114,17 +125,19 @@ class OpenAIResponsesLLMSettings(CloudLLMSettings, total=False):
 
     prompt_cache_key: str
     prompt_cache_retention: PromptCacheRetention | None
+    prompt_cache_options: ResponsesPromptCacheOptions | None
 
     context_management: Iterable[ResponsesContextManagement] | None
-    truncation: Literal["auto", "disabled"] | None
+    truncation: Truncation | None
     include: list[ResponseIncludable] | None
 
-    web_search: WebSearchToolParam | None
+    web_search: WebSearchToolParam | WebSearchPreviewToolParam | None
 
     text: ResponseTextConfigParam
     stream_options: ResponsesStreamOptionsParam | None
     safety_identifier: str
-    service_tier: Literal["auto", "default", "flex", "scale", "priority"] | None
+    moderation: ResponsesModeration | None
+    service_tier: ServiceTier | None
     metadata: Metadata | None
     store: bool | None
     user: str

--- a/src/grasp_agents/printer.py
+++ b/src/grasp_agents/printer.py
@@ -299,7 +299,7 @@ class Printer:
                     text += "\n</response>\n"
                 elif isinstance(item, FunctionToolCallItem):
                     text += "\n</tool call>\n"
-                else:  # WebSearchCallItem
+                elif isinstance(item, WebSearchCallItem):
                     text += f"{item.summary}\n</web search>\n"
 
             elif isinstance(

--- a/src/grasp_agents/types/__init__.py
+++ b/src/grasp_agents/types/__init__.py
@@ -49,6 +49,7 @@ from .items import (
     SearchAction,
     SearchSource,
     ToolCallItem,
+    UnknownItem,
     WebSearchCallItem,
     prefixed_id,
 )
@@ -197,6 +198,7 @@ __all__ = [
     "ToolOutputItemEvent",
     "TurnEndEvent",
     "TurnStartEvent",
+    "UnknownItem",
     "WebSearchCallCompleted",
     "WebSearchCallInProgress",
     "WebSearchCallItem",

--- a/src/grasp_agents/types/content.py
+++ b/src/grasp_agents/types/content.py
@@ -36,7 +36,7 @@ from pydantic import BaseModel, Field, model_validator
 
 # === Input content parts ===
 
-ImageDetail = Literal["low", "medium", "high", "ultra_high", "auto"]
+ImageDetail = Literal["low", "medium", "high", "ultra_high", "auto", "original"]
 
 
 class CacheControl(BaseModel):
@@ -46,11 +46,12 @@ class CacheControl(BaseModel):
     Set it on a content part to ask the provider to cache the prompt prefix
     *up to and including* that part. Place it on the last stable part of a
     prefix you expect to reuse across turns. Providers with prompt caching
-    honor it (Anthropic emits a cache breakpoint); the rest ignore it.
+    honor it (Anthropic and OpenAI on gpt-5.6+); the rest ignore it.
 
     ``ttl`` selects the cache lifetime where the provider supports tiers
     (Anthropic: ``"5m"`` default, ``"1h"`` extended); ``None`` uses the
-    provider default.
+    provider default. OpenAI ignores it — there the TTL is set per request
+    via the ``prompt_cache_options`` LLM setting.
     """
 
     type: Literal["ephemeral"] = "ephemeral"

--- a/src/grasp_agents/types/items.py
+++ b/src/grasp_agents/types/items.py
@@ -11,7 +11,7 @@ from openai.types.responses import (
     ResponseOutputMessage,
     ResponseReasoningItem,
 )
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pydantic_core import to_jsonable_python
 
 from .content import (
@@ -386,6 +386,43 @@ class WebSearchCallItem(BaseModel):
         return f"{line} @ {action.url}" if action.url else line
 
 
+# Item types with a dedicated model; UnknownItem refuses these so a malformed
+# known item fails validation loudly instead of degrading to a passthrough.
+_KNOWN_ITEM_TYPES = frozenset(
+    {
+        "message",
+        "function_call",
+        "function_call_output",
+        "reasoning",
+        "web_search_call",
+    }
+)
+
+
+class UnknownItem(BaseModel):
+    """
+    A response item of a type this framework doesn't model, preserved
+    verbatim.
+
+    Round-trips new provider item types — e.g. programmatic-tool-calling
+    ``program`` items with their replay ``fingerprint`` — through the
+    transcript without dropping fields. Only the OpenAI Responses provider
+    sends these back; other providers skip them.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    type: str
+
+    @model_validator(mode="after")
+    def _reject_known_types(self) -> UnknownItem:
+        if self.type in _KNOWN_ITEM_TYPES:
+            raise ValueError(
+                f"item type {self.type!r} must validate as its dedicated model"
+            )
+        return self
+
+
 AssistantMessage = OutputMessageItem
 
 
@@ -408,12 +445,19 @@ type InputItem = (
     | FunctionToolOutputItem
     | ReasoningItem
     | WebSearchCallItem
+    | UnknownItem
 )
 
-type OutputItem = Annotated[
-    OutputMessageItem | FunctionToolCallItem | ReasoningItem | WebSearchCallItem,
-    Field(discriminator="type"),
-]
+# The discriminated union handles the known tags; an unrecognized ``type``
+# falls through to the UnknownItem passthrough (which refuses known tags, so
+# malformed known items still fail loudly).
+type OutputItem = (
+    Annotated[
+        OutputMessageItem | FunctionToolCallItem | ReasoningItem | WebSearchCallItem,
+        Field(discriminator="type"),
+    ]
+    | UnknownItem
+)
 
 ToolCallItem = Annotated[FunctionToolCallItem, Field(discriminator="type")]
 

--- a/src/grasp_agents/types/response.py
+++ b/src/grasp_agents/types/response.py
@@ -15,8 +15,10 @@ from openai.types.responses import (
 )
 from openai.types.responses.response import IncompleteDetails, ToolChoice
 from openai.types.responses.response_usage import (
-    InputTokensDetails,
-    OutputTokensDetails,
+    InputTokensDetails as _SDKInputTokensDetails,
+)
+from openai.types.responses.response_usage import (
+    OutputTokensDetails as _SDKOutputTokensDetails,
 )
 from openai.types.responses.response_usage import ResponseUsage as _SDKResponseUsage
 from openai.types.shared import Metadata, Reasoning
@@ -32,20 +34,25 @@ from .items import (
 )
 
 
+class InputTokensDetails(_SDKInputTokensDetails):
+    cached_tokens: int = 0
+    cache_write_tokens: int = 0
+
+
+class OutputTokensDetails(_SDKOutputTokensDetails):
+    reasoning_tokens: int = 0
+
+
 class ResponseUsage(_SDKResponseUsage):
     input_tokens: int = 0
-    input_tokens_details: InputTokensDetails = Field(
-        default_factory=lambda: InputTokensDetails(cached_tokens=0)
+    input_tokens_details: InputTokensDetails = Field(  # pyright: ignore[reportIncompatibleVariableOverride] — defaulted fields
+        default_factory=InputTokensDetails
     )
     output_tokens: int = 0
-    output_tokens_details: OutputTokensDetails = Field(
-        default_factory=lambda: OutputTokensDetails(reasoning_tokens=0)
+    output_tokens_details: OutputTokensDetails = Field(  # pyright: ignore[reportIncompatibleVariableOverride] — defaulted fields
+        default_factory=OutputTokensDetails
     )
     total_tokens: int = 0
-    # Input tokens written to the provider's prompt cache this call (a subset
-    # of ``input_tokens``, like ``cached_tokens``). Cache writes are billed at
-    # a premium (e.g. 1.25x on Anthropic), so cost accounting needs the split.
-    cache_creation_tokens: int = 0
     cost: float | None = None
 
     def __add__(self, other: ResponseUsage) -> ResponseUsage:
@@ -55,14 +62,14 @@ class ResponseUsage(_SDKResponseUsage):
             total_tokens=self.total_tokens + other.total_tokens,
             input_tokens_details=InputTokensDetails(
                 cached_tokens=self.input_tokens_details.cached_tokens
-                + other.input_tokens_details.cached_tokens
+                + other.input_tokens_details.cached_tokens,
+                cache_write_tokens=self.input_tokens_details.cache_write_tokens
+                + other.input_tokens_details.cache_write_tokens,
             ),
             output_tokens_details=OutputTokensDetails(
                 reasoning_tokens=self.output_tokens_details.reasoning_tokens
                 + other.output_tokens_details.reasoning_tokens
             ),
-            cache_creation_tokens=self.cache_creation_tokens
-            + other.cache_creation_tokens,
             cost=(self.cost or 0) + (other.cost or 0)
             if self.cost is not None or other.cost is not None
             else None,
@@ -97,8 +104,10 @@ class Response(_SDKResponse):
     frequency_penalty: float | None = None
 
     reasoning: Reasoning | None = None
-    # effort: ["none", "minimal", "low", "medium", "high", "xhigh"] (default=None)
+    # effort: ["none", "minimal", "low", "medium", "high", "xhigh", "max"]
     # summary: ["auto", "concise", "detailed"] (default=None)
+    # context: ["auto", "current_turn", "all_turns"] — persisted reasoning
+    # mode: ["standard", "pro"]
 
     text: ResponseTextConfig | None = None
     # one of ResponseFormatText, ResponseFormatTextJSONSchemaConfig,

--- a/src/grasp_agents/ui/replay.py
+++ b/src/grasp_agents/ui/replay.py
@@ -86,6 +86,6 @@ def history_events(
             events.append(
                 ToolOutputItemEvent(source=tool, destination=agent, data=item)
             )
-        else:
+        elif isinstance(item, WebSearchCallItem):
             events.append(WebSearchCallItemEvent(source=agent, data=item))
     return events

--- a/src/grasp_agents/usage_tracker.py
+++ b/src/grasp_agents/usage_tracker.py
@@ -29,7 +29,7 @@ def add_cost_to_usage(
             prompt_tokens=usage.input_tokens,
             completion_tokens=usage.output_tokens,
             cache_read_input_tokens=usage.input_tokens_details.cached_tokens,
-            cache_creation_input_tokens=usage.cache_creation_tokens,
+            cache_creation_input_tokens=usage.input_tokens_details.cache_write_tokens,
             custom_llm_provider=litellm_provider,
         )
         usage.cost = prompt_cost + completion_cost

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -16,10 +16,6 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Self
 
-from openai.types.responses.response_usage import (
-    InputTokensDetails,
-    OutputTokensDetails,
-)
 from pydantic import BaseModel, Field
 
 from grasp_agents.agent.agent_context import AgentContext
@@ -42,7 +38,12 @@ from grasp_agents.types.llm_events import (
     ResponseCompleted,
     ResponseCreated,
 )
-from grasp_agents.types.response import Response, ResponseUsage
+from grasp_agents.types.response import (
+    InputTokensDetails,
+    OutputTokensDetails,
+    Response,
+    ResponseUsage,
+)
 
 
 def _make_usage() -> ResponseUsage:

--- a/tests/anthropic/test_converters.py
+++ b/tests/anthropic/test_converters.py
@@ -66,6 +66,7 @@ from grasp_agents.types.content import (
     OutputMessageText,
 )
 from grasp_agents.types.items import (
+    AssistantMessage,
     FunctionToolCallItem,
     FunctionToolOutputItem,
     InputMessageItem,
@@ -74,6 +75,7 @@ from grasp_agents.types.items import (
     ReasoningItem,
     SearchAction,
     SearchSource,
+    UserMessage,
     WebSearchCallItem,
 )
 from grasp_agents.types.llm_events import (
@@ -1731,3 +1733,51 @@ class TestWebFetchStream:
         assert (
             wf.provider_specific_fields["anthropic:error_code"] == "url_not_accessible"
         )
+
+
+class TestMidConversationSystemMessages:
+    def test_leading_run_hoisted_rest_positional(self) -> None:
+        from grasp_agents.types.items import SystemMessage
+
+        items = [
+            SystemMessage.from_text("You are helpful.", role="system"),
+            UserMessage.from_text("hi"),
+            AssistantMessage(
+                status="completed", content=[OutputMessageText(text="hello")]
+            ),
+            UserMessage.from_text("ok"),
+            SystemMessage.from_text("Reply only in uppercase.", role="system"),
+        ]
+
+        system, messages = items_to_anthropic_messages(items)
+
+        assert system == "You are helpful."
+        assert [m["role"] for m in messages] == ["user", "assistant", "user", "system"]
+        [block] = messages[3]["content"]
+        assert block["text"] == "Reply only in uppercase."
+
+    def test_mid_conversation_developer_maps_to_system_role(self) -> None:
+        from grasp_agents.types.items import DeveloperMessage
+
+        items = [
+            UserMessage.from_text("hi"),
+            DeveloperMessage(content=[InputText(text="New instructions.")]),
+        ]
+
+        system, messages = items_to_anthropic_messages(items)
+
+        assert system is None
+        assert messages[1]["role"] == "system"
+
+    def test_mid_conversation_system_keeps_cache_control(self) -> None:
+        from grasp_agents.types.content import CacheControl
+        from grasp_agents.types.items import SystemMessage
+
+        msg = SystemMessage(
+            role="system",
+            content=[InputText(text="pinned", cache_control=CacheControl(ttl="1h"))],
+        )
+        _, messages = items_to_anthropic_messages([UserMessage.from_text("hi"), msg])
+
+        [block] = messages[1]["content"]
+        assert block["cache_control"] == {"type": "ephemeral", "ttl": "1h"}

--- a/tests/anthropic/test_integration.py
+++ b/tests/anthropic/test_integration.py
@@ -794,3 +794,46 @@ class TestAnthropicErrorMappingLive:
 
         with pytest.raises(LlmNotFoundError):
             await _consume()
+
+
+@pytest.mark.integration
+class TestAnthropicMidConversationSystem:
+    """
+    Mid-conversation system items pass through as system-role messages;
+    model support is enforced by the API, not the converter.
+    """
+
+    def _items(self) -> list[Any]:
+        from grasp_agents.types.content import OutputMessageText as _Text
+        from grasp_agents.types.items import AssistantMessage, SystemMessage
+
+        return [
+            InputMessageItem.from_text("Say hello."),
+            AssistantMessage(status="completed", content=[_Text(text="Hello!")]),
+            InputMessageItem.from_text("Say hello again."),
+            SystemMessage.from_text("Reply only in uppercase.", role="system"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_succeeds_on_supporting_model(self, anthropic_api_key: str) -> None:
+        from grasp_agents.llm_providers.anthropic.anthropic_llm import AnthropicLLM
+
+        llm = AnthropicLLM(
+            model_name="claude-opus-4-8", llm_settings={"max_tokens": 100}
+        )
+        response = await llm.generate_response(self._items())
+
+        assert response.status == "completed"
+        assert response.output_text
+        assert response.output_text == response.output_text.upper()
+
+    @pytest.mark.asyncio
+    async def test_rejected_on_older_model(self, anthropic_api_key: str) -> None:
+        from grasp_agents.llm_providers.anthropic.anthropic_llm import AnthropicLLM
+        from grasp_agents.types.llm_errors import LlmBadRequestError
+
+        llm = AnthropicLLM(
+            model_name="claude-haiku-4-5", llm_settings={"max_tokens": 100}
+        )
+        with pytest.raises(LlmBadRequestError):
+            await llm.generate_response(self._items())

--- a/tests/integration/test_code_interpreter_live.py
+++ b/tests/integration/test_code_interpreter_live.py
@@ -44,7 +44,7 @@ _SYS_PROMPT = (
 def _make_llm() -> OpenAIResponsesLLM:
     # The Responses API (unlike Chat Completions) supports image tool outputs,
     # which is what lets a displayed plot be fed back to the model.
-    model_name = os.environ.get("CODE_INTERP_TEST_MODEL", "gpt-4o-mini")
+    model_name = os.environ.get("CODE_INTERP_TEST_MODEL", "gpt-5.4-mini")
     return OpenAIResponsesLLM(model_name=model_name)
 
 

--- a/tests/integration/test_mcp_memory_live.py
+++ b/tests/integration/test_mcp_memory_live.py
@@ -38,7 +38,7 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
 
 
 def _make_llm() -> OpenAILLM:
-    model_name = os.environ.get("MEMORY_TEST_MODEL", "openai/gpt-4o-mini")
+    model_name = os.environ.get("MEMORY_TEST_MODEL", "openai/gpt-5.4-mini")
     retries = int(os.environ.get("MEMORY_TEST_VALIDATION_RETRIES", "3"))
     return OpenAILLM(
         model_name=model_name,

--- a/tests/integration/test_memory_authoring_live.py
+++ b/tests/integration/test_memory_authoring_live.py
@@ -69,7 +69,7 @@ async def test_memory_authoring_does_not_clobber(memdir: Path) -> None:
     - MEMORY.md still contains the title line and the original pointer
     - at least one new topic file or index pointer was added
     """
-    model_name = os.environ.get("MEMORY_TEST_MODEL", "openai/gpt-4o-mini")
+    model_name = os.environ.get("MEMORY_TEST_MODEL", "openai/gpt-5.4-mini")
     retries = int(os.environ.get("MEMORY_TEST_VALIDATION_RETRIES", "3"))
     llm = OpenAILLM(
         model_name=model_name,

--- a/tests/integration/test_memory_notebook_live.py
+++ b/tests/integration/test_memory_notebook_live.py
@@ -39,7 +39,7 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
 
 
 def _make_llm() -> OpenAILLM:
-    model_name = os.environ.get("MEMORY_TEST_MODEL", "openai/gpt-4o-mini")
+    model_name = os.environ.get("MEMORY_TEST_MODEL", "openai/gpt-5.4-mini")
     retries = int(os.environ.get("MEMORY_TEST_VALIDATION_RETRIES", "3"))
     return OpenAILLM(
         model_name=model_name,

--- a/tests/litellm/test_integration.py
+++ b/tests/litellm/test_integration.py
@@ -42,7 +42,7 @@ class TestLiteLLMIntegration:
 
         # LiteLLM reads OPENAI_API_KEY from env automatically
         return LiteLLM(
-            model_name="gpt-4.1-nano",
+            model_name="gpt-5.4-nano",
             llm_settings={"max_completion_tokens": 100},
         )
 
@@ -100,7 +100,7 @@ class TestLiteLLMStructuredOutput:
         from grasp_agents.llm_providers.litellm.lite_llm import LiteLLM
 
         return LiteLLM(
-            model_name="gpt-4.1-nano",
+            model_name="gpt-5.4-nano",
             llm_settings={"max_completion_tokens": 200},
             apply_output_schema_via_provider=True,
         )
@@ -152,7 +152,7 @@ class TestLiteLLMParallelToolUse:
         from grasp_agents.llm_providers.litellm.lite_llm import LiteLLM
 
         return LiteLLM(
-            model_name="gpt-4.1-nano",
+            model_name="gpt-5.4-nano",
             llm_settings={"max_completion_tokens": 256},
         )
 

--- a/tests/llm/test_llm_core.py
+++ b/tests/llm/test_llm_core.py
@@ -110,7 +110,7 @@ class TestAnthropicCacheUsage:
         usage = convert_usage(self._usage())
         assert usage.input_tokens == 100 + 5000 + 200
         assert usage.input_tokens_details.cached_tokens == 5000
-        assert usage.cache_creation_tokens == 200
+        assert usage.input_tokens_details.cache_write_tokens == 200
         assert usage.total_tokens == usage.input_tokens + 10
 
     def test_cost_is_positive_and_prices_cache_writes(self) -> None:

--- a/tests/llm/test_usage_tracker.py
+++ b/tests/llm/test_usage_tracker.py
@@ -1,14 +1,15 @@
 """Tests for UsageTracker.update."""
 
 import pytest
-from openai.types.responses.response_usage import (
-    InputTokensDetails,
-    OutputTokensDetails,
-)
 
 from grasp_agents.types.content import OutputMessageText
 from grasp_agents.types.items import OutputMessageItem
-from grasp_agents.types.response import Response, ResponseUsage
+from grasp_agents.types.response import (
+    InputTokensDetails,
+    OutputTokensDetails,
+    Response,
+    ResponseUsage,
+)
 from grasp_agents.usage_tracker import UsageTracker
 
 
@@ -194,3 +195,35 @@ class TestUpdateFromResponseWithCosts:
         tracker.update("agent_a", [response], model_name="gpt-4o")
 
         assert tracker.usages["agent_a"].cost == pytest.approx(0.42)
+
+
+class TestCacheWriteTokens:
+    def test_defaults_tolerate_missing_field(self):
+        """Serialized usage from before the SDK carried cache writes loads."""
+        usage = ResponseUsage.model_validate(
+            {
+                "input_tokens": 100,
+                "output_tokens": 10,
+                "total_tokens": 110,
+                "input_tokens_details": {"cached_tokens": 20},
+                "output_tokens_details": {"reasoning_tokens": 0},
+            }
+        )
+
+        assert usage.input_tokens_details.cache_write_tokens == 0
+
+    def test_details_addition(self):
+        total = ResponseUsage(
+            input_tokens=1,
+            input_tokens_details=InputTokensDetails(
+                cached_tokens=5, cache_write_tokens=7
+            ),
+        ) + ResponseUsage(
+            input_tokens=2,
+            input_tokens_details=InputTokensDetails(
+                cached_tokens=10, cache_write_tokens=13
+            ),
+        )
+
+        assert total.input_tokens_details.cached_tokens == 15
+        assert total.input_tokens_details.cache_write_tokens == 20

--- a/tests/openai_completions/test_integration.py
+++ b/tests/openai_completions/test_integration.py
@@ -43,7 +43,7 @@ class TestOpenAICompletionsIntegration:
         )
 
         return OpenAILLM(
-            model_name="openai/gpt-4.1-nano",
+            model_name="openai/gpt-5.4-nano",
             llm_settings={"max_completion_tokens": 100},
         )
 
@@ -106,7 +106,7 @@ class TestOpenAICompletionsStructuredOutput:
         )
 
         return OpenAILLM(
-            model_name="openai/gpt-4.1-nano", apply_output_schema_via_provider=True
+            model_name="openai/gpt-5.4-nano", apply_output_schema_via_provider=True
         )
 
     @pytest.mark.asyncio
@@ -158,7 +158,7 @@ class TestOpenAICompletionsParallelToolUse:
         )
 
         return OpenAILLM(
-            model_name="openai/gpt-4.1-nano",
+            model_name="openai/gpt-5.4-nano",
             llm_settings={"max_completion_tokens": 256},
         )
 

--- a/tests/openai_completions/test_items_to_messages.py
+++ b/tests/openai_completions/test_items_to_messages.py
@@ -666,3 +666,49 @@ class TestResponseToCompletionsMessage:
         assert len(msg["reasoning_details"]) == 1
         assert msg["reasoning_details"][0]["type"] == "reasoning.summary"
         assert msg["reasoning_details"][0]["summary"] == "Thinking"
+
+
+class TestCacheControls:
+    def test_text_part_cache_control_becomes_breakpoint(self) -> None:
+        from grasp_agents.types.content import CacheControl, InputText
+        from grasp_agents.types.items import UserMessage
+
+        msg = UserMessage(
+            content=[
+                InputText(
+                    text="pinned", cache_control=CacheControl()
+                ),
+                InputText(text="tail"),
+            ]
+        )
+
+        [param] = items_to_completions_messages([msg])
+
+        first, second = param["content"]
+        assert first["prompt_cache_breakpoint"] == {"mode": "explicit"}
+        assert "prompt_cache_breakpoint" not in second
+
+    def test_system_message_stays_structured_with_cache_control(self) -> None:
+        from grasp_agents.types.content import CacheControl, InputText
+        from grasp_agents.types.items import SystemMessage
+
+        msg = SystemMessage(
+            role="system",
+            content=[
+                InputText(
+                    text="pinned", cache_control=CacheControl()
+                )
+            ],
+        )
+
+        [param] = items_to_completions_messages([msg])
+
+        [block] = param["content"]
+        assert block["prompt_cache_breakpoint"] == {"mode": "explicit"}
+
+    def test_plain_text_message_still_flattens(self) -> None:
+        from grasp_agents.types.items import UserMessage
+
+        [param] = items_to_completions_messages([UserMessage.from_text("hi")])
+
+        assert param["content"] == "hi"

--- a/tests/openai_responses/test_agent_tool_integration.py
+++ b/tests/openai_responses/test_agent_tool_integration.py
@@ -39,7 +39,7 @@ class TestAgentToolIntegration:
         )
 
         return OpenAIResponsesLLM(
-            model_name="gpt-4.1-nano",
+            model_name="gpt-5.4-nano",
             llm_settings={"max_output_tokens": 200},
         )
 

--- a/tests/openai_responses/test_converters.py
+++ b/tests/openai_responses/test_converters.py
@@ -85,7 +85,7 @@ _BASE_RESPONSE: dict[str, Any] = {
         "input_tokens": 10,
         "output_tokens": 20,
         "total_tokens": 30,
-        "input_tokens_details": {"cached_tokens": 0},
+        "input_tokens_details": {"cached_tokens": 0, "cache_write_tokens": 0},
         "output_tokens_details": {"reasoning_tokens": 0},
     },
 }
@@ -345,3 +345,116 @@ class TestMessageIdNotSent:
         )
         [param2] = items_to_provider_inputs([no_phase])
         assert "phase" not in param2
+
+
+class TestPromptCacheBreakpoints:
+    def test_input_part_cache_control_becomes_breakpoint(self) -> None:
+        from grasp_agents.types.content import CacheControl
+        from grasp_agents.types.items import UserMessage
+
+        msg = UserMessage(
+            content=[
+                InputText(text="stable prefix", cache_control=CacheControl(ttl="1h")),
+                InputText(text="tail"),
+            ]
+        )
+
+        [param] = items_to_provider_inputs([msg])
+        first, second = cast("list[dict[str, Any]]", param["content"])
+
+        assert first["prompt_cache_breakpoint"] == {"mode": "explicit"}
+        assert "cache_control" not in first
+        assert "prompt_cache_breakpoint" not in second
+
+    def test_output_text_part_gets_no_breakpoint(self) -> None:
+        from grasp_agents.types.content import CacheControl
+
+        msg = OutputMessageItem(
+            status="completed",
+            content=[OutputMessageText(text="reply", cache_control=CacheControl())],
+        )
+
+        [param] = items_to_provider_inputs([msg])
+        [part] = cast("list[dict[str, Any]]", param["content"])
+
+        assert "prompt_cache_breakpoint" not in part
+        assert "cache_control" not in part
+
+    def test_item_level_cache_control_scrubbed(self) -> None:
+        from grasp_agents.types.content import CacheControl
+
+        item = FunctionToolOutputItem(
+            call_id="call_1", output="ok", cache_control=CacheControl()
+        )
+
+        [param] = items_to_provider_inputs([item])
+
+        assert "cache_control" not in param
+
+
+class TestUnknownItemRoundtrip:
+    def test_program_item_fingerprint_round_trips(self) -> None:
+        from grasp_agents.types.items import UnknownItem
+
+        resp = InternalResponse.model_validate(
+            {
+                "object": "response",
+                "model": "gpt-5.6",
+                "output": [
+                    {
+                        "type": "program",
+                        "id": "prog_1",
+                        "call_id": "call_9",
+                        "code": "tools.add({a: 1, b: 2})",
+                        "fingerprint": "fp-opaque-123",
+                    }
+                ],
+            }
+        )
+
+        [item] = resp.output
+        assert isinstance(item, UnknownItem)
+
+        [param] = items_to_provider_inputs([item])
+        assert param == {
+            "type": "program",
+            "id": "prog_1",
+            "call_id": "call_9",
+            "code": "tools.add({a: 1, b: 2})",
+            "fingerprint": "fp-opaque-123",
+        }
+
+    def test_malformed_known_item_still_fails(self) -> None:
+        import pytest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            InternalResponse.model_validate(
+                {
+                    "object": "response",
+                    "model": "m",
+                    "output": [{"type": "message", "role": "assistant"}],
+                }
+            )
+
+
+class TestWebSearchActionParams:
+    def test_search_without_queries_omits_query(self) -> None:
+        item = WebSearchCallItem(action=SearchAction())
+
+        [param] = items_to_provider_inputs([item])
+        action = cast("dict[str, Any]", param["action"])
+
+        assert "query" not in action
+
+    def test_find_in_page_action_round_trips(self) -> None:
+        item = WebSearchCallItem(
+            action=FindInPageAction(url="https://x.test", pattern="needle")
+        )
+
+        [param] = items_to_provider_inputs([item])
+        action = cast("dict[str, Any]", param["action"])
+
+        assert action["type"] == "find_in_page"
+        assert action["url"] == "https://x.test"
+        assert action["pattern"] == "needle"

--- a/tests/openai_responses/test_integration.py
+++ b/tests/openai_responses/test_integration.py
@@ -47,7 +47,7 @@ class TestOpenAIResponsesIntegration:
         )
 
         return OpenAIResponsesLLM(
-            model_name="gpt-4.1-nano", llm_settings={"max_output_tokens": 100}
+            model_name="gpt-5.4-nano", llm_settings={"max_output_tokens": 100}
         )
 
     @pytest.mark.asyncio
@@ -109,7 +109,7 @@ class TestOpenAIResponsesStructuredOutput:
         )
 
         return OpenAIResponsesLLM(
-            model_name="gpt-4.1-nano",
+            model_name="gpt-5.4-nano",
             llm_settings={"max_output_tokens": 200},
             apply_output_schema_via_provider=True,
         )
@@ -150,7 +150,7 @@ class TestOpenAIResponsesWebSearch:
         )
 
         return OpenAIResponsesLLM(
-            model_name="gpt-5.2",
+            model_name="gpt-5.4",
             llm_settings={
                 "max_output_tokens": 4096,
                 "web_search": {"type": "web_search_preview"},
@@ -227,7 +227,7 @@ class TestOpenAIResponsesReasoningContinuity:
         )
 
         return OpenAIResponsesLLM(
-            model_name="gpt-5.2",
+            model_name="gpt-5.4",
             llm_settings={
                 "max_output_tokens": 4096,
                 "reasoning": {"effort": "low", "summary": "auto"},
@@ -329,7 +329,7 @@ class TestOpenAIResponsesCorruptedEncryptedContent:
         )
 
         return OpenAIResponsesLLM(
-            model_name="gpt-5-mini",
+            model_name="gpt-5.4-mini",
             llm_settings={
                 "max_output_tokens": 4096,
                 "reasoning": {"effort": "low", "summary": "auto"},
@@ -381,10 +381,15 @@ class TestOpenAIResponsesCorruptedEncryptedContent:
             await llm.generate_response(full_input, tools=tools)
 
     @pytest.mark.asyncio
-    async def test_missing_encrypted_content_causes_api_error(
+    async def test_missing_encrypted_content_tolerated(
         self, llm: CloudLLM, tools: dict[str, BaseTool[Any, Any, Any]]
     ) -> None:
-        """Stripping encrypted_content from reasoning items must error."""
+        """
+        Reasoning items with *missing* encrypted_content are tolerated.
+
+        The API used to reject them under ``store=False``; it now accepts the
+        request (only corrupted content still errors — see the test above).
+        """
         user_msg = InputMessageItem.from_text(
             "From the set {6, 11, 17, 19, 25, 33}, find the unique pair "
             "whose sum is exactly 42. Work through the combinations, "
@@ -419,8 +424,8 @@ class TestOpenAIResponsesCorruptedEncryptedContent:
 
         full_input = [user_msg, *stripped_items, *tool_outputs]
 
-        with pytest.raises(Exception):
-            await llm.generate_response(full_input, tools=tools)
+        r2 = await llm.generate_response(full_input, tools=tools)
+        assert r2.status == "completed"
 
 
 @pytest.mark.integration
@@ -582,7 +587,7 @@ class TestOpenAIResponsesParallelToolUse:
         )
 
         return OpenAIResponsesLLM(
-            model_name="gpt-4.1-nano",
+            model_name="gpt-5.4-nano",
             llm_settings={"max_output_tokens": 256},
         )
 
@@ -655,3 +660,47 @@ class TestOpenAIResponsesParallelToolUse:
 
         assert r2.status == "completed"
         assert "42" in r2.output_text
+
+
+@pytest.mark.integration
+class TestOpenAIResponsesExplicitPromptCaching:
+    """CacheControl → explicit prompt-cache breakpoints (gpt-5.6+)."""
+
+    @pytest.mark.asyncio
+    async def test_breakpoint_writes_then_reads_cache(
+        self, openai_api_key: str
+    ) -> None:
+        from uuid import uuid4
+
+        from grasp_agents.llm_providers.openai_responses.responses_llm import (
+            OpenAIResponsesLLM,
+        )
+        from grasp_agents.types.content import CacheControl, InputText
+        from grasp_agents.types.items import UserMessage
+
+        llm = OpenAIResponsesLLM(
+            model_name="gpt-5.6-luna",
+            llm_settings={
+                "max_output_tokens": 200,
+                "prompt_cache_options": {"mode": "explicit"},
+                # A fresh key per run so the first call always writes.
+                "prompt_cache_key": f"grasp-cache-test-{uuid4().hex}",
+            },
+        )
+        stable = "You are a precise assistant. " * 200
+        msg = UserMessage(
+            content=[
+                InputText(text=stable, cache_control=CacheControl()),
+                InputText(text="Reply with the single word: ok"),
+            ]
+        )
+
+        r1 = await llm.generate_response([msg])
+        assert r1.status == "completed"
+        assert r1.usage is not None
+        assert r1.usage.input_tokens_details.cache_write_tokens > 0
+
+        r2 = await llm.generate_response([msg])
+        assert r2.status == "completed"
+        assert r2.usage is not None
+        assert r2.usage.input_tokens_details.cached_tokens > 0

--- a/tests/orchestration/test_executor_integration.py
+++ b/tests/orchestration/test_executor_integration.py
@@ -10,10 +10,6 @@ from dataclasses import dataclass
 from typing import Any
 
 import pytest
-from openai.types.responses.response_usage import (
-    InputTokensDetails,
-    OutputTokensDetails,
-)
 from pydantic import BaseModel
 
 from grasp_agents.agent.agent_loop import AgentLoop
@@ -42,7 +38,12 @@ from grasp_agents.types.llm_events import (
     ResponseCompleted,
     ResponseCreated,
 )
-from grasp_agents.types.response import Response, ResponseUsage
+from grasp_agents.types.response import (
+    InputTokensDetails,
+    OutputTokensDetails,
+    Response,
+    ResponseUsage,
+)
 from tests._helpers import _make_agent_loop
 
 # ---------- Mock LLM ----------

--- a/tests/sandbox/test_bash_polish.py
+++ b/tests/sandbox/test_bash_polish.py
@@ -577,15 +577,15 @@ async def test_loop_injects_bash_note_after_idle_wait(tmp_path: Path) -> None:
     """
     from dataclasses import field
 
-    from openai.types.responses.response_usage import (
-        InputTokensDetails,
-        OutputTokensDetails,
-    )
-
     from grasp_agents.tools.base import BaseTool as _BaseTool
     from grasp_agents.types.content import OutputMessageText
     from grasp_agents.types.items import OutputMessageItem
-    from grasp_agents.types.response import Response, ResponseUsage
+    from grasp_agents.types.response import (
+        InputTokensDetails,
+        OutputTokensDetails,
+        Response,
+        ResponseUsage,
+    )
 
     usage = ResponseUsage(
         input_tokens=1,

--- a/uv.lock
+++ b/uv.lock
@@ -1181,7 +1181,7 @@ wheels = [
 
 [[package]]
 name = "grasp-agents"
-version = "1.0.23"
+version = "1.0.24"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -1314,7 +1314,7 @@ requires-dist = [
     { name = "litellm", specifier = ">=1.82,<2" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.8,<2" },
     { name = "nbformat", marker = "extra == 'notebook-edit'", specifier = ">=5.10.4,<6" },
-    { name = "openai", specifier = ">=2.23,<3" },
+    { name = "openai", specifier = ">=2.47,<3" },
     { name = "openinference-instrumentation-anthropic", marker = "extra == 'phoenix'", specifier = ">=1,<2" },
     { name = "openinference-instrumentation-google-genai", marker = "extra == 'phoenix'", specifier = ">=1.1,<2" },
     { name = "openinference-instrumentation-litellm", marker = "extra == 'phoenix'", specifier = ">=0.1.25,<1" },
@@ -2691,7 +2691,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.43.0"
+version = "2.47.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2703,9 +2703,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/fa/88d0c58a0c58df7e6758e66b99c5d028d5e0bb49f8812d7203940cd9dbf1/openai-2.43.0.tar.gz", hash = "sha256:e74d238200a26868977002190fb6631613480a93dfe0c9c982e77021ed60a017", size = 785369, upload-time = "2026-06-17T17:06:56.06Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/61/9aeef14de759306e85175126d3d6d56ee4f5072a9512c6c171d58d02a62d/openai-2.47.0.tar.gz", hash = "sha256:4e205548acd4304f235b86202269912e55bc88270b15d2a051fa2b53b90343a6", size = 1089906, upload-time = "2026-07-22T17:47:29.723Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/d2/ba767f4bbb30776c03d40906a2d3afad716a165ffa1771fc23b8992f7920/openai-2.43.0-py3-none-any.whl", hash = "sha256:65a670b54fadf2268c9e1330133373c963eb779ee969e5cbad419ec2c21dce97", size = 1355077, upload-time = "2026-06-17T17:06:53.614Z" },
+    { url = "https://files.pythonhosted.org/packages/41/69/26b032059273ad798d18fbcdbe369e871181841fd8bcb5caee32b7510039/openai-2.47.0-py3-none-any.whl", hash = "sha256:b3a1a7ad974092427ccb46d89f8852bdb67866680bcabeecc3ff5a3fdd71b15b", size = 1639987, upload-time = "2026-07-22T17:47:27.873Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Update OpenAI SDK to 2.47 and adopt new API features

Bumps the `openai` floor from 2.23 to 2.47 and adopts the API additions that
landed in between, with converter and usage-accounting fixes across providers.

## Highlights

- **Explicit prompt caching (OpenAI, gpt-5.6+).** A part-level `CacheControl`
  now emits a `prompt_cache_breakpoint` on both the Responses and Chat
  Completions providers (text/image/file parts; Completions keeps messages
  structured when a breakpoint is present instead of flattening to a string).
  New typed settings: `prompt_cache_options`, `moderation` (both providers).
- **Usage accounting.** The SDK made `cache_write_tokens` a required field,
  which broke usage construction and validation of previously serialized
  payloads. `InputTokensDetails` / `OutputTokensDetails` are now our own
  subclasses with defaulted fields, imported from `grasp_agents.types.response`
  everywhere. **Breaking:** `ResponseUsage.cache_creation_tokens` is removed —
  cache writes live in `input_tokens_details.cache_write_tokens` (Anthropic's
  `cache_creation_input_tokens` is mapped into it; cost accounting reads it).
- **Unknown-item passthrough.** Response item types we don't model (e.g.
  programmatic-tool-calling `program` items with their replay `fingerprint`)
  now validate into an `UnknownItem` and round-trip verbatim on the OpenAI
  Responses provider; other providers skip them. Known item types still
  validate strictly.
- **Anthropic mid-conversation system messages.** System/developer items after
  the leading run are sent as `role: "system"` messages at their position
  (the leading run still becomes the top-level `system` param). The API
  enforces placement and model support (Claude Opus 4.8+); integration tests
  pin both the accepting and rejecting models.
- **Web search fixes.** `find_in_page` actions now convert to the proper param
  (they previously degraded to `open_page`, losing the pattern);
  `query`/`queries`/`sources` are emitted only when present; the `web_search`
  setting also accepts the preview tool param (`search_content_types` image
  results).
- **Smaller items.** Persisted reasoning (`reasoning.context` / `mode`) and
  the `"xhigh"`/`"max"` reasoning efforts flow through settings;
  `InputFile.detail` passes through; assistant-message `phase` round-trip
  verified.

## Testing

- Full unit suite passes.
- All provider integration suites pass against the real APIs, including new
  live tests for explicit cache breakpoints (verified cache write → read) and
  Anthropic mid-conversation system model gating. OpenAI integration tests now
  use gpt-5.4+ models only (nano for simple tests).
- One API behavior change surfaced and pinned: OpenAI no longer rejects
  reasoning items with *missing* `encrypted_content` under `store=False`
  (corrupted content still errors); the test now documents the tolerant
  behavior.
