### PR TITLE
fix(llm): opt-in tolerance for a provider that keeps emitting after the JSON

### DIFF
--- a/src/grasp_agents/agent/llm_agent.py
+++ b/src/grasp_agents/agent/llm_agent.py
@@ -1235,10 +1235,13 @@ class LLMAgent[InT, OutT, CtxT](
         await self._serialize_rollback_checkpoint(self._ctx, checkpoint)
 
     def parse_output_default(self, final_answer: str) -> OutT:
+        # Tracks the LLM's own tolerance: a model whose provider closes the JSON
+        # value and keeps emitting passes `LLM._validate_response` and would
+        # then fail here, turning a recoverable response into a failed run.
         return validate_obj_from_json_or_py_string(
             final_answer,
             schema=self._out_type,
-            from_substring=False,
+            from_substring=self.llm.tolerate_output_around_json,
             strip_language_markdown=True,
         )
 

--- a/src/grasp_agents/llm/cloud_llm.py
+++ b/src/grasp_agents/llm/cloud_llm.py
@@ -104,6 +104,8 @@ class CloudLLM(LLM):
     apply_tool_call_schema_via_provider: bool = False
 
     def __post_init__(self) -> None:
+        super().__post_init__()
+
         self._validate_platform()
 
         if self.llm_settings is not None and self._settings_type is not None:

--- a/src/grasp_agents/llm/llm.py
+++ b/src/grasp_agents/llm/llm.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from functools import cached_property
-from typing import Any, Self, TypedDict, final
+from typing import Any, ClassVar, Self, TypedDict, final
 from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, with_config
@@ -59,8 +59,28 @@ class LLM(ABC):
     # emitting: see ``_validate_json_allowing_surrounding_content``. Off by
     # default because it makes validation accept the FIRST valid value in the
     # output, so a model that emits a draft before its answer would have the
-    # draft accepted instead of re-sampled.
+    # draft accepted instead of re-sampled. Applies to the final answer only —
+    # tool call arguments stay strict.
     tolerate_output_around_json: bool = False
+
+    # Whether this provider's non-streaming path can actually honour the flag
+    # above. A provider whose SDK parses the reply itself (Anthropic's
+    # ``messages.parse``) rejects trailing bytes before our validation runs, so
+    # setting the flag there would be a silent no-op; subclasses that route
+    # around their SDK's parse set this True and the rest reject the flag.
+    _supports_output_around_json_tolerance: ClassVar[bool] = False
+
+    def __post_init__(self) -> None:
+        if self.tolerate_output_around_json and not (
+            self._supports_output_around_json_tolerance
+        ):
+            raise ValueError(
+                f"{type(self).__name__} cannot honour "
+                "tolerate_output_around_json: its provider SDK parses the "
+                "response itself and rejects content around the JSON value "
+                "before validation runs. Supported on the OpenAI Responses and "
+                "Chat Completions providers."
+            )
 
     def __deepcopy__(self, memo: dict[int, Any]) -> Self:
         # Frozen + non-copyable SDK clients (AsyncOpenAI, etc.) — share by ref
@@ -425,10 +445,14 @@ class LLM(ABC):
                 continue
             tool = tools[tc.name]
             try:
-                self._validate_json_allowing_surrounding_content(
-                    tc.arguments,
-                    tool.llm_in_type,
-                    what=f"'{tc.name}' tool call arguments",
+                # Strict regardless of ``tolerate_output_around_json``: the flag
+                # covers the final answer only. ``AgentLoop._convert_tool_input``
+                # re-parses these same arguments strictly before dispatch, so
+                # relaxing here would only move the failure later — and a tool
+                # call is dispatched, not read, which makes accepting the first
+                # of two candidate payloads a worse trade than a re-sample.
+                validate_obj_from_json_or_py_string(
+                    tc.arguments, schema=tool.llm_in_type
                 )
             except JSONSchemaValidationError as exc:
                 failed.append(

--- a/src/grasp_agents/llm/llm.py
+++ b/src/grasp_agents/llm/llm.py
@@ -55,6 +55,12 @@ class LLM(ABC):
     # client retries default to 0 so the two never multiply. ``None``
     # disables retries entirely.
     retry_policy: RetryPolicy | None = field(default_factory=RetryPolicy)
+    # Opt in per model when a provider closes the JSON value and keeps
+    # emitting: see ``_validate_json_tolerating_surrounding_content``. Off by
+    # default because it makes validation accept the FIRST valid value in the
+    # output, so a model that emits a draft before its answer would have the
+    # draft accepted instead of re-sampled.
+    tolerate_output_around_json: bool = False
 
     def __deepcopy__(self, memo: dict[int, Any]) -> Self:
         # Frozen + non-copyable SDK clients (AsyncOpenAI, etc.) — share by ref
@@ -356,17 +362,27 @@ class LLM(ABC):
         what: str,
     ) -> None:
         """
-        Validate `s` against `schema`, ignoring content around the JSON value.
+        Validate `s` against `schema`, strictly unless this model opts out.
 
         A grammar-constrained provider can satisfy the schema and then keep
         emitting: Bedrock's decoder appends a redundant `}` after a complete,
         schema-valid object for some models. Re-sampling output that was already
-        correct costs a whole extra call, so a strict failure is retried against
-        the leading JSON value before it counts as a validation error.
+        correct costs a whole extra call, so a model with
+        ``tolerate_output_around_json`` set retries a strict failure against the
+        leading JSON value before it counts as a validation error.
 
-        Strict stays the first attempt, and the recovery is logged — it is a
-        provider defect, and repairing it silently would hide it.
+        Field-level validation is unchanged either way — only content *around*
+        the JSON value is forgiven. That is still a trade: the FIRST valid value
+        wins, so a model that narrates a draft before its answer would have the
+        draft accepted. Hence opt-in per model, strict by default.
+
+        The recovery is logged — it is a provider defect, and repairing it
+        silently would hide it.
         """
+        if not self.tolerate_output_around_json:
+            validate_obj_from_json_or_py_string(s, schema=schema)
+            return
+
         try:
             validate_obj_from_json_or_py_string(s, schema=schema)
             return

--- a/src/grasp_agents/llm/llm.py
+++ b/src/grasp_agents/llm/llm.py
@@ -56,7 +56,7 @@ class LLM(ABC):
     # disables retries entirely.
     retry_policy: RetryPolicy | None = field(default_factory=RetryPolicy)
     # Opt in per model when a provider closes the JSON value and keeps
-    # emitting: see ``_validate_json_tolerating_surrounding_content``. Off by
+    # emitting: see ``_validate_json_allowing_surrounding_content``. Off by
     # default because it makes validation accept the FIRST valid value in the
     # output, so a model that emits a draft before its answer would have the
     # draft accepted instead of re-sampled.
@@ -346,7 +346,7 @@ class LLM(ABC):
 
         if output_schema is not None and not response.tool_call_items:
             try:
-                self._validate_json_tolerating_surrounding_content(
+                self._validate_json_allowing_surrounding_content(
                     response.output_text, output_schema, what="response"
                 )
             except JSONSchemaValidationError as exc:
@@ -354,7 +354,7 @@ class LLM(ABC):
                     response.output_text, output_schema
                 ) from exc
 
-    def _validate_json_tolerating_surrounding_content(
+    def _validate_json_allowing_surrounding_content(
         self,
         s: str,
         schema: Any,
@@ -365,11 +365,16 @@ class LLM(ABC):
         Validate `s` against `schema`, strictly unless this model opts out.
 
         A grammar-constrained provider can satisfy the schema and then keep
-        emitting: Bedrock's decoder appends a redundant `}` after a complete,
-        schema-valid object for some models. Re-sampling output that was already
-        correct costs a whole extra call, so a model with
-        ``tolerate_output_around_json`` set retries a strict failure against the
-        leading JSON value before it counts as a validation error.
+        emitting: the constraint covers the value, not the stopping, so once the
+        closing brace lands the model is free to append more tokens before it
+        stops. Measured against Bedrock's Gemma 4 this affects a few percent of
+        calls; the appended bytes are usually the start of a prose answer the
+        model was going to write anyway (`---`, `**`), sometimes a stray token or
+        a duplicate `}`. No request-side setting suppresses it.
+
+        Re-sampling output that was already correct costs a whole extra call, so
+        a model with ``tolerate_output_around_json`` set retries a strict failure
+        against the leading JSON value before it counts as a validation error.
 
         Field-level validation is unchanged either way — only content *around*
         the JSON value is forgiven. That is still a trade: the FIRST valid value
@@ -379,15 +384,12 @@ class LLM(ABC):
         The recovery is logged — it is a provider defect, and repairing it
         silently would hide it.
         """
-        if not self.tolerate_output_around_json:
-            validate_obj_from_json_or_py_string(s, schema=schema)
-            return
-
         try:
             validate_obj_from_json_or_py_string(s, schema=schema)
             return
         except JSONSchemaValidationError:
-            pass
+            if not self.tolerate_output_around_json:
+                raise
 
         # Raises JSONSchemaValidationError when there is no valid JSON value at
         # all: that response is genuinely bad and must reach the caller.
@@ -423,7 +425,7 @@ class LLM(ABC):
                 continue
             tool = tools[tc.name]
             try:
-                self._validate_json_tolerating_surrounding_content(
+                self._validate_json_allowing_surrounding_content(
                     tc.arguments,
                     tool.llm_in_type,
                     what=f"'{tc.name}' tool call arguments",

--- a/src/grasp_agents/llm/llm.py
+++ b/src/grasp_agents/llm/llm.py
@@ -340,13 +340,50 @@ class LLM(ABC):
 
         if output_schema is not None and not response.tool_call_items:
             try:
-                validate_obj_from_json_or_py_string(
-                    response.output_text, schema=output_schema
+                self._validate_json_tolerating_surrounding_content(
+                    response.output_text, output_schema, what="response"
                 )
             except JSONSchemaValidationError as exc:
                 raise LLMResponseValidationError(
                     response.output_text, output_schema
                 ) from exc
+
+    def _validate_json_tolerating_surrounding_content(
+        self,
+        s: str,
+        schema: Any,
+        *,
+        what: str,
+    ) -> None:
+        """
+        Validate `s` against `schema`, ignoring content around the JSON value.
+
+        A grammar-constrained provider can satisfy the schema and then keep
+        emitting: Bedrock's decoder appends a redundant `}` after a complete,
+        schema-valid object for some models. Re-sampling output that was already
+        correct costs a whole extra call, so a strict failure is retried against
+        the leading JSON value before it counts as a validation error.
+
+        Strict stays the first attempt, and the recovery is logged — it is a
+        provider defect, and repairing it silently would hide it.
+        """
+        try:
+            validate_obj_from_json_or_py_string(s, schema=schema)
+            return
+        except JSONSchemaValidationError:
+            pass
+
+        # Raises JSONSchemaValidationError when there is no valid JSON value at
+        # all: that response is genuinely bad and must reach the caller.
+        validate_obj_from_json_or_py_string(s, schema=schema, from_substring=True)
+
+        logger.warning(
+            "llm %s: %s validated only after discarding trailing/leading "
+            "content around the JSON value: %s",
+            self.model_name,
+            what,
+            grasp_logging.body_for_log(s, full=grasp_logging.LOG_LLM_OUTPUT),
+        )
 
     def _validate_tool_calls(
         self,
@@ -370,8 +407,10 @@ class LLM(ABC):
                 continue
             tool = tools[tc.name]
             try:
-                validate_obj_from_json_or_py_string(
-                    tc.arguments, schema=tool.llm_in_type
+                self._validate_json_tolerating_surrounding_content(
+                    tc.arguments,
+                    tool.llm_in_type,
+                    what=f"'{tc.name}' tool call arguments",
                 )
             except JSONSchemaValidationError as exc:
                 failed.append(

--- a/src/grasp_agents/llm_providers/openai_completions/completions_llm.py
+++ b/src/grasp_agents/llm_providers/openai_completions/completions_llm.py
@@ -126,6 +126,10 @@ class OpenAILLM(CloudLLM):
     _settings_type: ClassVar[Any] = OpenAILLMSettings
 
     _native_provider_name: ClassVar[str] = "openai"
+    # `_get_api_response` routes around `chat.completions.parse()` when the
+    # flag is set, so our validation — not the SDK — decides on trailing
+    # content.
+    _supports_output_around_json_tolerance: ClassVar[bool] = True
     _native_api_key_env_vars: ClassVar[tuple[str, ...]] = ("OPENAI_API_KEY",)
     _cloud_platforms: ClassVar[frozenset[str]] = frozenset({"azure"})
 

--- a/src/grasp_agents/llm_providers/openai_completions/completions_llm.py
+++ b/src/grasp_agents/llm_providers/openai_completions/completions_llm.py
@@ -5,6 +5,8 @@ from typing import Any, ClassVar, Literal, TypedDict
 
 from openai import AsyncAzureOpenAI, AsyncOpenAI, AsyncStream
 from openai._types import omit  # type: ignore  # noqa: PLC2701
+from openai.lib._parsing._completions import validate_input_tools  # noqa: PLC2701
+from openai.lib._pydantic import to_strict_json_schema  # noqa: PLC2701
 from openai.lib.streaming.chat import (
     AsyncChatCompletionStreamManager as OpenAIAsyncChatCompletionStreamManager,
 )
@@ -248,6 +250,44 @@ class OpenAILLM(CloudLLM):
         response_format = api_output_schema or omit
 
         if self.apply_output_schema_via_provider:
+            if (
+                self.tolerate_output_around_json
+                and isinstance(api_output_schema, type)
+                and issubclass(api_output_schema, BaseModel)
+            ):
+                # The same strict schema `.parse()` would send, sent through
+                # `.create()` instead: `.parse()` also parses the reply and
+                # rejects one whose JSON value is followed by extra bytes, which
+                # is exactly what `tolerate_output_around_json` exists to
+                # forgive — its check runs first, so leniency downstream would
+                # never be reached. Leaving the parsing to `_validate_response`
+                # keeps provider-side enforcement either way.
+                #
+                # Streaming is deliberately not covered: `_get_api_stream` still
+                # hands the schema to `.stream()`, whose parse is equally strict.
+                #
+                # `.parse()` also rejects a non-function or non-strict tool up
+                # front; `.create()` does not, so run that check explicitly
+                # rather than lose it.
+                validate_input_tools(tools)
+                schema_format: OpenAIResponseFormatJSONSchema = {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": api_output_schema.__name__,
+                        "schema": to_strict_json_schema(api_output_schema),
+                        "strict": True,
+                    },
+                }
+                return await self.client.chat.completions.create(
+                    model=self.model_name,
+                    messages=api_input,
+                    tools=tools,
+                    tool_choice=tool_choice,
+                    stream=False,
+                    response_format=schema_format,
+                    **api_llm_settings,
+                )
+
             return await self.client.beta.chat.completions.parse(  # type: ignore[reportUnknownVariableType]
                 model=self.model_name,
                 messages=api_input,

--- a/src/grasp_agents/llm_providers/openai_responses/responses_llm.py
+++ b/src/grasp_agents/llm_providers/openai_responses/responses_llm.py
@@ -294,17 +294,29 @@ class OpenAIResponsesLLM(CloudLLM):
         )
 
         if self.apply_output_schema_via_provider:
-            if isinstance(api_output_schema, type) and issubclass(
-                api_output_schema, BaseModel
+            if (
+                self.tolerate_output_around_json
+                and isinstance(api_output_schema, type)
+                and issubclass(api_output_schema, BaseModel)
             ):
-                # Same strict schema `.parse()` would send, but sent through
-                # `.create()`: `.parse()` also parses the reply and rejects one
-                # whose JSON value is followed by any extra bytes, which some
-                # providers emit (Bedrock's decoder appends a redundant `}` for
-                # certain models). Leaving the parsing to `_validate_response`
-                # keeps provider-side enforcement while letting a recoverable
-                # response through instead of spending a retry on it.
+                # The same strict schema `.parse()` would send, sent through
+                # `.create()` instead: `.parse()` also parses the reply and
+                # rejects one whose JSON value is followed by extra bytes, which
+                # is exactly what `tolerate_output_around_json` exists to
+                # forgive — its check runs first, so leniency downstream would
+                # never be reached. Leaving the parsing to `_validate_response`
+                # keeps provider-side enforcement either way.
+                #
+                # Streaming is deliberately not covered: `_get_api_stream` still
+                # hands the schema to `.stream()`, whose parse is equally
+                # strict.
                 text_settings = dict(api_llm_settings.pop("text", None) or {})
+                if "format" in text_settings:
+                    # Mirrors `.parse()`, which refuses to silently replace a
+                    # caller-supplied format.
+                    raise TypeError(
+                        "Cannot mix and match text.format with an output schema"
+                    )
                 text_settings["format"] = {
                     "type": "json_schema",
                     "name": api_output_schema.__name__,

--- a/src/grasp_agents/llm_providers/openai_responses/responses_llm.py
+++ b/src/grasp_agents/llm_providers/openai_responses/responses_llm.py
@@ -317,6 +317,12 @@ class OpenAIResponsesLLM(CloudLLM):
                     raise TypeError(
                         "Cannot mix and match text.format with an output schema"
                     )
+                # `create()` takes no top-level `verbosity` — only `parse()`
+                # still accepts it — so relocate it to where the API reads it
+                # from. An explicit `text.verbosity` wins.
+                verbosity = api_llm_settings.pop("verbosity", None)
+                if verbosity is not None:
+                    text_settings.setdefault("verbosity", verbosity)
                 text_settings["format"] = {
                     "type": "json_schema",
                     "name": api_output_schema.__name__,

--- a/src/grasp_agents/llm_providers/openai_responses/responses_llm.py
+++ b/src/grasp_agents/llm_providers/openai_responses/responses_llm.py
@@ -155,6 +155,9 @@ class OpenAIResponsesLLM(CloudLLM):
     _settings_type: ClassVar[Any] = OpenAIResponsesLLMSettings
 
     _native_provider_name: ClassVar[str] = "openai"
+    # `_get_api_response` routes around `responses.parse()` when the flag is
+    # set, so our validation — not the SDK — decides on trailing content.
+    _supports_output_around_json_tolerance: ClassVar[bool] = True
     _native_api_key_env_vars: ClassVar[tuple[str, ...]] = ("OPENAI_API_KEY",)
     _cloud_platforms: ClassVar[frozenset[str]] = frozenset({"azure"})
 

--- a/src/grasp_agents/llm_providers/openai_responses/responses_llm.py
+++ b/src/grasp_agents/llm_providers/openai_responses/responses_llm.py
@@ -5,6 +5,7 @@ from typing import Any, ClassVar, Literal, cast
 
 from openai import AsyncAzureOpenAI, AsyncOpenAI
 from openai._types import omit  # noqa: PLC2701
+from openai.lib._pydantic import to_strict_json_schema  # noqa: PLC2701
 from openai.lib.streaming.responses._responses import (
     AsyncResponseStreamManager,
 )
@@ -293,6 +294,34 @@ class OpenAIResponsesLLM(CloudLLM):
         )
 
         if self.apply_output_schema_via_provider:
+            if isinstance(api_output_schema, type) and issubclass(
+                api_output_schema, BaseModel
+            ):
+                # Same strict schema `.parse()` would send, but sent through
+                # `.create()`: `.parse()` also parses the reply and rejects one
+                # whose JSON value is followed by any extra bytes, which some
+                # providers emit (Bedrock's decoder appends a redundant `}` for
+                # certain models). Leaving the parsing to `_validate_response`
+                # keeps provider-side enforcement while letting a recoverable
+                # response through instead of spending a retry on it.
+                text_settings = dict(api_llm_settings.pop("text", None) or {})
+                text_settings["format"] = {
+                    "type": "json_schema",
+                    "name": api_output_schema.__name__,
+                    "schema": to_strict_json_schema(api_output_schema),
+                    "strict": True,
+                }
+                return await self.client.responses.create(
+                    model=self.model_name,
+                    input=input_items,
+                    stream=False,
+                    tools=tools,
+                    tool_choice=tool_choice,
+                    text=cast("ResponseTextConfigParam", text_settings),
+                    previous_response_id=previous_response_id or omit,
+                    conversation=conversation or omit,
+                    **api_llm_settings,
+                )
             return await self.client.responses.parse(  # type: ignore[reportUnknownVariableType]
                 text_format=text_format,
                 model=self.model_name,

--- a/tests/agent/test_output_parse_tolerance.py
+++ b/tests/agent/test_output_parse_tolerance.py
@@ -1,0 +1,93 @@
+"""
+The agent's output parse tracks its LLM's trailing-output tolerance.
+
+`LLM._validate_response` and `LLMAgent.parse_output_default` both parse the
+final answer. If only the first tolerates a provider that closes the JSON value
+and keeps emitting, the second turns a response the LLM just accepted into a
+failed run — worse than the re-sample the tolerance was meant to avoid, since
+an agent defaults to `max_retries=0`.
+"""
+
+from collections.abc import AsyncIterator, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from grasp_agents.agent.llm_agent import LLMAgent
+from grasp_agents.llm.llm import LLM
+from grasp_agents.tools.base import BaseTool
+from grasp_agents.types.errors import JSONSchemaValidationError
+from grasp_agents.types.llm_events import LlmEvent
+from grasp_agents.types.response import Response
+
+
+@dataclass(frozen=True)
+class _StubLLM(LLM):
+    """Never called: the agent is built only to reach its output parser."""
+
+    model_name: str = "stub"
+
+    async def _generate_response_once(
+        self,
+        input: Sequence[Any],
+        *,
+        tools: Mapping[str, BaseTool[BaseModel, Any, Any]] | None = None,
+        output_schema: Any | None = None,
+        tool_choice: Any | None = None,
+        **extra_llm_settings: Any,
+    ) -> Response:
+        raise NotImplementedError
+
+    async def _generate_response_stream_once(
+        self,
+        input: Sequence[Any],
+        *,
+        tools: Mapping[str, BaseTool[BaseModel, Any, Any]] | None = None,
+        output_schema: Any | None = None,
+        tool_choice: Any | None = None,
+        **extra_llm_settings: Any,
+    ) -> AsyncIterator[LlmEvent]:
+        raise NotImplementedError
+        yield  # type: ignore[unreachable]  # makes this an async generator
+
+
+class Answer(BaseModel):
+    capital: str
+    population_millions: int
+
+
+_GOOD = '{"capital":"Paris","population_millions":68}'
+# What Bedrock's decoder emits for some models: a complete object, then one
+# redundant closing brace.
+_WITH_STRAY_BRACE = _GOOD + "}"
+
+
+def _agent(*, tolerate: bool) -> LLMAgent[str, Answer, None]:
+    return LLMAgent[str, Answer, None](
+        name=f"parser_agent_{tolerate}",
+        llm=_StubLLM(tolerate_output_around_json=tolerate),
+    )
+
+
+class TestOutputParseTolerance:
+    def test_tolerating_llm_parses_a_stray_brace(self) -> None:
+        parsed = _agent(tolerate=True).parse_output_default(_WITH_STRAY_BRACE)
+        assert parsed.capital == "Paris"
+        assert parsed.population_millions == 68
+
+    def test_strict_llm_still_rejects_it(self) -> None:
+        with pytest.raises(JSONSchemaValidationError):
+            _agent(tolerate=False).parse_output_default(_WITH_STRAY_BRACE)
+
+    def test_clean_output_parses_either_way(self) -> None:
+        for tolerate in (True, False):
+            assert _agent(tolerate=tolerate).parse_output_default(_GOOD).capital == (
+                "Paris"
+            )
+
+    def test_tolerance_does_not_accept_a_missing_field(self) -> None:
+        """Only content around the value is forgiven, never the value itself."""
+        with pytest.raises(JSONSchemaValidationError):
+            _agent(tolerate=True).parse_output_default('{"capital":"Paris"}')

--- a/tests/agent/test_output_parse_tolerance.py
+++ b/tests/agent/test_output_parse_tolerance.py
@@ -10,7 +10,7 @@ an agent defaults to `max_retries=0`.
 
 from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, ClassVar
 
 import pytest
 from pydantic import BaseModel
@@ -28,6 +28,10 @@ class _StubLLM(LLM):
     """Never called: the agent is built only to reach its output parser."""
 
     model_name: str = "stub"
+
+    # The tolerance is provider-gated; this stub stands in for one that supports
+    # it, since the test targets the agent's parse rather than a transport.
+    _supports_output_around_json_tolerance: ClassVar[bool] = True
 
     async def _generate_response_once(
         self,

--- a/tests/llm/test_llm_validation.py
+++ b/tests/llm/test_llm_validation.py
@@ -10,7 +10,7 @@ Focuses on:
 import logging
 from collections.abc import AsyncIterator, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, ClassVar
 
 import httpx
 import pytest
@@ -106,7 +106,11 @@ class MockLLM(LLM):
 
     responses: list[Response] = field(default_factory=list)
 
+    # Stands in for a provider whose reply our own validation parses.
+    _supports_output_around_json_tolerance: ClassVar[bool] = True
+
     def __post_init__(self):
+        super().__post_init__()
         object.__setattr__(self, "_call_count", 0)
 
     @property
@@ -541,15 +545,27 @@ class TestSchemaValidationToleratesTrailingContent:
             await llm.generate_response(_USER_MSG, output_schema=TrailingContentModel)
 
     @pytest.mark.asyncio
-    async def test_tool_call_arguments_tolerate_trailing_content(self) -> None:
+    async def test_tool_call_arguments_stay_strict(self) -> None:
+        """
+        The flag covers the final answer only.
+
+        `AgentLoop._convert_tool_input` re-parses the same arguments strictly
+        before dispatch, so tolerating them here would move the failure later
+        instead of preventing it. A tool call is also dispatched rather than
+        read, which makes guessing between two candidate payloads a worse trade
+        than a re-sample.
+        """
         llm = MockLLM(
             model_name="mock",
-            responses=[_tool_call_response("add", '{"a":1,"b":2}}')],
+            responses=[
+                _tool_call_response("add", '{"a":1,"b":2}}'),
+                _tool_call_response("add", '{"a":1,"b":2}'),
+            ],
             retry_policy=RetryPolicy(validation_retries=2),
             tolerate_output_around_json=True,
         )
         await llm.generate_response(_USER_MSG, tools={"add": AddTool()})
-        assert llm.call_count == 1
+        assert llm.call_count == 2
 
 
 class TestSchemaValidationStrictByDefault:
@@ -591,3 +607,32 @@ class TestSchemaValidationStrictByDefault:
         )
         await llm.generate_response(_USER_MSG, output_schema=TrailingContentModel)
         assert llm.call_count == 2
+
+
+@dataclass(frozen=True)
+class UnsupportedToleranceLLM(MockLLM):
+    """A provider whose SDK parses the reply itself, so it cannot be lenient."""
+
+    _supports_output_around_json_tolerance: ClassVar[bool] = False
+
+
+class TestToleranceIsProviderGated:
+    """
+    The flag must fail loudly where it cannot work.
+
+    A provider that lets its SDK parse the reply (Anthropic's `messages.parse`,
+    both streaming paths) rejects trailing content before our validation runs,
+    so accepting the flag there would silently do nothing.
+    """
+
+    def test_unsupported_provider_rejects_the_flag(self) -> None:
+        with pytest.raises(ValueError, match="cannot honour"):
+            UnsupportedToleranceLLM(model_name="mock", tolerate_output_around_json=True)
+
+    def test_unsupported_provider_is_fine_with_the_flag_off(self) -> None:
+        llm = UnsupportedToleranceLLM(model_name="mock")
+        assert llm.tolerate_output_around_json is False
+
+    def test_supported_provider_accepts_the_flag(self) -> None:
+        llm = MockLLM(model_name="mock", tolerate_output_around_json=True)
+        assert llm.tolerate_output_around_json is True

--- a/tests/llm/test_llm_validation.py
+++ b/tests/llm/test_llm_validation.py
@@ -452,3 +452,93 @@ class TestStreamRetry:
         last_before = events[retrying_idx - 1]
         assert isinstance(last_before, ResponseCompleted)
         assert events[retrying_idx].sequence_number == last_before.sequence_number + 1
+
+
+class TrailingContentModel(BaseModel):
+    capital: str
+    population_millions: int
+
+
+class TestSchemaValidationToleratesTrailingContent:
+    """
+    A provider may close the object and then keep emitting.
+
+    Bedrock's grammar-constrained decoding for Gemma occasionally appends a
+    redundant `}` after a complete, schema-valid object. Rejecting that costs a
+    whole re-sample for output that was already correct, so validation accepts
+    the leading JSON value and ignores what trails it.
+    """
+
+    _GOOD = '{"capital":"Paris","population_millions":68}'
+
+    @pytest.mark.asyncio
+    async def test_stray_closing_brace_validates(self) -> None:
+        llm = MockLLM(
+            model_name="mock",
+            responses=[_text_response(self._GOOD + "}")],
+            retry_policy=RetryPolicy(validation_retries=2),
+        )
+        await llm.generate_response(_USER_MSG, output_schema=TrailingContentModel)
+        assert llm.call_count == 1, "must not spend a retry on recoverable output"
+
+    @pytest.mark.asyncio
+    async def test_recovery_is_logged_with_the_trailing_bytes(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        llm = MockLLM(
+            model_name="mock",
+            responses=[_text_response(self._GOOD + "}")],
+            retry_policy=RetryPolicy(validation_retries=2),
+        )
+        with caplog.at_level(logging.WARNING):
+            await llm.generate_response(_USER_MSG, output_schema=TrailingContentModel)
+
+        assert any("trailing" in r.message.lower() for r in caplog.records), (
+            "a silent recovery hides the provider defect"
+        )
+
+    @pytest.mark.asyncio
+    async def test_prose_around_the_object_validates(self) -> None:
+        """Fenced or chatty output is the same defect class."""
+        llm = MockLLM(
+            model_name="mock",
+            responses=[_text_response(f"Here you go:\n```json\n{self._GOOD}\n```\n")],
+            retry_policy=RetryPolicy(validation_retries=2),
+        )
+        await llm.generate_response(_USER_MSG, output_schema=TrailingContentModel)
+        assert llm.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_genuinely_malformed_output_still_fails(self) -> None:
+        """Leniency must not swallow output with no valid object in it."""
+        llm = MockLLM(
+            model_name="mock",
+            responses=[
+                _text_response("I cannot answer that."),
+                _text_response(self._GOOD),
+            ],
+            retry_policy=RetryPolicy(validation_retries=1),
+        )
+        await llm.generate_response(_USER_MSG, output_schema=TrailingContentModel)
+        assert llm.call_count == 2, "unrecoverable output must still be re-sampled"
+
+    @pytest.mark.asyncio
+    async def test_truncated_object_still_fails(self) -> None:
+        """A cut-off object has no complete JSON value — not recoverable."""
+        llm = MockLLM(
+            model_name="mock",
+            responses=[_text_response('{"capital":"Paris","population_mil')],
+            retry_policy=RetryPolicy(validation_retries=0),
+        )
+        with pytest.raises(LLMResponseValidationError):
+            await llm.generate_response(_USER_MSG, output_schema=TrailingContentModel)
+
+    @pytest.mark.asyncio
+    async def test_tool_call_arguments_tolerate_trailing_content(self) -> None:
+        llm = MockLLM(
+            model_name="mock",
+            responses=[_tool_call_response("add", '{"a":1,"b":2}}')],
+            retry_policy=RetryPolicy(validation_retries=2),
+        )
+        await llm.generate_response(_USER_MSG, tools={"add": AddTool()})
+        assert llm.call_count == 1

--- a/tests/llm/test_llm_validation.py
+++ b/tests/llm/test_llm_validation.py
@@ -477,6 +477,7 @@ class TestSchemaValidationToleratesTrailingContent:
             model_name="mock",
             responses=[_text_response(self._GOOD + "}")],
             retry_policy=RetryPolicy(validation_retries=2),
+            tolerate_output_around_json=True,
         )
         await llm.generate_response(_USER_MSG, output_schema=TrailingContentModel)
         assert llm.call_count == 1, "must not spend a retry on recoverable output"
@@ -489,6 +490,7 @@ class TestSchemaValidationToleratesTrailingContent:
             model_name="mock",
             responses=[_text_response(self._GOOD + "}")],
             retry_policy=RetryPolicy(validation_retries=2),
+            tolerate_output_around_json=True,
         )
         with caplog.at_level(logging.WARNING):
             await llm.generate_response(_USER_MSG, output_schema=TrailingContentModel)
@@ -504,6 +506,7 @@ class TestSchemaValidationToleratesTrailingContent:
             model_name="mock",
             responses=[_text_response(f"Here you go:\n```json\n{self._GOOD}\n```\n")],
             retry_policy=RetryPolicy(validation_retries=2),
+            tolerate_output_around_json=True,
         )
         await llm.generate_response(_USER_MSG, output_schema=TrailingContentModel)
         assert llm.call_count == 1
@@ -518,6 +521,7 @@ class TestSchemaValidationToleratesTrailingContent:
                 _text_response(self._GOOD),
             ],
             retry_policy=RetryPolicy(validation_retries=1),
+            tolerate_output_around_json=True,
         )
         await llm.generate_response(_USER_MSG, output_schema=TrailingContentModel)
         assert llm.call_count == 2, "unrecoverable output must still be re-sampled"
@@ -529,6 +533,7 @@ class TestSchemaValidationToleratesTrailingContent:
             model_name="mock",
             responses=[_text_response('{"capital":"Paris","population_mil')],
             retry_policy=RetryPolicy(validation_retries=0),
+            tolerate_output_around_json=True,
         )
         with pytest.raises(LLMResponseValidationError):
             await llm.generate_response(_USER_MSG, output_schema=TrailingContentModel)
@@ -539,6 +544,48 @@ class TestSchemaValidationToleratesTrailingContent:
             model_name="mock",
             responses=[_tool_call_response("add", '{"a":1,"b":2}}')],
             retry_policy=RetryPolicy(validation_retries=2),
+            tolerate_output_around_json=True,
         )
         await llm.generate_response(_USER_MSG, tools={"add": AddTool()})
         assert llm.call_count == 1
+
+
+class TestSchemaValidationStrictByDefault:
+    """
+    Without `tolerate_output_around_json`, validation is unchanged.
+
+    The flag is opt-in because leniency accepts the FIRST valid JSON value in
+    the output: a model that narrates a draft before its real answer would have
+    the draft accepted rather than re-sampled.
+    """
+
+    _GOOD = '{"capital":"Paris","population_millions":68}'
+
+    @pytest.mark.asyncio
+    async def test_stray_brace_still_costs_a_retry(self) -> None:
+        llm = MockLLM(
+            model_name="mock",
+            responses=[_text_response(self._GOOD + "}"), _text_response(self._GOOD)],
+            retry_policy=RetryPolicy(validation_retries=1),
+        )
+        await llm.generate_response(_USER_MSG, output_schema=TrailingContentModel)
+        assert llm.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_default_is_strict(self) -> None:
+        assert MockLLM(model_name="mock").tolerate_output_around_json is False
+
+    @pytest.mark.asyncio
+    async def test_a_decoy_first_object_is_rejected(self) -> None:
+        """The risk the flag guards: leniency would accept the decoy."""
+        decoy = '{"capital":"?","population_millions":0}'
+        llm = MockLLM(
+            model_name="mock",
+            responses=[
+                _text_response(f"I will use this shape: {decoy}. Answer: {self._GOOD}"),
+                _text_response(self._GOOD),
+            ],
+            retry_policy=RetryPolicy(validation_retries=1),
+        )
+        await llm.generate_response(_USER_MSG, output_schema=TrailingContentModel)
+        assert llm.call_count == 2

--- a/tests/llm/test_llm_validation.py
+++ b/tests/llm/test_llm_validation.py
@@ -463,10 +463,12 @@ class TestSchemaValidationToleratesTrailingContent:
     """
     A provider may close the object and then keep emitting.
 
-    Bedrock's grammar-constrained decoding for Gemma occasionally appends a
-    redundant `}` after a complete, schema-valid object. Rejecting that costs a
-    whole re-sample for output that was already correct, so validation accepts
-    the leading JSON value and ignores what trails it.
+    Grammar-constrained decoding constrains the value, not the stopping: once the
+    closing brace lands the model may append more tokens before it stops. Bedrock
+    does this for Gemma 4 on a few percent of calls — usually the opening of a
+    prose answer (`---`, `**`), sometimes a stray token or a duplicate `}`.
+    Rejecting that costs a whole re-sample for output that was already correct,
+    so validation accepts the leading JSON value and ignores what trails it.
     """
 
     _GOOD = '{"capital":"Paris","population_millions":68}'

--- a/tests/openai_completions/test_output_schema_transport.py
+++ b/tests/openai_completions/test_output_schema_transport.py
@@ -1,0 +1,239 @@
+"""
+How an output schema reaches the Chat Completions API.
+
+Mirrors `tests/openai_responses/test_output_schema_transport.py`: with
+`tolerate_output_around_json` set, the strict json_schema must still reach the
+provider — so generation stays constrained — while the reply's parsing is left
+to `LLM._validate_response`. `.parse()` would do both, and its parse rejects a
+reply whose JSON value is followed by extra bytes, which is what the tolerance
+exists to forgive.
+
+Chat Completions is affected by the same provider behaviour as Responses: on
+Bedrock's Gemma 4, a few percent of schema-constrained replies carry trailing
+bytes after the closing brace.
+"""
+
+import inspect
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from openai import AsyncOpenAI
+from openai.types.chat import ChatCompletion
+from pydantic import BaseModel
+
+from grasp_agents.llm_providers.openai_completions.completions_llm import OpenAILLM
+
+
+class Answer(BaseModel):
+    capital: str
+    population_millions: int
+
+
+def _completion() -> ChatCompletion:
+    """Minimal reply the converter accepts — a choice with schema-valid content."""
+    return ChatCompletion.model_validate(
+        {
+            "id": "cmpl_1",
+            "created": 0,
+            "model": "m",
+            "object": "chat.completion",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "message": {
+                        "role": "assistant",
+                        "content": '{"capital":"Paris","population_millions":11}',
+                    },
+                }
+            ],
+        }
+    )
+
+
+def _llm(*, tolerate: bool = True, **kwargs: Any) -> OpenAILLM:
+    llm = OpenAILLM(
+        model_name="google.gemma-4-31b",
+        api_provider={"name": "x", "base_url": "https://x/openai/v1", "api_key": "k"},
+        apply_output_schema_via_provider=True,
+        tolerate_output_around_json=tolerate,
+        **kwargs,
+    )
+    object.__setattr__(llm.client, "chat", AsyncMock())
+    object.__setattr__(llm.client, "beta", AsyncMock())
+    llm.client.chat.completions.create.return_value = _completion()  # type: ignore[attr-defined]
+    llm.client.beta.chat.completions.parse.return_value = _completion()  # type: ignore[attr-defined]
+    return llm
+
+
+class TestOutputSchemaTransport:
+    @pytest.mark.asyncio
+    async def test_uses_create_not_parse(self) -> None:
+        llm = _llm()
+        await llm._get_api_response([], api_output_schema=Answer)
+
+        llm.client.chat.completions.create.assert_awaited_once()  # type: ignore[attr-defined]
+        llm.client.beta.chat.completions.parse.assert_not_awaited()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_schema_is_sent_strict(self) -> None:
+        llm = _llm()
+        await llm._get_api_response([], api_output_schema=Answer)
+
+        fmt = llm.client.chat.completions.create.await_args.kwargs["response_format"]  # type: ignore[attr-defined]
+        assert fmt["type"] == "json_schema"
+        js = fmt["json_schema"]
+        assert js["strict"] is True
+        assert js["name"] == "Answer"
+        # Strict mode's own requirements, so enforcement is not silently weakened.
+        assert js["schema"]["additionalProperties"] is False
+        assert set(js["schema"]["required"]) == {"capital", "population_millions"}
+
+    @pytest.mark.asyncio
+    async def test_stream_false_is_sent(self) -> None:
+        """`create()` defaults to non-streaming only if we say so explicitly."""
+        llm = _llm()
+        await llm._get_api_response([], api_output_schema=Answer)
+
+        assert llm.client.chat.completions.create.await_args.kwargs["stream"] is False  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_forwarded_kwargs_are_all_accepted_by_the_real_create(self) -> None:
+        """
+        The mocked client accepts anything, so a kwarg the real SDK rejects would
+        pass every other test here and fail in production. Bind the captured call
+        against the genuine signature instead.
+
+        This is what caught `verbosity` on the Responses side, where `parse()`
+        accepted a parameter `create()` does not.
+        """
+        llm = _llm()
+        await llm._get_api_response(
+            [],
+            api_output_schema=Answer,
+            temperature=0.25,
+            max_tokens=256,
+            reasoning_effort="none",
+        )
+
+        kwargs = llm.client.chat.completions.create.await_args.kwargs  # type: ignore[attr-defined]
+        real = AsyncOpenAI(api_key="x").chat.completions.create
+        inspect.signature(real).bind(**kwargs)
+
+    @pytest.mark.asyncio
+    async def test_non_pydantic_schema_falls_back_to_parse(self) -> None:
+        """`str` and other non-model schemas keep the previous transport."""
+        llm = _llm()
+        await llm._get_api_response([], api_output_schema=str)
+
+        llm.client.beta.chat.completions.parse.assert_awaited_once()  # type: ignore[attr-defined]
+        llm.client.chat.completions.create.assert_not_awaited()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_non_strict_tool_is_still_rejected(self) -> None:
+        """
+        `.parse()` refuses a tool without `strict: true`; the create() route must
+        not quietly start accepting one.
+        """
+        llm = _llm()
+        loose_tool = {
+            "type": "function",
+            "function": {"name": "f", "parameters": {"type": "object"}},
+        }
+        with pytest.raises(ValueError, match="strict"):
+            await llm._get_api_response(
+                [], api_tools=[loose_tool], api_output_schema=Answer
+            )
+
+    @pytest.mark.asyncio
+    async def test_non_function_tool_is_still_rejected(self) -> None:
+        llm = _llm()
+        with pytest.raises(ValueError, match="function"):
+            await llm._get_api_response(
+                [], api_tools=[{"type": "custom"}], api_output_schema=Answer
+            )
+
+    @pytest.mark.asyncio
+    async def test_strict_tool_passes_through(self) -> None:
+        llm = _llm()
+        strict_tool = {
+            "type": "function",
+            "function": {
+                "name": "f",
+                "strict": True,
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": False,
+                },
+            },
+        }
+        await llm._get_api_response(
+            [], api_tools=[strict_tool], api_output_schema=Answer
+        )
+
+        assert llm.client.chat.completions.create.await_args.kwargs["tools"] == [  # type: ignore[attr-defined]
+            strict_tool
+        ]
+
+    @pytest.mark.asyncio
+    async def test_model_level_settings_survive_end_to_end(self) -> None:
+        """
+        Driven through `_generate_response_once`, because that is where
+        `llm_settings` is merged and forwarded — `_get_api_response` only ever
+        sees settings as keyword arguments.
+        """
+        llm = _llm(llm_settings={"temperature": 0.25})
+        await llm._generate_response_once([], output_schema=Answer)
+
+        kwargs = llm.client.chat.completions.create.await_args.kwargs  # type: ignore[attr-defined]
+        assert kwargs["temperature"] == pytest.approx(0.25)
+        assert kwargs["response_format"]["json_schema"]["strict"] is True
+
+
+class TestTransportUnchangedWhenNotTolerating:
+    """
+    With `tolerate_output_around_json` off — the default — a model must run the
+    exact code path it ran before the flag existed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_uses_parse(self) -> None:
+        llm = _llm(tolerate=False)
+        await llm._get_api_response([], api_output_schema=Answer)
+
+        llm.client.beta.chat.completions.parse.assert_awaited_once()  # type: ignore[attr-defined]
+        llm.client.chat.completions.create.assert_not_awaited()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_schema_still_reaches_the_provider(self) -> None:
+        """Enforcement is not what the flag gates — only the transport is."""
+        llm = _llm(tolerate=False)
+        await llm._get_api_response([], api_output_schema=Answer)
+
+        kwargs = llm.client.beta.chat.completions.parse.await_args.kwargs  # type: ignore[attr-defined]
+        assert kwargs["response_format"] is Answer
+
+    @pytest.mark.asyncio
+    async def test_default_is_not_tolerating(self) -> None:
+        llm = OpenAILLM(
+            model_name="m",
+            api_provider={"name": "x", "base_url": "https://x", "api_key": "k"},
+        )
+        assert llm.tolerate_output_around_json is False
+
+    @pytest.mark.asyncio
+    async def test_gate_off_sends_no_schema(self) -> None:
+        llm = OpenAILLM(
+            model_name="m",
+            api_provider={"name": "x", "base_url": "https://x", "api_key": "k"},
+            apply_output_schema_via_provider=False,
+        )
+        object.__setattr__(llm.client, "chat", AsyncMock())
+        llm.client.chat.completions.create.return_value = _completion()  # type: ignore[attr-defined]
+
+        await llm._get_api_response([], api_output_schema=Answer)
+
+        kwargs = llm.client.chat.completions.create.await_args.kwargs  # type: ignore[attr-defined]
+        assert "response_format" not in kwargs

--- a/tests/openai_responses/test_output_schema_transport.py
+++ b/tests/openai_responses/test_output_schema_transport.py
@@ -29,6 +29,9 @@ class Answer(BaseModel):
 def _empty_response() -> OpenAIResponse:
     return OpenAIResponse.model_construct(
         id="resp_1",
+        created_at=0.0,
+        object="response",
+        status="completed",
         model="m",
         output=[],
         parallel_tool_calls=False,
@@ -72,12 +75,28 @@ class TestOutputSchemaTransport:
         assert set(fmt["schema"]["required"]) == {"capital", "population_millions"}
 
     @pytest.mark.asyncio
-    async def test_existing_text_settings_are_preserved(self) -> None:
-        """A model configured with `text.verbosity` must keep it."""
-        llm = _llm(llm_settings={"text": {"verbosity": "medium"}})
+    async def test_caller_text_settings_are_merged_not_replaced(self) -> None:
+        """`format` is added to the caller's `text`, not swapped in for it."""
+        llm = _llm()
         await llm._get_api_response(
             [], api_output_schema=Answer, text={"verbosity": "medium"}
         )
+
+        text = llm.client.responses.create.await_args.kwargs["text"]  # type: ignore[attr-defined]
+        assert text["verbosity"] == "medium"
+        assert text["format"]["strict"] is True
+
+    @pytest.mark.asyncio
+    async def test_model_level_text_settings_survive_end_to_end(self) -> None:
+        """
+        A model configured with `text.verbosity` keeps it.
+
+        Driven through `_generate_response_once`, because that is where
+        `llm_settings` is merged and forwarded — `_get_api_response` only ever
+        sees settings as keyword arguments.
+        """
+        llm = _llm(llm_settings={"text": {"verbosity": "medium"}})
+        await llm._generate_response_once([], output_schema=Answer)
 
         text = llm.client.responses.create.await_args.kwargs["text"]  # type: ignore[attr-defined]
         assert text["verbosity"] == "medium"

--- a/tests/openai_responses/test_output_schema_transport.py
+++ b/tests/openai_responses/test_output_schema_transport.py
@@ -40,11 +40,12 @@ def _empty_response() -> OpenAIResponse:
     )
 
 
-def _llm(**kwargs: Any) -> OpenAIResponsesLLM:
+def _llm(*, tolerate: bool = True, **kwargs: Any) -> OpenAIResponsesLLM:
     llm = OpenAIResponsesLLM(
         model_name="google.gemma-4-31b",
         api_provider={"name": "x", "base_url": "https://x/openai/v1", "api_key": "k"},
         apply_output_schema_via_provider=True,
+        tolerate_output_around_json=tolerate,
         **kwargs,
     )
     object.__setattr__(llm.client, "responses", AsyncMock())
@@ -110,6 +111,48 @@ class TestOutputSchemaTransport:
 
         llm.client.responses.parse.assert_awaited_once()  # type: ignore[attr-defined]
         llm.client.responses.create.assert_not_awaited()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_caller_supplied_format_is_not_silently_replaced(self) -> None:
+        """`.parse()` raises on this; the create() route must not differ."""
+        llm = _llm()
+        with pytest.raises(TypeError, match="Cannot mix and match"):
+            await llm._get_api_response(
+                [],
+                api_output_schema=Answer,
+                text={"format": {"type": "json_object"}},
+            )
+
+
+class TestTransportUnchangedWhenNotTolerating:
+    """
+    With `tolerate_output_around_json` off — the default — a model must run the
+    exact code path it ran before the flag existed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_uses_parse(self) -> None:
+        llm = _llm(tolerate=False)
+        await llm._get_api_response([], api_output_schema=Answer)
+
+        llm.client.responses.parse.assert_awaited_once()  # type: ignore[attr-defined]
+        llm.client.responses.create.assert_not_awaited()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_schema_still_reaches_the_provider(self) -> None:
+        """Enforcement is not what the flag gates — only the transport is."""
+        llm = _llm(tolerate=False)
+        await llm._get_api_response([], api_output_schema=Answer)
+
+        assert llm.client.responses.parse.await_args.kwargs["text_format"] is Answer  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_default_is_not_tolerating(self) -> None:
+        llm = OpenAIResponsesLLM(
+            model_name="m",
+            api_provider={"name": "x", "base_url": "https://x", "api_key": "k"},
+        )
+        assert llm.tolerate_output_around_json is False
 
     @pytest.mark.asyncio
     async def test_gate_off_sends_no_schema(self) -> None:

--- a/tests/openai_responses/test_output_schema_transport.py
+++ b/tests/openai_responses/test_output_schema_transport.py
@@ -1,0 +1,107 @@
+"""
+How an output schema reaches the Responses API.
+
+`apply_output_schema_via_provider` must send a *strict* json_schema so the
+provider constrains generation, while leaving the parsing of the reply to
+`LLM._validate_response`. Routing it through `responses.parse()` would do both,
+and its parse rejects a reply whose JSON value is followed by extra bytes —
+which some providers emit (Bedrock's decoder appends a redundant `}` for
+certain models), turning a schema-valid response into a wasted re-sample.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from openai.types.responses import Response as OpenAIResponse
+from pydantic import BaseModel
+
+from grasp_agents.llm_providers.openai_responses.responses_llm import (
+    OpenAIResponsesLLM,
+)
+
+
+class Answer(BaseModel):
+    capital: str
+    population_millions: int
+
+
+def _empty_response() -> OpenAIResponse:
+    return OpenAIResponse.model_construct(
+        id="resp_1",
+        model="m",
+        output=[],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        tools=[],
+    )
+
+
+def _llm(**kwargs: Any) -> OpenAIResponsesLLM:
+    llm = OpenAIResponsesLLM(
+        model_name="google.gemma-4-31b",
+        api_provider={"name": "x", "base_url": "https://x/openai/v1", "api_key": "k"},
+        apply_output_schema_via_provider=True,
+        **kwargs,
+    )
+    object.__setattr__(llm.client, "responses", AsyncMock())
+    llm.client.responses.create.return_value = _empty_response()  # type: ignore[attr-defined]
+    llm.client.responses.parse.return_value = _empty_response()  # type: ignore[attr-defined]
+    return llm
+
+
+class TestOutputSchemaTransport:
+    @pytest.mark.asyncio
+    async def test_uses_create_not_parse(self) -> None:
+        llm = _llm()
+        await llm._get_api_response([], api_output_schema=Answer)
+
+        llm.client.responses.create.assert_awaited_once()  # type: ignore[attr-defined]
+        llm.client.responses.parse.assert_not_awaited()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_schema_is_sent_strict(self) -> None:
+        llm = _llm()
+        await llm._get_api_response([], api_output_schema=Answer)
+
+        fmt = llm.client.responses.create.await_args.kwargs["text"]["format"]  # type: ignore[attr-defined]
+        assert fmt["type"] == "json_schema"
+        assert fmt["strict"] is True
+        # Strict mode's own requirements, so enforcement is not silently weakened.
+        assert fmt["schema"]["additionalProperties"] is False
+        assert set(fmt["schema"]["required"]) == {"capital", "population_millions"}
+
+    @pytest.mark.asyncio
+    async def test_existing_text_settings_are_preserved(self) -> None:
+        """A model configured with `text.verbosity` must keep it."""
+        llm = _llm(llm_settings={"text": {"verbosity": "medium"}})
+        await llm._get_api_response(
+            [], api_output_schema=Answer, text={"verbosity": "medium"}
+        )
+
+        text = llm.client.responses.create.await_args.kwargs["text"]  # type: ignore[attr-defined]
+        assert text["verbosity"] == "medium"
+        assert text["format"]["strict"] is True
+
+    @pytest.mark.asyncio
+    async def test_non_pydantic_schema_falls_back_to_parse(self) -> None:
+        """`str` and other non-model schemas keep the previous transport."""
+        llm = _llm()
+        await llm._get_api_response([], api_output_schema=str)
+
+        llm.client.responses.parse.assert_awaited_once()  # type: ignore[attr-defined]
+        llm.client.responses.create.assert_not_awaited()  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_gate_off_sends_no_schema(self) -> None:
+        llm = OpenAIResponsesLLM(
+            model_name="m",
+            api_provider={"name": "x", "base_url": "https://x", "api_key": "k"},
+            apply_output_schema_via_provider=False,
+        )
+        object.__setattr__(llm.client, "responses", AsyncMock())
+        llm.client.responses.create.return_value = _empty_response()  # type: ignore[attr-defined]
+
+        await llm._get_api_response([], api_output_schema=Answer)
+
+        assert "text" not in llm.client.responses.create.await_args.kwargs  # type: ignore[attr-defined]

--- a/tests/openai_responses/test_output_schema_transport.py
+++ b/tests/openai_responses/test_output_schema_transport.py
@@ -5,8 +5,8 @@ How an output schema reaches the Responses API.
 provider constrains generation, while leaving the parsing of the reply to
 `LLM._validate_response`. Routing it through `responses.parse()` would do both,
 and its parse rejects a reply whose JSON value is followed by extra bytes —
-which some providers emit (Bedrock's decoder appends a redundant `}` for
-certain models), turning a schema-valid response into a wasted re-sample.
+which some providers emit, because a schema constrains the value but not the
+stopping, turning a schema-valid response into a wasted re-sample.
 """
 
 from typing import Any

--- a/tests/openai_responses/test_output_schema_transport.py
+++ b/tests/openai_responses/test_output_schema_transport.py
@@ -88,6 +88,59 @@ class TestOutputSchemaTransport:
         assert text["format"]["strict"] is True
 
     @pytest.mark.asyncio
+    async def test_top_level_verbosity_is_relocated_not_dropped(self) -> None:
+        """
+        `create()` rejects a top-level `verbosity`; only `parse()` accepts it.
+
+        Forwarding it unchanged would raise `TypeError` for any model that sets
+        it, so it has to move under `text`, where the API reads it from.
+        """
+        llm = _llm()
+        await llm._get_api_response([], api_output_schema=Answer, verbosity="medium")
+
+        kwargs = llm.client.responses.create.await_args.kwargs  # type: ignore[attr-defined]
+        assert "verbosity" not in kwargs, "would be a TypeError against the real SDK"
+        assert kwargs["text"]["verbosity"] == "medium"
+
+    @pytest.mark.asyncio
+    async def test_explicit_text_verbosity_wins_over_top_level(self) -> None:
+        llm = _llm()
+        await llm._get_api_response(
+            [], api_output_schema=Answer, verbosity="low", text={"verbosity": "high"}
+        )
+
+        assert llm.client.responses.create.await_args.kwargs["text"]["verbosity"] == (  # type: ignore[attr-defined]
+            "high"
+        )
+
+    @pytest.mark.asyncio
+    async def test_forwarded_kwargs_are_all_accepted_by_the_real_create(self) -> None:
+        """
+        Guards the whole switch, not just `verbosity`.
+
+        The mocked client accepts anything, so a kwarg the real SDK rejects
+        would pass every other test here and fail in production. Bind the
+        captured call against the genuine signature instead.
+        """
+        import inspect
+
+        from openai import AsyncOpenAI
+
+        llm = _llm()
+        await llm._get_api_response(
+            [],
+            api_output_schema=Answer,
+            verbosity="medium",
+            reasoning={"effort": "none"},
+            max_output_tokens=256,
+            store=False,
+        )
+
+        kwargs = llm.client.responses.create.await_args.kwargs  # type: ignore[attr-defined]
+        real = AsyncOpenAI(api_key="x").responses.create
+        inspect.signature(real).bind(**kwargs)
+
+    @pytest.mark.asyncio
     async def test_model_level_text_settings_survive_end_to_end(self) -> None:
         """
         A model configured with `text.verbosity` keeps it.


### PR DESCRIPTION
## The problem

Investigated from validation-retry warnings on the lesson text summarizer (`google.gemma-4-31b` on the bedrock-mantle endpoint). Traces showed:

```
ValidationError: 1 validation error for TextResourceSummarySchema
Invalid JSON: trailing characters at line 1 column 3108
input_value='{"overview":"This resour..."end_chunk_idx":201}]}}'
```

Count the closers: the schema needs `}` `]` `}`. The response has `}]}}` — **one extra closing brace** after a complete, fully schema-valid object.

Confirmed against the live endpoint. Structured output works: Bedrock enforces the schema and returns conforming JSON. Its grammar-constrained decoding just doesn't always stop once the object is closed. Rate is low single digits — 40/40 clean in controlled batches, and it would not reproduce on demand. The same pathology is visible in the open on `google.gemma-3-27b-it`, which emits a valid opening object and then loops whitespace to the token ceiling.

So a re-sample was being spent on output that was already correct.

## What changed

**`tolerate_output_around_json: bool = False` on `LLM`** — opt in per model. Four things move together behind it:

1. **Validation** (`llm.py`) tries strict first and, only on failure, revalidates against the leading JSON value via the existing `from_substring=True` path, logging the recovery.
2. **Transport** (`responses_llm.py`) stops routing schemas through `responses.parse()`, which performs the same strict parse itself and would raise before validation could recover. It sends the **identical strict json_schema** through `create()` instead.
3. **The agent's output parse** (`llm_agent.py`) tracks the same flag. It had `from_substring=False` hardcoded, so a tolerating model passed validation and then failed here — and since an agent defaults to `max_retries=0`, that is a *failed run* where the strict path merely re-sampled and usually recovered. Tolerance that stops halfway is worse than none.
4. **Top-level `verbosity` is relocated** on the `create()` route — see below.

With the flag off — the default — a model runs the same method, the same parses and the same errors as before this branch. The entire diff is inert until someone opts in.

## Why opt-in rather than library-wide

Leniency accepts the **first** valid JSON value in the output. Measured on real payloads:

| Case | Strict | Lenient |
|---|---|---|
| Missing field | reject | **reject** |
| Wrong type | reject | **reject** |
| Truncated object | reject | **reject** |
| No JSON at all | reject | **reject** |
| One stray `}` | reject | accept ✅ intended |
| Prose around the object | reject | accept |
| **Two objects, first one wrong** | reject | **accepts the first** ⚠️ |
| **Decoy object in a preamble** | reject | **accepts the decoy** ⚠️ |

Field-level validation is untouched — nothing malformed slips through. But a model that narrates a draft before its answer would have the draft accepted rather than re-sampled. That has no business applying to every model in a library every service depends on. The last two rows are pinned as tests in `TestSchemaValidationStrictByDefault`.

This also follows the existing shape of the library: `apply_output_schema_via_provider` and `apply_tool_call_schema_via_provider` are already per-LLM booleans that exist because providers differ.

## `parse()` vs `create()` — the full diff

Derived mechanically (AST over `openai==2.47.0`, filtering `@overload` stubs — `inspect.getsource` returns the stub for `create()` and makes the two look identical):

| # | Difference | `parse()` | `create()` |
|---|---|---|---|
| 1 | Params accepted | `+ text_format`, `+ verbosity` | — |
| 2 | Request body keys | 32 | 31 |
| 3 | Request options | `+ post_parser` | — |
| 4 | `cast_to` | `ParsedResponse[TextFormatT]` | `Response` |
| 5 | `_type_to_text_format_param` | called | not called |
| 6 | `_make_tools`, `parse_response`, `copy` | called | not called |

- **1, 2, 5** — this PR reimplements the `text.format` construction by hand from the same helpers, including the mixed-format `TypeError` guard, and copies the caller's `text` rather than mutating it.
- **`verbosity`** was the one genuine loss: `create()` has no such parameter, so forwarding the settings bag unchanged raised `TypeError` for any model that set it — and `OpenAIResponsesLLMSettings` declares it (`responses_llm.py:120`). Of the 25 declared settings it is the only one `create()` rejects. It now moves to `text.verbosity`, where `ResponseTextConfigParam` declares it; an explicit `text.verbosity` still wins.
- **3, 4, 6 (`post_parser` / `parse_response`)** — the reply-checking half. Dropping it is the intent. Nothing in `src/` or `tests/` reads `output_parsed`, and `_convert_api_response` already accepts `ParsedResponse[Any] | Response`.
- **`_make_tools`** only rewrites Chat-Completions-shaped tools (nested `"function"` key). Verified it is the identity function on real `to_api_tool` output at both `strict=True` and `strict=False`.

Live check: `create()` with `strict: true` returned 3/3 conforming.

## Tests

TDD, red first at each step, and each fix verified to genuinely fail without its change (via `git stash`).

- `tests/llm/test_llm_validation.py` — trailing brace validates without a retry; the recovery is logged; prose/fenced output recovers; **malformed output still re-samples**; **a truncated object still raises**. Plus `TestSchemaValidationStrictByDefault`: with the flag off the stray brace still costs a retry, the decoy is still rejected, the default is strict.
- `tests/openai_responses/test_output_schema_transport.py` — `create()` not `parse()`; schema sent strict with strict-mode's own requirements; caller `text` merged; model-level `llm_settings` `text` survives end to end; top-level `verbosity` relocated; explicit `text.verbosity` wins; non-pydantic schemas fall back to `parse()`; caller `text.format` raises; and `TestTransportUnchangedWhenNotTolerating`.
- `tests/agent/test_output_parse_tolerance.py` — a tolerating LLM's agent parses the stray brace; a strict one still rejects it; clean output parses either way; tolerance never accepts a missing field.

**One test earns a special mention.** The suite mocks `client.responses` with an `AsyncMock`, and **a mock accepts any keyword argument** — so the `verbosity` bug passed every assertion while being a call the real SDK refuses. `test_forwarded_kwargs_are_all_accepted_by_the_real_create` now binds the captured call against the genuine `AsyncOpenAI.responses.create` signature, so any kwarg the SDK would reject fails here rather than in production.

```
full suite (excl. integration)   2789 passed, 21 skipped, 0 failed
pyright <5 changed files>           0 errors
ruff                                clean
```

`tests/sandbox/test_local_exec.py::test_cpu_timeout_kills_busy_loop` is deselected — fails on a clean tree (verified via `git stash`), unrelated, environment-dependent CPU-timeout signal assertion. The remaining `ASYNC119` in `responses_llm.py` is pre-existing and only shifted line number.

## Known gaps — deliberately not fixed here

Reviewed the change against its own neighbours and found three places where the flag does not reach. None is a regression; all are "the flag silently does less than its name suggests".

1. **The flag is honored on 1 of 4 transports.** Responses-streaming (`.stream(text_format=)`), Completions-non-streaming (`beta.chat.completions.parse()`, `completions_llm.py:251`) and Completions-streaming all still pre-parse strictly, so setting the flag there changes nothing and says nothing. The flag lives on the `LLM` base, so it looks universal. Worth either extending to Completions or making it complain when set where it cannot work — note the consumer config has a commented-out `OpenAICompletionsModelConfig` for this very model.
2. **Tool-call arguments are asymmetric.** `_validate_tool_calls` is tolerant, but `agent_loop._convert_tool_input:399` still parses with `from_substring=False, strip_language_markdown=False`. Verified: validation passes, execution fails. Severity limited — `agent_loop.py:708` turns it into a tool_result the model can react to, and no tool-using model opts in today. Either thread the flag through, or drop the tool-call half (the observed defect was on output).
3. **Dataclass-like schemas** fall back to `parse()`, since the branch guards on `issubclass(..., BaseModel)` while the SDK also supports dataclasses via `TypeAdapter`. Silent no-op, narrower.

## Notes for the reviewer

- `to_strict_json_schema` comes from `openai.lib._pydantic`, matching the existing precedent in this package (`openai_responses/tool_converters.py:5`).
- **Not addressed:** validation errors still bypass the `FallbackLLM` cascade (`fallback_llm.py:174` catches only `LlmErrorTuple`). Checked and *cleared* a related worry: `FallbackLLM` overrides `_validate_response` and `_validate_tool_calls` as documented no-ops, so members validate with their own flag and a Gemma→Gemini chain behaves correctly.
- Two cosmetic things left alone: `_validate_json_tolerating_surrounding_content` now overclaims its name (it only tolerates when the flag is set), and the strict call appears twice where one `try` would do.
- **Consumer side:** enabling this for `google.gemma-4-31b` needs a `grasp-core` change threading the flag through `build_llm` from `ModelConfig`. Written and tested, but blocked on a release of this branch — pyright there resolves against the published `grasp_agents`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R22Eh5KPDZ5YUiSwDxGjK9