### PR TITLE
Combine base64 and provider refactor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grasp_agents"
-version = "1.0.25"
+version = "1.0.27"
 description = "Grasp Agents Library"
 readme = "README.md"
 requires-python = ">=3.12,<4"

--- a/src/grasp_agents/llm/cloud_llm.py
+++ b/src/grasp_agents/llm/cloud_llm.py
@@ -8,11 +8,12 @@ from functools import cache
 from typing import Any, ClassVar, NoReturn, Required, TypedDict
 
 import httpx
-from pydantic import BaseModel, ConfigDict, TypeAdapter, with_config
+from pydantic import BaseModel, ConfigDict, TypeAdapter, ValidationError, with_config
 
 from grasp_agents import grasp_logging
 from grasp_agents.rate_limiting.rate_limiter import RateLimiter, limit_rate
 from grasp_agents.tools.base import BaseTool, ToolChoice
+from grasp_agents.types.errors import LLMResponseValidationError
 from grasp_agents.types.items import InputItem
 from grasp_agents.types.llm_errors import (
     LlmError,
@@ -239,16 +240,34 @@ class CloudLLM(LLM):
         """
         Map a provider SDK exception to an LlmError subclass.
 
-        Returns None for unrecognized exceptions (passed through as-is).
-        Override in provider subclasses.
+        Override in provider subclasses. An override must return a typed
+        error for *every* exception its SDK can raise — the retry and
+        fallback layers act only on ``LlmErrorTuple``, so anything left
+        unmapped is fatal and skips both. Return None only for exceptions
+        that did not come from the SDK (a bug in our own code), which
+        should propagate untouched rather than be retried.
         """
         del err
         return None
 
-    def _raise_mapped(self, err: Exception) -> NoReturn:
+    def _raise_mapped(
+        self, err: Exception, *, output_schema: Any | None = None
+    ) -> NoReturn:
+        if isinstance(err, LlmErrorTuple):
+            # Already typed — re-mapping is lossy (``LlmContextWindowError``
+            # would degrade to ``LlmBadRequestError``, ``retry_after`` would
+            # be dropped) because our types subclass the OpenAI SDK's.
+            raise err
         mapped = self._map_api_error(err)
         if mapped is not None:
             raise mapped from err
+        if isinstance(err, ValidationError):
+            # Provider-side structured output that did not match the schema.
+            # SDKs validate it outside their own error handling, so it
+            # arrives as a bare pydantic error. Re-sampling the same model is
+            # the recovery, so it must reach the validation-retry layer
+            # rather than the API-retry and fallback layers.
+            raise LLMResponseValidationError(str(err), output_schema) from err
         raise err
 
     # --- Cost stamping ---
@@ -322,10 +341,8 @@ class CloudLLM(LLM):
             # an error body surfaces here (e.g. ``CompletionError``) and must
             # reach retry/fallback as a typed LlmError, not a bare exception.
             response = self._convert_api_response(raw)
-        except LlmErrorTuple:
-            raise
         except Exception as err:
-            self._raise_mapped(err)
+            self._raise_mapped(err, output_schema=output_schema)
 
         self._stamp_cost(response)
         logger.info(
@@ -379,10 +396,8 @@ class CloudLLM(LLM):
         t0 = time.monotonic()
         try:
             api_stream = await self._get_api_stream(**api_kwargs, **extra_settings)
-        except LlmErrorTuple:
-            raise
         except Exception as err:
-            self._raise_mapped(err)
+            self._raise_mapped(err, output_schema=output_schema)
 
         # Provider SDKs typically defer the HTTP request to the first iteration
         # of a lazily-returned stream, so SDK errors can surface here rather
@@ -394,10 +409,8 @@ class CloudLLM(LLM):
                 event = await anext(event_stream)
             except StopAsyncIteration:
                 break
-            except LlmErrorTuple:
-                raise
             except Exception as err:
-                self._raise_mapped(err)
+                self._raise_mapped(err, output_schema=output_schema)
             if isinstance(event, ResponseFailed):
                 # A terminal failure delivered as a stream event, not an
                 # exception — surface it as a typed, retryable error here so

--- a/src/grasp_agents/llm/llm.py
+++ b/src/grasp_agents/llm/llm.py
@@ -11,7 +11,7 @@ from functools import cached_property
 from typing import Any, Self, TypedDict, final
 from uuid import uuid4
 
-from pydantic import BaseModel, ConfigDict, ValidationError, with_config
+from pydantic import BaseModel, ConfigDict, with_config
 
 from grasp_agents import grasp_logging
 from grasp_agents.tools.base import BaseTool, ToolChoice
@@ -36,12 +36,7 @@ from .resilience import RetryPolicy
 
 logger = logging.getLogger(__name__)
 
-# Plain Pydantic validation errors can be raised by LLM SDKs
-_RETRYABLE_ERRORS = (
-    LLMToolCallValidationError,
-    LLMResponseValidationError,
-    ValidationError,
-)
+_RETRYABLE_ERRORS = (LLMToolCallValidationError, LLMResponseValidationError)
 
 
 @with_config(ConfigDict(extra="allow"))

--- a/src/grasp_agents/llm_providers/_http_helpers.py
+++ b/src/grasp_agents/llm_providers/_http_helpers.py
@@ -1,9 +1,10 @@
 """
-Shared HTTP parsing helpers for provider error-mapping modules.
+Shared parsing helpers for provider error-mapping modules.
 
 Private to ``grasp_agents.llm_providers``. Kept here rather than in each
 provider's ``utils.py`` because these parsers should produce identical
-output across providers that all speak standard HTTP headers.
+output across providers that all speak standard HTTP headers, or that
+share the OpenAI SDK's exception shape.
 """
 
 from __future__ import annotations
@@ -11,6 +12,14 @@ from __future__ import annotations
 import math
 
 import httpx
+import openai
+
+_QUOTA_CODES = frozenset({"insufficient_quota", "credit_balance_too_low"})
+_QUOTA_PHRASES = (
+    "insufficient_quota",
+    "exceeded your current quota",
+    "credit balance is too low",
+)
 
 
 def parse_retry_after(response: httpx.Response) -> float | None:
@@ -33,3 +42,29 @@ def parse_retry_after(response: httpx.Response) -> float | None:
     if not math.isfinite(value) or value < 0:
         return None
     return value
+
+
+def is_quota_message(text: str) -> bool:
+    """
+    Detect billing/quota exhaustion from an error message.
+
+    The last resort, for providers that discard the structured error body:
+    LiteLLM rewrites every exception with a fixed ``code``/``type``, and
+    OpenAI-compatible gateways often put the marker in the message alone.
+    """
+    lowered = text.lower()
+    return any(phrase in lowered for phrase in _QUOTA_PHRASES)
+
+
+def is_quota_error(err: openai.APIError) -> bool:
+    """
+    Detect billing/quota exhaustion on an OpenAI-shaped SDK error.
+
+    Distinguishes a spent account from an ordinary 429: the former never
+    clears, so it must fail over instead of being retried. ``code`` and
+    ``type`` are both checked — a mid-stream error frame populates only
+    one of them, depending on the provider.
+    """
+    if err.code in _QUOTA_CODES or err.type in _QUOTA_CODES:
+        return True
+    return is_quota_message(str(err))

--- a/src/grasp_agents/llm_providers/anthropic/error_mapping.py
+++ b/src/grasp_agents/llm_providers/anthropic/error_mapping.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import anthropic
 
-from grasp_agents.llm_providers._http_helpers import parse_retry_after
+from grasp_agents.llm_providers._http_helpers import is_quota_message, parse_retry_after
 from grasp_agents.types.llm_errors import (
     LlmApiConnectionError,
+    LlmApiError,
     LlmApiStatusError,
     LlmApiTimeoutError,
     LlmAuthenticationError,
@@ -15,6 +16,7 @@ from grasp_agents.types.llm_errors import (
     LlmError,
     LlmInternalServerError,
     LlmNotFoundError,
+    LlmQuotaExceededError,
     LlmRateLimitError,
 )
 
@@ -24,24 +26,34 @@ def map_api_error(err: Exception) -> LlmError | None:
         return LlmApiTimeoutError(request=err.request)
     if isinstance(err, anthropic.APIConnectionError):
         return LlmApiConnectionError(message=str(err), request=err.request)
-    if not isinstance(err, anthropic.APIStatusError):
-        return None
 
-    msg = str(err)
-    code = err.status_code
-    resp, body = err.response, err.body
-    if code == 429:
-        return LlmRateLimitError(
-            msg, response=resp, body=body, retry_after=parse_retry_after(resp)
-        )
-    if code in {401, 403}:
-        return LlmAuthenticationError(msg, response=resp, body=body)
-    if code == 404:
-        return LlmNotFoundError(msg, response=resp, body=body)
-    if code == 413:
-        return LlmContextWindowError(msg, response=resp, body=body)
-    if code >= 500:
-        return LlmInternalServerError(msg, response=resp, body=body)
-    if code == 400:
-        return LlmBadRequestError(msg, response=resp, body=body)
-    return LlmApiStatusError(msg, response=resp, body=body)
+    if isinstance(err, anthropic.APIStatusError):
+        msg = str(err)
+        code = err.status_code
+        resp, body = err.response, err.body
+        # A spent account, which Anthropic reports as a 400 rather than a
+        # 429 — retrying will not clear it, so it must fail over instead.
+        if is_quota_message(msg):
+            return LlmQuotaExceededError(msg, response=resp, body=body)
+        if code == 429:
+            return LlmRateLimitError(
+                msg, response=resp, body=body, retry_after=parse_retry_after(resp)
+            )
+        if code in {401, 403}:
+            return LlmAuthenticationError(msg, response=resp, body=body)
+        if code == 404:
+            return LlmNotFoundError(msg, response=resp, body=body)
+        if code == 413:
+            return LlmContextWindowError(msg, response=resp, body=body)
+        if code >= 500:
+            return LlmInternalServerError(msg, response=resp, body=body)
+        if code == 400:
+            return LlmBadRequestError(msg, response=resp, body=body)
+        return LlmApiStatusError(msg, response=resp, body=body)
+
+    if isinstance(err, anthropic.APIError):
+        # No HTTP status — a response body the SDK could not validate, or an
+        # error raised outside the status path. Must still reach the cascade.
+        return LlmApiError(str(err), err.request, body=err.body)
+
+    return None

--- a/src/grasp_agents/llm_providers/anthropic/response_to_provider_inputs.py
+++ b/src/grasp_agents/llm_providers/anthropic/response_to_provider_inputs.py
@@ -195,7 +195,9 @@ def _image_to_block(img: InputImage) -> ImageBlockParam:
     cc = _to_cache_control(img.cache_control)
 
     if img.is_base64 and img.image_url:
-        data = img.image_url.removeprefix(BASE64_DATA_PREFIX)
+        data = img.image_url.removeprefix(
+            BASE64_DATA_PREFIX.format(mime_type=img.mime_type)
+        )
         if img.mime_type not in SUPPORTED_MIME_TYPES:
             raise ValueError(f"Unsupported MIME type for base64 image: {img.mime_type}")
 

--- a/src/grasp_agents/llm_providers/gemini/error_mapping.py
+++ b/src/grasp_agents/llm_providers/gemini/error_mapping.py
@@ -9,6 +9,9 @@ from google.genai import errors as genai_errors
 
 from grasp_agents.llm_providers._http_helpers import parse_retry_after
 from grasp_agents.types.llm_errors import (
+    LlmApiConnectionError,
+    LlmApiStatusError,
+    LlmApiTimeoutError,
     LlmAuthenticationError,
     LlmBadRequestError,
     LlmError,
@@ -48,6 +51,15 @@ def _get_response(err: genai_errors.APIError) -> httpx.Response:
 
 
 def map_api_error(err: Exception) -> LlmError | None:
+    # The GenAI SDK inspects httpx transport failures for its own retry
+    # predicate but does not wrap them, so they surface here unchanged.
+    if isinstance(err, httpx.TimeoutException):
+        return LlmApiTimeoutError(request=httpx.Request(*_SYNTHETIC_REQUEST))
+    if isinstance(err, httpx.TransportError):
+        return LlmApiConnectionError(
+            message=str(err), request=httpx.Request(*_SYNTHETIC_REQUEST)
+        )
+
     if not isinstance(err, genai_errors.APIError):
         return None
 
@@ -70,4 +82,4 @@ def map_api_error(err: Exception) -> LlmError | None:
     if code == 400:
         return LlmBadRequestError(msg, response=resp, body=None)
 
-    return None
+    return LlmApiStatusError(msg, response=resp, body=None)

--- a/src/grasp_agents/llm_providers/litellm/error_mapping.py
+++ b/src/grasp_agents/llm_providers/litellm/error_mapping.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 
 import httpx
 import litellm
+import openai
 
-from grasp_agents.llm_providers._http_helpers import parse_retry_after
+from grasp_agents.llm_providers._http_helpers import is_quota_error, parse_retry_after
 from grasp_agents.types.errors import CompletionError
 from grasp_agents.types.llm_errors import (
     LlmApiConnectionError,
+    LlmApiError,
+    LlmApiStatusError,
     LlmApiTimeoutError,
     LlmAuthenticationError,
     LlmBadRequestError,
@@ -19,9 +22,19 @@ from grasp_agents.types.llm_errors import (
     LlmInternalServerError,
     LlmNotFoundError,
     LlmPermissionDeniedError,
+    LlmQuotaExceededError,
     LlmRateLimitError,
     LlmUnprocessableEntityError,
 )
+
+_SYNTHETIC_REQUEST = ("POST", "https://api.openai.com/v1")
+
+
+def _synthetic_response(status_code: int) -> httpx.Response:
+    return httpx.Response(
+        status_code=status_code,
+        request=httpx.Request(*_SYNTHETIC_REQUEST),
+    )
 
 
 def map_api_error(err: Exception) -> LlmError | None:
@@ -30,11 +43,14 @@ def map_api_error(err: Exception) -> LlmError | None:
     if isinstance(err, CompletionError):
         # A 200 response carrying an error/invalid body (e.g. OpenRouter's
         # in-body upstream failures) — transient, must reach retry/fallback.
-        synthetic = httpx.Response(
-            status_code=502,
-            request=httpx.Request("POST", "https://api.openai.com/v1"),
-        )
-        return LlmInternalServerError(msg, response=synthetic, body=None)
+        return LlmInternalServerError(msg, response=_synthetic_response(502), body=None)
+
+    # Both mean the account can no longer pay for the call, whatever status
+    # the upstream chose — fail over instead of retrying a dead key.
+    if isinstance(err, litellm.BudgetExceededError) or (
+        isinstance(err, openai.APIError) and is_quota_error(err)
+    ):
+        return LlmQuotaExceededError(msg, response=_synthetic_response(429), body=None)
 
     if isinstance(err, litellm.Timeout):
         return LlmApiTimeoutError(request=err.request)
@@ -75,5 +91,14 @@ def map_api_error(err: Exception) -> LlmError | None:
 
     if isinstance(err, (litellm.InternalServerError, litellm.ServiceUnavailableError)):
         return LlmInternalServerError(msg, response=err.response, body=err.body)
+
+    if isinstance(err, openai.APIStatusError):
+        return LlmApiStatusError(msg, response=err.response, body=err.body)
+
+    if isinstance(err, openai.APIError):
+        # Every litellm exception derives from the OpenAI SDK's, so this
+        # catches the long tail (in-stream error frames, bodies the SDK
+        # could not validate) that the branches above do not name.
+        return LlmApiError(msg, err.request, body=err.body)
 
     return None

--- a/src/grasp_agents/llm_providers/openai_completions/error_mapping.py
+++ b/src/grasp_agents/llm_providers/openai_completions/error_mapping.py
@@ -5,30 +5,52 @@ from __future__ import annotations
 import httpx
 import openai
 
-from grasp_agents.llm_providers._http_helpers import parse_retry_after
+from grasp_agents.llm_providers._http_helpers import is_quota_error, parse_retry_after
 from grasp_agents.types.errors import CompletionError
 from grasp_agents.types.llm_errors import (
     LlmApiConnectionError,
+    LlmApiError,
     LlmApiStatusError,
     LlmApiTimeoutError,
     LlmAuthenticationError,
     LlmBadRequestError,
+    LlmContentFilterError,
     LlmError,
     LlmInternalServerError,
     LlmNotFoundError,
+    LlmQuotaExceededError,
     LlmRateLimitError,
 )
+
+_SYNTHETIC_REQUEST = ("POST", "https://api.openai.com/v1")
+
+
+def _synthetic_response(status_code: int) -> httpx.Response:
+    return httpx.Response(
+        status_code=status_code,
+        request=httpx.Request(*_SYNTHETIC_REQUEST),
+    )
 
 
 def map_api_error(err: Exception) -> LlmError | None:
     if isinstance(err, CompletionError):
         # A 200 response carrying an error/invalid body (e.g. OpenRouter's
         # in-body upstream failures) — transient, must reach retry/fallback.
-        synthetic = httpx.Response(
-            status_code=502,
-            request=httpx.Request("POST", "https://api.openai.com/v1"),
+        return LlmInternalServerError(
+            str(err), response=_synthetic_response(502), body=None
         )
-        return LlmInternalServerError(str(err), response=synthetic, body=None)
+
+    # Finish-reason failures from the `.parse()` helper: not transport errors,
+    # but they abort the call and so must still reach the fallback cascade.
+    if isinstance(err, openai.ContentFilterFinishReasonError):
+        return LlmContentFilterError()
+
+    if isinstance(err, openai.LengthFinishReasonError):
+        # Re-sampling the same model with the same cap repeats the
+        # truncation; another model with more headroom may not.
+        return LlmBadRequestError(
+            str(err), response=_synthetic_response(400), body=None
+        )
 
     if isinstance(err, openai.APITimeoutError):
         return LlmApiTimeoutError(request=err.request)
@@ -36,27 +58,43 @@ def map_api_error(err: Exception) -> LlmError | None:
     if isinstance(err, openai.APIConnectionError):
         return LlmApiConnectionError(message=str(err), request=err.request)
 
-    if not isinstance(err, openai.APIStatusError):
-        return None
+    if isinstance(err, openai.APIStatusError):
+        msg = str(err)
+        code = err.status_code
+        resp, body = err.response, err.body
 
-    msg = str(err)
-    code = err.status_code
-    resp, body = err.response, err.body
-    if code == 429:
-        return LlmRateLimitError(
-            msg, response=resp, body=body, retry_after=parse_retry_after(resp)
-        )
+        # Checked before the status branches: gateways disagree on the code
+        # they return for a spent account (429, 402, 403 are all seen).
+        if is_quota_error(err):
+            return LlmQuotaExceededError(msg, response=resp, body=body)
 
-    if code in {401, 403}:
-        return LlmAuthenticationError(msg, response=resp, body=body)
+        if code == 429:
+            return LlmRateLimitError(
+                msg, response=resp, body=body, retry_after=parse_retry_after(resp)
+            )
 
-    if code == 404:
-        return LlmNotFoundError(msg, response=resp, body=body)
+        if code in {401, 403}:
+            return LlmAuthenticationError(msg, response=resp, body=body)
 
-    if code >= 500:
-        return LlmInternalServerError(msg, response=resp, body=body)
+        if code == 404:
+            return LlmNotFoundError(msg, response=resp, body=body)
 
-    if code in {400, 422}:
-        return LlmBadRequestError(msg, response=resp, body=body)
+        if code >= 500:
+            return LlmInternalServerError(msg, response=resp, body=body)
 
-    return LlmApiStatusError(msg, response=resp, body=body)
+        if code in {400, 422}:
+            return LlmBadRequestError(msg, response=resp, body=body)
+
+        return LlmApiStatusError(msg, response=resp, body=body)
+
+    if isinstance(err, openai.APIError):
+        # No HTTP status: an error frame inside a 200 SSE stream, or a
+        # response body the SDK could not validate. Quota exhaustion lands
+        # here on streamed calls, where the transport status is 200.
+        if is_quota_error(err):
+            return LlmQuotaExceededError(
+                str(err), response=_synthetic_response(429), body=err.body
+            )
+        return LlmApiError(str(err), err.request, body=err.body)
+
+    return None

--- a/src/grasp_agents/types/__init__.py
+++ b/src/grasp_agents/types/__init__.py
@@ -64,6 +64,7 @@ from .llm_errors import (
     LlmInternalServerError,
     LlmNotFoundError,
     LlmPermissionDeniedError,
+    LlmQuotaExceededError,
     LlmRateLimitError,
 )
 from .llm_events import (
@@ -149,6 +150,7 @@ __all__ = [
     "LlmInternalServerError",
     "LlmNotFoundError",
     "LlmPermissionDeniedError",
+    "LlmQuotaExceededError",
     "LlmRateLimitError",
     "OpenPageAction",
     "OutputContentPart",

--- a/src/grasp_agents/types/llm_errors.py
+++ b/src/grasp_agents/types/llm_errors.py
@@ -56,6 +56,15 @@ class LlmRateLimitError(openai.RateLimitError):
         self.retry_after = retry_after
 
 
+class LlmQuotaExceededError(LlmRateLimitError):
+    """
+    Account credits/quota are exhausted.
+
+    Unlike a plain rate limit this does not clear on its own, so it is not
+    retried: only a different key or model can serve the request.
+    """
+
+
 class LlmInternalServerError(openai.InternalServerError):
     pass
 
@@ -96,6 +105,7 @@ type LlmError = (
     | LlmApiStatusError
     | LlmApiTimeoutError
     | LlmRateLimitError
+    | LlmQuotaExceededError
     | LlmInternalServerError
     | LlmAuthenticationError
     | LlmPermissionDeniedError
@@ -113,6 +123,7 @@ LlmErrorTuple = (
     LlmApiStatusError,
     LlmApiTimeoutError,
     LlmRateLimitError,
+    LlmQuotaExceededError,
     LlmInternalServerError,
     LlmAuthenticationError,
     LlmPermissionDeniedError,

--- a/src/grasp_agents/types/recovery.py
+++ b/src/grasp_agents/types/recovery.py
@@ -45,6 +45,7 @@ from .llm_errors import (
     LlmInternalServerError,
     LlmNotFoundError,
     LlmPermissionDeniedError,
+    LlmQuotaExceededError,
     LlmRateLimitError,
     LlmUnprocessableEntityError,
 )
@@ -65,6 +66,9 @@ class RecoveryHint(StrEnum):
     RATE_LIMITED = "rate_limited"
     """Server asked us to slow down. Honor ``retry_after`` if present."""
 
+    QUOTA_EXCEEDED = "quota_exceeded"
+    """Account credits/quota are spent. Only another key or model can serve."""
+
     NEEDS_COMPACTION = "needs_compaction"
     """Input exceeded the model's context window; reduce before retrying."""
 
@@ -82,6 +86,9 @@ class RecoveryHint(StrEnum):
 
 
 _HINT_REGISTRY: dict[type[BaseException], RecoveryHint] = {
+    # Quota exhaustion — a RateLimitError subclass, so the MRO walk must find
+    # it first; unlike a rate limit it never clears, so it is not retryable.
+    LlmQuotaExceededError: RecoveryHint.QUOTA_EXCEEDED,
     # Rate limiting — check before the generic status parent.
     LlmRateLimitError: RecoveryHint.RATE_LIMITED,
     # Context-window overflow — specific subclass of BadRequestError; must be

--- a/tests/anthropic/test_converters.py
+++ b/tests/anthropic/test_converters.py
@@ -8,6 +8,7 @@ Uses real Anthropic SDK model objects (not mocks) to ensure type compatibility.
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 from typing import Any
 
@@ -61,6 +62,7 @@ from grasp_agents.llm_providers.anthropic.tool_converters import (
 )
 from grasp_agents.tools.base import BaseTool, NamedToolChoice
 from grasp_agents.types.content import (
+    InputImage,
     InputText,
     OutputMessageRefusal,
     OutputMessageText,
@@ -559,6 +561,55 @@ class TestResponseToMessage:
         assert isinstance(assistant_content, list)
         assert assistant_content[0]["type"] == "redacted_thinking"
         assert assistant_content[0]["data"] == "encrypted_data"
+
+
+class TestImageBlocks:
+    """
+    Base64 images must reach Anthropic as the raw payload.
+
+    ``InputImage`` stores base64 images as a ``data:<mime>;base64,<payload>``
+    URI; Anthropic's ``source.data`` takes the payload alone and 400s on the
+    full URI.
+    """
+
+    def test_base64_image_strips_data_uri_prefix(self):
+        payload = base64.b64encode(b"\x89PNG\r\n\x1a\nfakepngbytes").decode()
+        items = [
+            InputMessageItem(
+                role="user",
+                content=[
+                    InputText(text="What is this?"),
+                    InputImage.from_base64(payload),
+                ],
+            )
+        ]
+
+        _system, messages = items_to_anthropic_messages(items)
+
+        content = messages[0]["content"]
+        assert isinstance(content, list)
+        image_block = content[1]
+        assert image_block["type"] == "image"
+        source = image_block["source"]
+        assert source["type"] == "base64"
+        assert source["media_type"] == "image/png"
+        assert source["data"] == payload
+
+    def test_url_image_passed_through(self):
+        items = [
+            InputMessageItem(
+                role="user",
+                content=[InputImage.from_url("https://example.com/a.png")],
+            )
+        ]
+
+        _system, messages = items_to_anthropic_messages(items)
+
+        content = messages[0]["content"]
+        assert isinstance(content, list)
+        source = content[0]["source"]
+        assert source["type"] == "url"
+        assert source["url"] == "https://example.com/a.png"
 
 
 # ==== tool_converters ====

--- a/tests/anthropic/test_error_mapping.py
+++ b/tests/anthropic/test_error_mapping.py
@@ -8,6 +8,7 @@ import httpx
 from grasp_agents.llm_providers.anthropic.error_mapping import map_api_error
 from grasp_agents.types.llm_errors import (
     LlmApiConnectionError,
+    LlmApiError,
     LlmApiStatusError,
     LlmApiTimeoutError,
     LlmAuthenticationError,
@@ -15,6 +16,7 @@ from grasp_agents.types.llm_errors import (
     LlmContextWindowError,
     LlmInternalServerError,
     LlmNotFoundError,
+    LlmQuotaExceededError,
     LlmRateLimitError,
 )
 
@@ -61,3 +63,18 @@ class TestAnthropicErrorMapping:
 
     def test_non_anthropic_error_returns_none(self) -> None:
         assert map_api_error(ValueError("nope")) is None
+
+    def test_bare_api_error_maps_to_api_error(self) -> None:
+        # No HTTP status — must still be typed, or it skips retry and fallback.
+        err = anthropic.APIError("no status", request=_REQUEST, body=None)
+        assert isinstance(map_api_error(err), LlmApiError)
+
+    def test_low_credit_balance_maps_to_quota_exceeded(self) -> None:
+        # Anthropic reports a spent account as a 400, not a 429; retrying
+        # will not clear it, so it must fail over instead.
+        err = anthropic.APIStatusError(
+            "Your credit balance is too low to access the Anthropic API",
+            response=httpx.Response(400, request=_REQUEST),
+            body=None,
+        )
+        assert isinstance(map_api_error(err), LlmQuotaExceededError)

--- a/tests/gemini/test_error_mapping.py
+++ b/tests/gemini/test_error_mapping.py
@@ -18,6 +18,9 @@ from google.genai import errors as genai_errors
 
 from grasp_agents.llm_providers.gemini.error_mapping import map_api_error
 from grasp_agents.types.llm_errors import (
+    LlmApiConnectionError,
+    LlmApiStatusError,
+    LlmApiTimeoutError,
     LlmAuthenticationError,
     LlmBadRequestError,
     LlmInternalServerError,
@@ -105,3 +108,23 @@ class TestGeminiErrorMapping:
 
     def test_non_genai_error_returns_none(self):
         assert map_api_error(ValueError("not an API error")) is None
+
+    def test_unlisted_status_maps_to_api_status(self):
+        # Anything left untyped skips retry and fallback, so codes the
+        # branches above do not name must still land on a typed error.
+        err = genai_errors.ClientError(
+            409, {"error": {"message": "conflict", "status": "ABORTED"}}
+        )
+
+        assert isinstance(map_api_error(err), LlmApiStatusError)
+
+    def test_httpx_transport_failures_map(self):
+        # The SDK inspects httpx failures for its own retry predicate but
+        # never wraps them, so they reach the mapper unchanged.
+        request = httpx.Request("POST", "https://generativelanguage.googleapis.com")
+
+        timeout = map_api_error(httpx.ReadTimeout("timed out", request=request))
+        connect = map_api_error(httpx.ConnectError("refused", request=request))
+
+        assert isinstance(timeout, LlmApiTimeoutError)
+        assert isinstance(connect, LlmApiConnectionError)

--- a/tests/litellm/test_error_mapping.py
+++ b/tests/litellm/test_error_mapping.py
@@ -1,0 +1,66 @@
+"""Map LiteLLM exceptions to typed LlmError values."""
+
+from __future__ import annotations
+
+import httpx
+import litellm
+import openai
+
+from grasp_agents.llm_providers.litellm.error_mapping import map_api_error
+from grasp_agents.types.llm_errors import (
+    LlmApiError,
+    LlmApiStatusError,
+    LlmQuotaExceededError,
+    LlmRateLimitError,
+)
+
+_REQUEST = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+
+
+class TestLiteLLMErrorsWithoutStatus:
+    """
+    Every litellm exception derives from the OpenAI SDK's, so the generic
+    fallthrough must type the long tail the named branches do not cover —
+    anything left untyped skips both retry and fallback.
+    """
+
+    def test_bare_api_error_maps_to_api_error(self) -> None:
+        err = openai.APIError(message="stream blew up", request=_REQUEST, body=None)
+        assert isinstance(map_api_error(err), LlmApiError)
+
+    def test_unlisted_status_maps_to_api_status(self) -> None:
+        err = openai.APIStatusError(
+            "teapot", response=httpx.Response(418, request=_REQUEST), body=None
+        )
+        assert isinstance(map_api_error(err), LlmApiStatusError)
+
+    def test_non_openai_error_returns_none(self) -> None:
+        assert map_api_error(ValueError("nope")) is None
+
+
+class TestLiteLLMQuotaDetection:
+    def test_budget_exceeded_maps_to_quota_exceeded(self) -> None:
+        err = litellm.BudgetExceededError(current_cost=10.0, max_budget=5.0)
+        assert isinstance(map_api_error(err), LlmQuotaExceededError)
+
+    def test_insufficient_quota_maps_to_quota_exceeded(self) -> None:
+        # LiteLLM rewrites every exception with a fixed code/type and drops
+        # the upstream body, so only the message carries the signal.
+        err = litellm.RateLimitError(
+            "You exceeded your current quota, please check your plan",
+            llm_provider="openai",
+            model="gpt-5",
+            response=httpx.Response(429, request=_REQUEST),
+        )
+        assert isinstance(map_api_error(err), LlmQuotaExceededError)
+
+    def test_plain_rate_limit_stays_retryable(self) -> None:
+        err = litellm.RateLimitError(
+            "slow down",
+            llm_provider="openai",
+            model="gpt-5",
+            response=httpx.Response(429, request=_REQUEST),
+        )
+        mapped = map_api_error(err)
+        assert isinstance(mapped, LlmRateLimitError)
+        assert not isinstance(mapped, LlmQuotaExceededError)

--- a/tests/llm/test_recovery_hints.py
+++ b/tests/llm/test_recovery_hints.py
@@ -27,6 +27,7 @@ from grasp_agents.types.llm_errors import (
     LlmInternalServerError,
     LlmNotFoundError,
     LlmPermissionDeniedError,
+    LlmQuotaExceededError,
     LlmRateLimitError,
     LlmUnprocessableEntityError,
 )
@@ -120,6 +121,12 @@ class TestRecoveryHintClassification:
     def test_content_filter_maps_to_refused(self) -> None:
         err = LlmContentFilterError()
         assert classify_error(err) is RecoveryHint.CONTENT_REFUSED
+
+    def test_quota_beats_rate_limit_parent(self) -> None:
+        """A spent account never clears, so it must not inherit RATE_LIMITED."""
+        err = LlmQuotaExceededError("spent", response=_fake_response(), body=None)
+        assert classify_error(err) is RecoveryHint.QUOTA_EXCEEDED
+        assert not is_retryable(classify_error(err))
 
     def test_unknown_exception_maps_to_unknown(self) -> None:
         assert classify_error(RuntimeError("mystery")) is RecoveryHint.UNKNOWN
@@ -223,6 +230,7 @@ class TestIsRetryable:
         assert is_retryable(RecoveryHint.RATE_LIMITED)
 
     def test_non_transient_are_not_retryable(self) -> None:
+        assert not is_retryable(RecoveryHint.QUOTA_EXCEEDED)
         assert not is_retryable(RecoveryHint.NEEDS_COMPACTION)
         assert not is_retryable(RecoveryHint.REAUTH_REQUIRED)
         assert not is_retryable(RecoveryHint.CONTENT_REFUSED)
@@ -279,6 +287,12 @@ class TestRetryPolicyAlignment:
             ),
             (
                 lambda: LlmContextWindowError(
+                    "x", response=_fake_response(), body=None
+                ),
+                False,
+            ),
+            (
+                lambda: LlmQuotaExceededError(
                     "x", response=_fake_response(), body=None
                 ),
                 False,

--- a/tests/llm/test_resilience.py
+++ b/tests/llm/test_resilience.py
@@ -23,6 +23,9 @@ from grasp_agents.llm.fallback_llm import FallbackLLM, _select_cascade_error
 from grasp_agents.llm.llm import LLM
 from grasp_agents.llm.model_info import ModelCapabilities
 from grasp_agents.llm.resilience import RetryPolicy
+from grasp_agents.llm_providers.openai_completions.error_mapping import (
+    map_api_error as openai_map_api_error,
+)
 from grasp_agents.tools.base import BaseTool
 from grasp_agents.types.content import OutputMessageText
 from grasp_agents.types.errors import (
@@ -1173,3 +1176,163 @@ class TestStreamErrorMapping:
         completed = [e for e in events if isinstance(e, ResponseCompleted)]
         assert len(completed) == 1
         assert completed[0].response.output_text == "rescued"
+
+
+# ---------- Unmapped-error escape hatch (CloudLLM + real provider mapper) ----------
+
+
+@dataclass(frozen=True)
+class RealMapperCloudLLM(CloudLLM):
+    """
+    A CloudLLM wired to the production OpenAI mapper, so these tests pin the
+    contract end to end rather than against a stub mapping.
+    """
+
+    raw_error: Exception = field(
+        default_factory=lambda: openai.APIError(message="boom", request=_REQ, body=None)
+    )
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        object.__setattr__(self, "_attempts", 0)
+
+    @property
+    def attempts(self) -> int:
+        return self._attempts  # type: ignore[attr-defined]
+
+    def _map_api_error(self, err: Exception) -> LlmError | None:
+        return openai_map_api_error(err)
+
+    def _make_api_input(
+        self,
+        input: Sequence[InputItem],
+        tools: Mapping[str, BaseTool[BaseModel, Any, Any]] | None = None,
+        tool_choice: Any | None = None,
+        output_schema: Any | None = None,
+        **extra_llm_settings: Any,
+    ) -> ApiCallParams:
+        return {"api_input": list(input)}
+
+    async def _get_api_response(
+        self,
+        api_input: list[Any],
+        *,
+        api_tools: list[Any] | None = None,
+        api_tool_choice: Any | None = None,
+        api_output_schema: type | None = None,
+        **api_llm_settings: Any,
+    ) -> Any:
+        object.__setattr__(self, "_attempts", self._attempts + 1)  # type: ignore[attr-defined]
+        raise self.raw_error
+
+    def _convert_api_response(self, raw: Any) -> Response:
+        raise NotImplementedError
+
+    async def _get_api_stream(
+        self,
+        api_input: list[Any],
+        *,
+        api_tools: list[Any] | None = None,
+        api_tool_choice: Any | None = None,
+        api_output_schema: type | None = None,
+        **api_llm_settings: Any,
+    ) -> AsyncIterator[Any]:
+        raise NotImplementedError
+
+    async def _convert_api_stream(
+        self, api_stream: AsyncIterator[Any]
+    ) -> AsyncIterator[LlmEvent]:
+        raise NotImplementedError
+        yield  # pragma: no cover
+
+
+_NO_DELAY = RetryPolicy(api_retries=2, validation_retries=0, initial_delay=0.0)
+
+
+class TestUnmappedErrorReachesCascade:
+    """
+    Every provider SDK error must arrive typed. The retry and fallback
+    layers act only on ``LlmErrorTuple``, and the raw SDK exceptions are
+    that tuple's *parents* — so an unmapped error skips both and kills the
+    run on the primary, however many fallbacks are configured.
+    """
+
+    @pytest.mark.asyncio
+    async def test_bare_api_error_falls_back(self) -> None:
+        # A bare APIError is what the SDK raises for an error frame inside a
+        # 200 SSE stream; it used to propagate past the whole cascade.
+        primary = RealMapperCloudLLM(model_name="primary", retry_policy=None)
+        fallback = StubLLM(model_name="fallback", response=_text_response("rescued"))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
+
+        response = await llm.generate_response(_USER_MSG)
+
+        assert response.output_text == "rescued"
+        assert primary.attempts == 1
+
+    @pytest.mark.asyncio
+    async def test_quota_error_falls_back_without_retrying(self) -> None:
+        """A spent account never clears, so it must not consume the budget."""
+        primary = RealMapperCloudLLM(
+            model_name="primary",
+            retry_policy=_NO_DELAY,
+            raw_error=openai.APIError(
+                message="You exceeded your current quota",
+                request=_REQ,
+                body={"type": "insufficient_quota", "code": "insufficient_quota"},
+            ),
+        )
+        fallback = StubLLM(model_name="fallback", response=_text_response("rescued"))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
+
+        response = await llm.generate_response(_USER_MSG)
+
+        assert response.output_text == "rescued"
+        assert primary.attempts == 1
+
+    @pytest.mark.asyncio
+    async def test_transient_unmapped_error_still_retries(self) -> None:
+        """An unclassifiable SDK error stays retryable before the cascade."""
+        primary = RealMapperCloudLLM(model_name="primary", retry_policy=_NO_DELAY)
+        fallback = StubLLM(model_name="fallback", response=_text_response("rescued"))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
+
+        await llm.generate_response(_USER_MSG)
+
+        assert primary.attempts == 3
+
+
+class TestRaiseMappedDoesNotRemap:
+    """
+    An already-typed error must pass through ``_raise_mapped`` untouched:
+    our types subclass the OpenAI SDK's, so re-mapping matches them again
+    and silently downgrades them.
+    """
+
+    @pytest.mark.asyncio
+    async def test_context_window_error_is_not_downgraded(self) -> None:
+        # Re-mapping would match the 400 branch and yield LlmBadRequestError,
+        # losing the NEEDS_COMPACTION signal compaction keys on.
+        llm = RealMapperCloudLLM(
+            model_name="primary",
+            retry_policy=None,
+            raw_error=LlmContextWindowError("too long", response=_resp(400), body=None),
+        )
+
+        with pytest.raises(LlmContextWindowError):
+            await llm.generate_response(_USER_MSG)
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_retry_after_is_preserved(self) -> None:
+        llm = RealMapperCloudLLM(
+            model_name="primary",
+            retry_policy=None,
+            raw_error=LlmRateLimitError(
+                "slow down", response=_resp(429), body=None, retry_after=30.0
+            ),
+        )
+
+        with pytest.raises(LlmRateLimitError) as excinfo:
+            await llm.generate_response(_USER_MSG)
+
+        assert excinfo.value.retry_after == 30.0

--- a/tests/llm/test_schema_parse_errors.py
+++ b/tests/llm/test_schema_parse_errors.py
@@ -1,0 +1,128 @@
+"""
+Provider-side structured-output parse failures.
+
+Provider SDKs validate the caller's output schema outside their own error
+handling, so a mismatch arrives as a bare ``pydantic.ValidationError``
+rather than an SDK error type. Re-sampling the same model is the recovery,
+so it has to reach the validation-retry layer — not the API-retry and
+fallback layers, which would burn the retry budget and swap models over a
+re-rollable generation failure.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from grasp_agents.llm.cloud_llm import ApiCallParams
+from grasp_agents.llm.fallback_llm import FallbackLLM
+from grasp_agents.llm.resilience import RetryPolicy
+from grasp_agents.tools.base import BaseTool
+from grasp_agents.types.errors import LLMResponseValidationError
+from grasp_agents.types.items import InputItem
+from tests.llm.test_resilience import (
+    _USER_MSG,
+    RealMapperCloudLLM,
+    StubLLM,
+    _text_response,
+)
+
+
+class _Schema(BaseModel):
+    n: int
+
+
+def _parse_failure() -> ValidationError:
+    try:
+        _Schema.model_validate_json('{"n": "not-an-int"}')
+    except ValidationError as err:
+        return err
+    raise AssertionError("expected a ValidationError")
+
+
+@dataclass(frozen=True)
+class BadInputCloudLLM(RealMapperCloudLLM):
+    """Fails while *building* the request, before the mapped region."""
+
+    def _make_api_input(
+        self,
+        input: Sequence[InputItem],
+        tools: Mapping[str, BaseTool[BaseModel, Any, Any]] | None = None,
+        tool_choice: Any | None = None,
+        output_schema: Any | None = None,
+        **extra_llm_settings: Any,
+    ) -> ApiCallParams:
+        raise _parse_failure()
+
+
+_VALIDATION_ONLY = RetryPolicy(api_retries=0, validation_retries=2, initial_delay=0.0)
+
+
+class TestParseFailureRoutesToValidationRetries:
+    @pytest.mark.asyncio
+    async def test_parse_failure_becomes_response_validation_error(self) -> None:
+        llm = RealMapperCloudLLM(
+            model_name="primary",
+            retry_policy=_VALIDATION_ONLY,
+            raw_error=_parse_failure(),
+        )
+
+        with pytest.raises(LLMResponseValidationError) as excinfo:
+            await llm.generate_response(_USER_MSG, output_schema=_Schema)
+
+        assert isinstance(excinfo.value.__cause__, ValidationError)
+        assert excinfo.value.schema is _Schema
+
+    @pytest.mark.asyncio
+    async def test_parse_failure_is_resampled_not_api_retried(self) -> None:
+        # api_retries=0, so reaching 3 attempts proves it went through the
+        # validation-retry layer rather than the API one.
+        llm = RealMapperCloudLLM(
+            model_name="primary",
+            retry_policy=_VALIDATION_ONLY,
+            raw_error=_parse_failure(),
+        )
+
+        with pytest.raises(LLMResponseValidationError):
+            await llm.generate_response(_USER_MSG, output_schema=_Schema)
+
+        assert llm.attempts == 3  # initial + 2 validation retries
+
+    @pytest.mark.asyncio
+    async def test_parse_failure_does_not_swap_models(self) -> None:
+        """A re-rollable generation failure must not spend the cascade."""
+        primary = RealMapperCloudLLM(
+            model_name="primary",
+            retry_policy=RetryPolicy(api_retries=0, validation_retries=0),
+            raw_error=_parse_failure(),
+        )
+        fallback = StubLLM(model_name="fallback", response=_text_response("rescued"))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
+
+        with pytest.raises(LLMResponseValidationError):
+            await llm.generate_response(_USER_MSG, output_schema=_Schema)
+
+
+class TestUnrelatedValidationErrorsAreNotConverted:
+    """
+    Only the provider-call region is converted. A ``ValidationError`` from
+    anywhere else is our own bug and must surface immediately rather than
+    being re-sampled as if the model produced it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_request_building_failure_propagates_raw(self) -> None:
+        llm = BadInputCloudLLM(
+            model_name="primary",
+            retry_policy=_VALIDATION_ONLY,
+            raw_error=_parse_failure(),
+        )
+
+        with pytest.raises(ValidationError):
+            await llm.generate_response(_USER_MSG, output_schema=_Schema)
+
+        assert llm.attempts == 0

--- a/tests/openai_completions/test_error_mapping.py
+++ b/tests/openai_completions/test_error_mapping.py
@@ -4,26 +4,41 @@ from __future__ import annotations
 
 import httpx
 import openai
+from openai.types.chat import ChatCompletion
 
 from grasp_agents.llm_providers.openai_completions.error_mapping import map_api_error
 from grasp_agents.types.errors import CompletionError
 from grasp_agents.types.llm_errors import (
     LlmApiConnectionError,
+    LlmApiError,
     LlmApiStatusError,
     LlmApiTimeoutError,
     LlmAuthenticationError,
     LlmBadRequestError,
+    LlmContentFilterError,
     LlmInternalServerError,
     LlmNotFoundError,
+    LlmQuotaExceededError,
     LlmRateLimitError,
 )
 
 _REQUEST = httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
 
+_QUOTA_BODY = {
+    "message": "You exceeded your current quota",
+    "type": "insufficient_quota",
+    "code": "insufficient_quota",
+    "param": None,
+}
 
-def _status_error(code: int, headers: dict[str, str] | None = None) -> Exception:
+
+def _status_error(
+    code: int,
+    headers: dict[str, str] | None = None,
+    body: object | None = None,
+) -> Exception:
     response = httpx.Response(code, request=_REQUEST, headers=headers or {})
-    return openai.APIStatusError("boom", response=response, body=None)
+    return openai.APIStatusError("boom", response=response, body=body)
 
 
 class TestOpenAICompletionsErrorMapping:
@@ -64,3 +79,71 @@ class TestOpenAICompletionsErrorMapping:
 
     def test_non_openai_error_returns_none(self) -> None:
         assert map_api_error(ValueError("nope")) is None
+
+
+class TestOpenAIErrorsWithoutStatus:
+    """
+    Errors the SDK raises without an HTTP status must still be typed: the
+    retry and fallback layers act only on ``LlmErrorTuple``, and a raw
+    ``openai.APIError`` is that tuple's *parent*, so leaving it unmapped
+    makes it skip both.
+    """
+
+    def test_bare_api_error_maps_to_api_error(self) -> None:
+        # How openai/_streaming.py reports an error frame inside a 200 SSE
+        # stream — the shape that used to bypass retry and fallback entirely.
+        err = openai.APIError(message="stream blew up", request=_REQUEST, body=None)
+        assert isinstance(map_api_error(err), LlmApiError)
+
+    def test_response_validation_error_maps_to_api_error(self) -> None:
+        err = openai.APIResponseValidationError(
+            response=httpx.Response(200, request=_REQUEST), body=None
+        )
+        assert isinstance(map_api_error(err), LlmApiError)
+
+    def test_content_filter_finish_reason_maps(self) -> None:
+        assert isinstance(
+            map_api_error(openai.ContentFilterFinishReasonError()),
+            LlmContentFilterError,
+        )
+
+    def test_length_finish_reason_maps_to_bad_request(self) -> None:
+        completion = ChatCompletion(
+            id="c1", choices=[], created=0, model="gpt-5", object="chat.completion"
+        )
+        err = openai.LengthFinishReasonError(completion=completion)
+        assert isinstance(map_api_error(err), LlmBadRequestError)
+
+
+class TestOpenAIQuotaDetection:
+    """
+    A spent account must be told apart from an ordinary 429: it never
+    clears, so it has to fail over rather than burn the retry budget.
+    """
+
+    def test_streamed_quota_maps_to_quota_exceeded(self) -> None:
+        # Quota exhaustion on a streamed call arrives as a bare APIError,
+        # because the transport status is 200.
+        err = openai.APIError(
+            message="You exceeded your current quota",
+            request=_REQUEST,
+            body=_QUOTA_BODY,
+        )
+        assert isinstance(map_api_error(err), LlmQuotaExceededError)
+
+    def test_status_quota_maps_to_quota_exceeded(self) -> None:
+        mapped = map_api_error(_status_error(429, body=_QUOTA_BODY))
+        assert isinstance(mapped, LlmQuotaExceededError)
+
+    def test_quota_detected_regardless_of_status_code(self) -> None:
+        # Gateways disagree on the code they return for a spent account.
+        assert isinstance(
+            map_api_error(_status_error(403, body=_QUOTA_BODY)), LlmQuotaExceededError
+        )
+
+    def test_plain_rate_limit_is_not_quota(self) -> None:
+        mapped = map_api_error(
+            _status_error(429, body={"type": "requests", "code": "rate_limit_exceeded"})
+        )
+        assert isinstance(mapped, LlmRateLimitError)
+        assert not isinstance(mapped, LlmQuotaExceededError)

--- a/uv.lock
+++ b/uv.lock
@@ -1181,7 +1181,7 @@ wheels = [
 
 [[package]]
 name = "grasp-agents"
-version = "1.0.25"
+version = "1.0.27"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
# Improve LLM error mapping and fallback

## Unmapped provider errors no longer skip retry and fallback

The retry and fallback layers act only on `LlmErrorTuple`. A provider SDK
exception joins that tuple only if the provider's `map_api_error` recognizes
it — anything else was re-raised untouched. Since our `Llm*` types *subclass*
the SDK's exception classes, an unmapped SDK error is that tuple's **parent**,
not a member, so it slipped past both layers and killed the run on the primary
model no matter how many fallbacks were configured.

Each mapper now types its whole SDK surface:

- **OpenAI / LiteLLM** — base `APIError` fallthrough to `LlmApiError`, covering
  error frames delivered inside a 200 SSE stream and response bodies the SDK
  could not validate. `.parse()` finish-reason failures (content filter,
  length) map as well.
- **Anthropic** — base `APIError` fallthrough.
- **Gemini** — unlisted status codes to `LlmApiStatusError`, plus httpx
  transport failures, which that SDK inspects but never wraps.

`_raise_mapped` is now the single seam guaranteeing a typed error. It also
leaves already-typed errors alone: re-mapping was lossy, degrading
`LlmContextWindowError` to `LlmBadRequestError` and dropping `retry_after`.
The three redundant `except LlmErrorTuple: raise` arms are gone.

## Quota exhaustion is distinguishable from a rate limit

Adds `LlmQuotaExceededError` and `RecoveryHint.QUOTA_EXCEEDED`, deliberately
outside the retryable set — a spent account never clears, so it now fails over
immediately instead of spending the retry budget on backoff. Detected from the
structured error `code`/`type`, falling back to the message for providers that
discard the upstream error body.

## Structured-output parse failures reach the validation-retry layer

Provider SDKs validate the caller's output schema in a post-parser that sits
outside their own error handling, so a mismatch surfaces as a bare
`pydantic.ValidationError`. It is now converted to `LLMResponseValidationError`
so the same model is re-sampled, rather than consuming API retries or swapping
models over a re-rollable generation failure.

## Anthropic base64 images

`BASE64_DATA_PREFIX` is a template (`data:{mime_type};base64,`). The Anthropic
converter stripped it unformatted, so the prefix never matched and the entire
data URI was sent as the image payload. It is now formatted with the image's
MIME type before stripping.

## Tests

New coverage for each mapper's fallthrough, quota detection and its
non-retryable routing, the no-re-mapping guarantee, and schema-parse failures
reaching validation retries rather than fallback — plus Anthropic image
converter cases. Full suite: 2784 passed, 1 skipped.

Version 1.0.25 → 1.0.27.
