### PR TITLE
Fix content filter handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grasp_agents"
-version = "1.0.27"
+version = "1.0.28"
 description = "Grasp Agents Library"
 readme = "README.md"
 requires-python = ">=3.12,<4"

--- a/src/grasp_agents/agent/agent_loop.py
+++ b/src/grasp_agents/agent/agent_loop.py
@@ -1566,6 +1566,13 @@ class AgentLoop[CtxT]:
             assert act.response is not None
             response = act.response
 
+            if not response.output:
+                logger.warning(
+                    "agent '%s' turn %d: LLM returned no output items",
+                    self.agent_name,
+                    self.turn,
+                )
+
             # ── JUDGE: classify next transition ──
 
             step = self._decide_next_step(response, exec_id=exec_id)

--- a/src/grasp_agents/agent/agent_loop.py
+++ b/src/grasp_agents/agent/agent_loop.py
@@ -401,7 +401,7 @@ class AgentLoop[CtxT]:
             call.arguments,
             schema=tool.llm_in_type,
             from_substring=False,
-            strip_language_markdown=False,
+            strip_language_markdown=True,
         )
         converter = self.tool_input_converters.get(tool.name)
 

--- a/src/grasp_agents/llm/llm.py
+++ b/src/grasp_agents/llm/llm.py
@@ -21,14 +21,14 @@ from grasp_agents.types.errors import (
     LLMToolCallValidationError,
 )
 from grasp_agents.types.items import InputItem
-from grasp_agents.types.llm_errors import LlmErrorTuple
+from grasp_agents.types.llm_errors import LlmContentFilterError, LlmErrorTuple
 from grasp_agents.types.llm_events import (
     LlmEvent,
     ResponseCompleted,
     ResponseIncomplete,
     ResponseRetrying,
 )
-from grasp_agents.types.response import Response
+from grasp_agents.types.response import REFUSAL_CATEGORY_KEY, Response
 from grasp_agents.utils.validation import validate_obj_from_json_or_py_string
 
 from .model_info import ModelCapabilities, get_model_capabilities
@@ -269,8 +269,9 @@ class LLM(ABC):
                     if isinstance(event, (ResponseCompleted, ResponseIncomplete)):
                         # Incomplete responses validate exactly like the
                         # non-streaming path (which returns them as response
-                        # objects): a refusal / content filter logs a warning;
-                        # a truncated response reaches the caller.
+                        # objects): a content filter raises, a written refusal
+                        # logs a warning, a truncated response reaches the
+                        # caller.
                         self._validate_response(
                             event.response, tools=tools, output_schema=output_schema
                         )
@@ -295,35 +296,58 @@ class LLM(ABC):
 
     # --- Validation ---
 
+    def _check_content_filter(self, response: Response) -> None:
+        """
+        Raise when the provider blocked this response on policy grounds.
+
+        Every provider normalizes such a block to
+        ``incomplete_details.reason == "content_filter"``, and every one
+        of them directs callers to discard whatever partial output
+        preceded it — so there is nothing for the agent to act on.
+        Returning it would stall the loop on a turn that adds nothing to
+        the transcript, or fail schema validation with an error that
+        blames the model for empty output. Raising skips retries (the
+        same request is blocked again) while still advancing a
+        ``FallbackLLM`` to the next model, which is the recovery
+        providers recommend.
+
+        A refusal the model *wrote* is different, and is not raised on:
+        it carries text the agent can read and correct course from. See
+        :meth:`_warn_refusal`.
+        """
+        details = response.incomplete_details
+        if details is None or details.reason != "content_filter":
+            return
+
+        raw_category = (response.provider_specific_fields or {}).get(
+            REFUSAL_CATEGORY_KEY
+        )
+        category = str(raw_category) if raw_category else None
+        named = f" ({category})" if category else ""
+        explanation = response.refusal or "no explanation given"
+        raise LlmContentFilterError(
+            f"llm {self.model_name}: content filter blocked this response"
+            f"{named}: {explanation}",
+            code=category,
+        )
+
     def _warn_refusal(self, response: Response) -> None:
         """
-        Log a warning when the response is a refusal or was blocked by the
-        provider's content filter.
+        Log a warning when the model declined to answer in its own words.
 
-        Reads the normalized signal both providers populate: an explicit
-        ``refusal`` content part (OpenAI / LiteLLM) or
-        ``incomplete_details.reason == "content_filter"`` (Anthropic maps
-        its ``stop_reason == "refusal"`` to this). Deliberately not an
-        error: the refusal flows into the transcript, so the agent — and
-        the caller — can see it and correct course. Structured-output
-        calls still fail schema validation on the refusal text and
-        re-sample via ``validation_retries``.
+        Deliberately not an error: the refusal text flows into the
+        transcript, so the agent — and the caller — can see it and
+        correct course. Structured-output calls still fail schema
+        validation on the refusal text and re-sample via
+        ``validation_retries``.
         """
         refusal = response.refusal
-        reason = (
-            response.incomplete_details.reason
-            if response.incomplete_details is not None
-            else None
-        )
-        if refusal or reason == "content_filter":
+        if refusal:
             logger.warning(
-                "llm %s: response is a refusal (status=%s, reason=%s): %s",
+                "llm %s: response is a refusal (status=%s): %s",
                 self.model_name,
                 response.status,
-                reason,
-                grasp_logging.body_for_log(
-                    refusal or "", full=grasp_logging.LOG_LLM_OUTPUT
-                ),
+                grasp_logging.body_for_log(refusal, full=grasp_logging.LOG_LLM_OUTPUT),
             )
 
     def _validate_response(
@@ -333,6 +357,9 @@ class LLM(ABC):
         tools: Mapping[str, BaseTool[BaseModel, Any, Any]] | None = None,
         output_schema: Any | None = None,
     ) -> None:
+        # Before any other check: a blocked response has no output to
+        # validate, and a schema failure here would misreport the cause.
+        self._check_content_filter(response)
         self._warn_refusal(response)
 
         if tools is not None:

--- a/src/grasp_agents/llm_providers/_http_helpers.py
+++ b/src/grasp_agents/llm_providers/_http_helpers.py
@@ -21,6 +21,27 @@ _QUOTA_PHRASES = (
     "credit balance is too low",
 )
 
+# Error-body codes that mean "blocked on policy grounds", as opposed to the
+# same words appearing as a finish reason. ``invalid_prompt`` and
+# ``content_policy_violation`` are OpenAI's; ``content_filter`` is what Azure
+# OpenAI returns for a content-management-policy block.
+_CONTENT_FILTER_CODES = frozenset(
+    {
+        "content_filter",
+        "content_policy_violation",
+        "invalid_prompt",
+    }
+)
+_CONTENT_FILTER_PHRASES = (
+    "content filter",
+    "content policy",
+    "content management policy",
+    "usage policy",
+    "was flagged",
+    "safety system",
+    "responsible ai",
+)
+
 
 def parse_retry_after(response: httpx.Response) -> float | None:
     """
@@ -68,3 +89,30 @@ def is_quota_error(err: openai.APIError) -> bool:
     if err.code in _QUOTA_CODES or err.type in _QUOTA_CODES:
         return True
     return is_quota_message(str(err))
+
+
+def is_content_filter_message(text: str) -> bool:
+    """
+    Detect a content-policy block from an error message.
+
+    The wording is not stable — it varies with the policy category that
+    fired — so this matches the phrases the variants share. Needed
+    because the same block reaches us with no structured marker on
+    several paths: a mid-stream error frame, a gateway that rewrites the
+    body, or an SDK that exposes only the message.
+    """
+    lowered = text.lower()
+    return any(phrase in lowered for phrase in _CONTENT_FILTER_PHRASES)
+
+
+def content_filter_code(err: openai.APIError) -> str | None:
+    """
+    The error's own content-filter marker, or ``None`` if it carries none.
+
+    ``code`` and ``type`` are both checked — a mid-stream error frame
+    populates only one of them, depending on the provider.
+    """
+    for marker in (err.code, err.type):
+        if marker in _CONTENT_FILTER_CODES:
+            return marker
+    return None

--- a/src/grasp_agents/llm_providers/anthropic/error_mapping.py
+++ b/src/grasp_agents/llm_providers/anthropic/error_mapping.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import anthropic
 
-from grasp_agents.llm_providers._http_helpers import is_quota_message, parse_retry_after
+from grasp_agents.llm_providers._http_helpers import (
+    is_content_filter_message,
+    is_quota_message,
+    parse_retry_after,
+)
 from grasp_agents.types.llm_errors import (
     LlmApiConnectionError,
     LlmApiError,
@@ -12,6 +16,7 @@ from grasp_agents.types.llm_errors import (
     LlmApiTimeoutError,
     LlmAuthenticationError,
     LlmBadRequestError,
+    LlmContentFilterError,
     LlmContextWindowError,
     LlmError,
     LlmInternalServerError,
@@ -35,6 +40,12 @@ def map_api_error(err: Exception) -> LlmError | None:
         # 429 — retrying will not clear it, so it must fail over instead.
         if is_quota_message(msg):
             return LlmQuotaExceededError(msg, response=resp, body=body)
+        # A prompt rejected up front comes back as a plain 400, which the
+        # BadRequest branch below would bury as a programmer bug. The
+        # classifier refusals that arrive as a normal 200 response are
+        # handled where the response is validated, not here.
+        if code in {400, 403} and is_content_filter_message(msg):
+            return LlmContentFilterError(msg)
         if code == 429:
             return LlmRateLimitError(
                 msg, response=resp, body=body, retry_after=parse_retry_after(resp)
@@ -54,6 +65,9 @@ def map_api_error(err: Exception) -> LlmError | None:
     if isinstance(err, anthropic.APIError):
         # No HTTP status — a response body the SDK could not validate, or an
         # error raised outside the status path. Must still reach the cascade.
-        return LlmApiError(str(err), err.request, body=err.body)
+        msg = str(err)
+        if is_content_filter_message(msg):
+            return LlmContentFilterError(msg)
+        return LlmApiError(msg, err.request, body=err.body)
 
     return None

--- a/src/grasp_agents/llm_providers/anthropic/llm_event_converters.py
+++ b/src/grasp_agents/llm_providers/anthropic/llm_event_converters.py
@@ -31,11 +31,12 @@ from grasp_agents.types.items import (
 )
 
 from . import AnthropicStreamEvent
-from .provider_output_to_response import convert_usage
+from .provider_output_to_response import convert_usage, refusal_fields, with_refusal
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from anthropic.types import RefusalStopDetails as AnthropicRefusalStopDetails
     from openai.types.responses import ResponseStatus
 
     from grasp_agents.types.llm_events import LlmEvent, ResponseCompleted
@@ -80,6 +81,8 @@ class AnthropicStreamConverter(BaseLlmStreamConverter[AnthropicStreamEvent]):
         self._server_tool_block_idx: dict[int, str] = {}
         # Accumulated citations for current text block
         self._citations: list[AnnotationUrlCitation] = []
+        # Structured reason for a classifier refusal (stop_reason="refusal")
+        self._stop_details: AnthropicRefusalStopDetails | None = None
 
     def _process_event(self, raw_event: AnthropicStreamEvent) -> Iterator[LlmEvent]:
         event_type = raw_event.type
@@ -249,6 +252,8 @@ class AnthropicStreamConverter(BaseLlmStreamConverter[AnthropicStreamEvent]):
         delta = event.delta
         if delta.stop_reason:
             self._finish_reason = delta.stop_reason
+        if delta.stop_details:
+            self._stop_details = delta.stop_details
 
         # Update usage with final output token count
         msg_usage: Any = event.usage
@@ -356,7 +361,22 @@ class AnthropicStreamConverter(BaseLlmStreamConverter[AnthropicStreamEvent]):
         return list(self._citations)
 
     def _build_response_completed(self) -> ResponseCompleted:
-        return super()._build_response_completed()
+        if self._finish_reason != "refusal":
+            return super()._build_response_completed()
+
+        # Recorded before the base snapshots the items: a refusal carries its
+        # reason only in ``stop_details``, and can land mid-stream, on the
+        # message it interrupted.
+        self._items = with_refusal(self._items, self._stop_details)
+        completed = super()._build_response_completed()
+
+        fields = refusal_fields(self._stop_details)
+        if fields is None:
+            return completed
+        response = completed.response.model_copy(
+            update={"provider_specific_fields": fields}
+        )
+        return completed.model_copy(update={"response": response})
 
     # ==== Hooks ====
 

--- a/src/grasp_agents/llm_providers/anthropic/provider_output_to_response.py
+++ b/src/grasp_agents/llm_providers/anthropic/provider_output_to_response.py
@@ -1,10 +1,12 @@
 """Convert Anthropic Message content blocks → internal item types."""
 
 import json
+from collections.abc import Sequence
 from typing import Any
 
 from anthropic.types import Message as AnthropicMessage
 from anthropic.types import RedactedThinkingBlock as AnthropicRedactedThinkingBlock
+from anthropic.types import RefusalStopDetails as AnthropicRefusalStopDetails
 from anthropic.types import ServerToolUseBlock as AnthropicServerToolUseBlock
 from anthropic.types import StopReason as AnthropicStopReason
 from anthropic.types import TextBlock as AnthropicTextBlock
@@ -29,6 +31,7 @@ from openai.types.responses.response import IncompleteDetails
 from grasp_agents.types.content import (
     Annotation,
     AnnotationUrlCitation,
+    OutputMessageRefusal,
     OutputMessageText,
     ReasoningSummary,
 )
@@ -43,10 +46,15 @@ from grasp_agents.types.items import (
     WebSearchCallItem,
 )
 from grasp_agents.types.response import (
+    REFUSAL_CATEGORY_KEY,
     InputTokensDetails,
     OutputTokensDetails,
     Response,
     ResponseUsage,
+)
+
+DEFAULT_REFUSAL_EXPLANATION = (
+    "A safety classifier declined this request; no explanation was given."
 )
 
 
@@ -308,6 +316,41 @@ def _map_stop_reason(
     return "completed", None
 
 
+def with_refusal(
+    items: Sequence[OutputItem], stop_details: AnthropicRefusalStopDetails | None
+) -> list[OutputItem]:
+    """
+    Record a classifier refusal as a refusal part on the turn's message.
+
+    A refusal arrives as an ordinary message whose reason lives only in
+    ``stop_details`` — and, when it fires before any output, with empty
+    ``content`` — so without this the response reads as a model that said
+    nothing. The part joins the message the classifier interrupted, and
+    marks it incomplete: one assistant message per turn, the same shape the
+    other providers produce for their own content filters.
+    """
+    explanation = (
+        stop_details.explanation if stop_details else None
+    ) or DEFAULT_REFUSAL_EXPLANATION
+    part = OutputMessageRefusal(refusal=explanation)
+
+    if items and isinstance(items[-1], OutputMessageItem):
+        interrupted = items[-1].model_copy(
+            update={"content": [*items[-1].content, part], "status": "incomplete"}
+        )
+        return [*items[:-1], interrupted]
+
+    return [*items, OutputMessageItem(status="incomplete", content=[part])]
+
+
+def refusal_fields(
+    stop_details: AnthropicRefusalStopDetails | None,
+) -> dict[str, Any] | None:
+    """Response-level fields naming the policy category, when there is one."""
+    category = stop_details.category if stop_details else None
+    return {REFUSAL_CATEGORY_KEY: category} if category else None
+
+
 def provider_output_to_response(provider_output: AnthropicMessage) -> Response:
     """Convert an Anthropic ``Message`` to a grasp-agents ``Response``."""
     # NOTE: ignored AnthropicMessage fields: `container`, `model``, `stop_sequence`
@@ -316,6 +359,11 @@ def provider_output_to_response(provider_output: AnthropicMessage) -> Response:
     usage = convert_usage(provider_output.usage)
     status, incomplete_details = _map_stop_reason(provider_output.stop_reason)
 
+    provider_specific_fields: dict[str, Any] | None = None
+    if provider_output.stop_reason == "refusal":
+        output_items = with_refusal(output_items, provider_output.stop_details)
+        provider_specific_fields = refusal_fields(provider_output.stop_details)
+
     return Response(
         id=provider_output.id,
         model=provider_output.model,
@@ -323,4 +371,5 @@ def provider_output_to_response(provider_output: AnthropicMessage) -> Response:
         incomplete_details=incomplete_details,
         output=output_items,
         usage=usage,
+        provider_specific_fields=provider_specific_fields,
     )

--- a/src/grasp_agents/llm_providers/gemini/error_mapping.py
+++ b/src/grasp_agents/llm_providers/gemini/error_mapping.py
@@ -7,13 +7,17 @@ from typing import Any, cast
 import httpx
 from google.genai import errors as genai_errors
 
-from grasp_agents.llm_providers._http_helpers import parse_retry_after
+from grasp_agents.llm_providers._http_helpers import (
+    is_content_filter_message,
+    parse_retry_after,
+)
 from grasp_agents.types.llm_errors import (
     LlmApiConnectionError,
     LlmApiStatusError,
     LlmApiTimeoutError,
     LlmAuthenticationError,
     LlmBadRequestError,
+    LlmContentFilterError,
     LlmError,
     LlmInternalServerError,
     LlmNotFoundError,
@@ -80,6 +84,11 @@ def map_api_error(err: Exception) -> LlmError | None:
     if code == 404:
         return LlmNotFoundError(msg, response=resp, body=None)
     if code == 400:
+        # A prompt rejected up front comes back as a plain 400; blocked
+        # *candidates* arrive as a normal 200 response and are handled where
+        # the response is validated, not here.
+        if is_content_filter_message(msg):
+            return LlmContentFilterError(msg)
         return LlmBadRequestError(msg, response=resp, body=None)
 
     return LlmApiStatusError(msg, response=resp, body=None)

--- a/src/grasp_agents/llm_providers/litellm/error_mapping.py
+++ b/src/grasp_agents/llm_providers/litellm/error_mapping.py
@@ -7,7 +7,12 @@ import httpx
 import litellm
 import openai
 
-from grasp_agents.llm_providers._http_helpers import is_quota_error, parse_retry_after
+from grasp_agents.llm_providers._http_helpers import (
+    content_filter_code,
+    is_content_filter_message,
+    is_quota_error,
+    parse_retry_after,
+)
 from grasp_agents.types.errors import CompletionError
 from grasp_agents.types.llm_errors import (
     LlmApiConnectionError,
@@ -67,7 +72,11 @@ def map_api_error(err: Exception) -> LlmError | None:
         )
 
     if isinstance(err, litellm.ContentPolicyViolationError):
-        return LlmContentFilterError()
+        # The code, if any, is whatever the upstream body carried: LiteLLM
+        # normalizes the exception type across providers but not the code,
+        # and stamping one here would attribute an OpenAI code to whichever
+        # provider actually blocked.
+        return LlmContentFilterError(msg, code=content_filter_code(err))
 
     if isinstance(err, litellm.AuthenticationError):
         return LlmAuthenticationError(msg, response=err.response, body=err.body)
@@ -84,6 +93,11 @@ def map_api_error(err: Exception) -> LlmError | None:
         return LlmContextWindowError(msg, response=err.response, body=err.body)
 
     if isinstance(err, litellm.BadRequestError):
+        # LiteLLM only raises ContentPolicyViolationError for the providers
+        # whose blocks it recognizes; the rest arrive as a plain bad request
+        # that the message alone identifies.
+        if is_content_filter_message(msg):
+            return LlmContentFilterError(msg, code=content_filter_code(err))
         return LlmBadRequestError(msg, response=err.response, body=err.body)
 
     if isinstance(err, litellm.exceptions.UnprocessableEntityError):
@@ -99,6 +113,9 @@ def map_api_error(err: Exception) -> LlmError | None:
         # Every litellm exception derives from the OpenAI SDK's, so this
         # catches the long tail (in-stream error frames, bodies the SDK
         # could not validate) that the branches above do not name.
+        cf_code = content_filter_code(err)
+        if cf_code or is_content_filter_message(msg):
+            return LlmContentFilterError(msg, code=cf_code)
         return LlmApiError(msg, err.request, body=err.body)
 
     return None

--- a/src/grasp_agents/llm_providers/openai_completions/error_mapping.py
+++ b/src/grasp_agents/llm_providers/openai_completions/error_mapping.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import httpx
 import openai
 
-from grasp_agents.llm_providers._http_helpers import is_quota_error, parse_retry_after
+from grasp_agents.llm_providers._http_helpers import (
+    content_filter_code,
+    is_content_filter_message,
+    is_quota_error,
+    parse_retry_after,
+)
 from grasp_agents.types.errors import CompletionError
 from grasp_agents.types.llm_errors import (
     LlmApiConnectionError,
@@ -43,7 +48,7 @@ def map_api_error(err: Exception) -> LlmError | None:
     # Finish-reason failures from the `.parse()` helper: not transport errors,
     # but they abort the call and so must still reach the fallback cascade.
     if isinstance(err, openai.ContentFilterFinishReasonError):
-        return LlmContentFilterError()
+        return LlmContentFilterError(str(err), code="content_filter")
 
     if isinstance(err, openai.LengthFinishReasonError):
         # Re-sampling the same model with the same cap repeats the
@@ -68,6 +73,15 @@ def map_api_error(err: Exception) -> LlmError | None:
         if is_quota_error(err):
             return LlmQuotaExceededError(msg, response=resp, body=body)
 
+        # Also before the status branches, and for the same reason: a policy
+        # block is rejected as a plain 400 (``invalid_prompt``), so the
+        # BadRequest branch below would bury it as a programmer bug. The
+        # message is only trusted on the codes a block can arrive under, so
+        # a rate limit that happens to quote a policy is not misread.
+        cf_code = content_filter_code(err)
+        if cf_code or (code in {400, 403, 422} and is_content_filter_message(msg)):
+            return LlmContentFilterError(msg, code=cf_code)
+
         if code == 429:
             return LlmRateLimitError(
                 msg, response=resp, body=body, retry_after=parse_retry_after(resp)
@@ -89,12 +103,17 @@ def map_api_error(err: Exception) -> LlmError | None:
 
     if isinstance(err, openai.APIError):
         # No HTTP status: an error frame inside a 200 SSE stream, or a
-        # response body the SDK could not validate. Quota exhaustion lands
-        # here on streamed calls, where the transport status is 200.
+        # response body the SDK could not validate. Quota exhaustion and
+        # content-policy blocks both land here on streamed calls, where the
+        # transport status is 200 and only the message identifies them.
+        msg = str(err)
         if is_quota_error(err):
             return LlmQuotaExceededError(
-                str(err), response=_synthetic_response(429), body=err.body
+                msg, response=_synthetic_response(429), body=err.body
             )
-        return LlmApiError(str(err), err.request, body=err.body)
+        cf_code = content_filter_code(err)
+        if cf_code or is_content_filter_message(msg):
+            return LlmContentFilterError(msg, code=cf_code)
+        return LlmApiError(msg, err.request, body=err.body)
 
     return None

--- a/src/grasp_agents/types/llm_errors.py
+++ b/src/grasp_agents/types/llm_errors.py
@@ -3,9 +3,32 @@ from typing import Literal
 import httpx
 import openai
 
+CONTENT_FILTER_DEFAULT_MESSAGE = "The provider's content filter blocked this request."
+
 
 class LlmContentFilterError(openai.ContentFilterFinishReasonError):
-    pass
+    """
+    The provider refused the request on policy grounds, or discarded the
+    output it had already produced.
+
+    Never retried — the same request on the same model is blocked again —
+    but it does advance a ``FallbackLLM``: another model is the recovery
+    both OpenAI and Anthropic recommend for a policy block.
+
+    ``code`` is the provider's own marker when it gave one: an error code
+    (``"invalid_prompt"``) or a policy category (``"cyber"``).
+    """
+
+    message: str
+    code: str | None
+
+    def __init__(self, message: str | None = None, *, code: str | None = None) -> None:
+        message = message or CONTENT_FILTER_DEFAULT_MESSAGE
+        # Bypasses the parent, whose __init__ hardcodes a fixed message, so
+        # the provider's own explanation reaches the caller.
+        openai.OpenAIError.__init__(self, message)
+        self.message = message
+        self.code = code
 
 
 class LlmApiError(openai.APIError):

--- a/src/grasp_agents/types/response.py
+++ b/src/grasp_agents/types/response.py
@@ -33,6 +33,15 @@ from .items import (
     prefixed_id,
 )
 
+REFUSAL_CATEGORY_KEY = "refusal_category"
+"""
+:attr:`Response.provider_specific_fields` key holding the policy category a
+provider's content filter named for a refusal (e.g. ``"cyber"``), if any.
+
+The refusal's human-readable explanation rides in the message's
+:class:`~grasp_agents.types.content.OutputMessageRefusal` part instead.
+"""
+
 
 class InputTokensDetails(_SDKInputTokensDetails):
     cached_tokens: int = 0

--- a/src/grasp_agents/utils/validation.py
+++ b/src/grasp_agents/utils/validation.py
@@ -16,6 +16,15 @@ logger = getLogger(__name__)
 
 _JSON_START_RE = re.compile(r"[{\[]")
 
+# A fence wrapping the *whole* payload — the shape a model produces when it
+# answers a JSON request with ```json ... ```. Anchored at both ends on
+# purpose: a fence anywhere else belongs to the content (a code block inside
+# a JSON string value), and stripping it there silently rewrites the answer.
+_WRAPPING_FENCE_RE = re.compile(
+    r"\A\s*```[a-zA-Z0-9]*[ \t]*\r?\n(?P<body>.*?)\r?\n?[ \t]*```\s*\Z",
+    re.DOTALL,
+)
+
 
 def extract_json_substring(text: str) -> str | None:
     decoder = json.JSONDecoder()
@@ -39,7 +48,8 @@ def parse_json_or_py_string(
     s_orig = s
 
     if strip_language_markdown:
-        s = re.sub(r"```[a-zA-Z0-9]*\n|```", "", s).strip()
+        match = _WRAPPING_FENCE_RE.match(s)
+        s = match.group("body").strip() if match else s.strip()
 
     if from_substring:
         s = extract_json_substring(s) or ""

--- a/src/grasp_agents/utils/validation.py
+++ b/src/grasp_agents/utils/validation.py
@@ -18,8 +18,8 @@ _JSON_START_RE = re.compile(r"[{\[]")
 
 # A fence wrapping the *whole* payload — the shape a model produces when it
 # answers a JSON request with ```json ... ```. Anchored at both ends on
-# purpose: a fence anywhere else belongs to the content (a code block inside
-# a JSON string value), and stripping it there silently rewrites the answer.
+# purpose: a fence mid-message belongs to the content (a code block inside a
+# JSON string value), and stripping it there silently rewrites the answer.
 _WRAPPING_FENCE_RE = re.compile(
     r"\A\s*```[a-zA-Z0-9]*[ \t]*\r?\n(?P<body>.*?)\r?\n?[ \t]*```\s*\Z",
     re.DOTALL,

--- a/tests/agent/test_agent_loop.py
+++ b/tests/agent/test_agent_loop.py
@@ -623,3 +623,25 @@ class TestTurnBoundaryEventPayloads:
         stop = [e for e in events if isinstance(e, TurnEndEvent)][-1]
         assert [o.call_id for o in stop.data.tool_outputs] == ["fa1"]
         assert "Final answer recorded." in stop.data.tool_outputs[0].text
+
+
+# ---------- Output-less turns ----------
+
+
+class TestEmptyResponse:
+    @pytest.mark.asyncio
+    async def test_empty_response_is_logged_and_the_loop_continues(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """
+        A response with no output items adds nothing to the transcript, so
+        the next turn re-sends the same request. That is invisible from the
+        outside — a log line is the only trace.
+        """
+        loop, _ = _make_loop([Response(model="mock"), _text_response("recovered")])
+
+        with caplog.at_level(logging.WARNING, logger="grasp_agents.agent.agent_loop"):
+            await _drain(loop)
+
+        assert loop.final_answer == "recovered"
+        assert any("no output items" in r.getMessage() for r in caplog.records)

--- a/tests/anthropic/test_converters.py
+++ b/tests/anthropic/test_converters.py
@@ -26,6 +26,7 @@ from anthropic.types import (
     RawMessageStartEvent,
     RawMessageStopEvent,
     RedactedThinkingBlock,
+    RefusalStopDetails,
     ServerToolUseBlock,
     SignatureDelta,
     StopReason,
@@ -92,6 +93,7 @@ from grasp_agents.types.llm_events import (
 from grasp_agents.types.llm_events import (
     OutputMessageTextPartTextDelta as LlmTextDelta,
 )
+from grasp_agents.types.response import Response
 
 # ==== Helpers ====
 
@@ -101,6 +103,7 @@ def _make_message(
     *,
     model: str = "claude-sonnet-4-20250514",
     stop_reason: StopReason = "end_turn",
+    stop_details: RefusalStopDetails | None = None,
     input_tokens: int = 100,
     output_tokens: int = 50,
 ) -> Message:
@@ -111,6 +114,7 @@ def _make_message(
         model=model,
         content=content,
         stop_reason=stop_reason,
+        stop_details=stop_details,
         stop_sequence=None,
         usage=Usage(input_tokens=input_tokens, output_tokens=output_tokens),
     )
@@ -292,6 +296,54 @@ class TestResponseConverters:
         assert response.status == "incomplete"
         assert response.incomplete_details is not None
         assert response.incomplete_details.reason == "max_output_tokens"
+
+
+_BLOCKED = RefusalStopDetails(
+    type="refusal",
+    category="cyber",
+    explanation="Blocked under Anthropic's Usage Policy.",
+)
+
+
+class TestRefusalConversion:
+    """
+    A classifier refusal arrives as a normal message with its reason only in
+    ``stop_details`` — and, before any output, with empty ``content``.
+    Without normalizing it, the response reads as a model that said nothing.
+    """
+
+    def test_refusal_carries_explanation_and_category(self):
+        msg = _make_message([], stop_reason="refusal", stop_details=_BLOCKED)
+        response = from_anthropic_message(msg)
+
+        assert response.incomplete_details is not None
+        assert response.incomplete_details.reason == "content_filter"
+        assert response.refusal == _BLOCKED.explanation
+        assert response.provider_specific_fields == {"refusal_category": "cyber"}
+
+    def test_refusal_without_details_still_carries_a_reason(self):
+        response = from_anthropic_message(_make_message([], stop_reason="refusal"))
+
+        assert response.refusal
+        assert response.provider_specific_fields is None
+
+    def test_mid_stream_refusal_joins_the_message_it_interrupted(self):
+        """
+        One assistant message per turn — text and refusal parts, marked
+        incomplete. The same shape the other providers produce.
+        """
+        msg = _make_message(
+            [TextBlock(type="text", text="Partial answer")],
+            stop_reason="refusal",
+            stop_details=_BLOCKED,
+        )
+        response = from_anthropic_message(msg)
+
+        assert len(response.message_items) == 1
+        item = response.message_items[0]
+        assert item.status == "incomplete"
+        assert item.text == "Partial answer"
+        assert item.refusal == _BLOCKED.explanation
 
 
 # ==== response_to_message ====
@@ -795,10 +847,11 @@ def _block_stop(idx: int) -> RawContentBlockStopEvent:
 def _msg_delta(
     stop_reason: StopReason = "end_turn",
     output_tokens: int = 20,
+    stop_details: RefusalStopDetails | None = None,
 ) -> RawMessageDeltaEvent:
     return RawMessageDeltaEvent(
         type="message_delta",
-        delta=MessageDelta(stop_reason=stop_reason),
+        delta=MessageDelta(stop_reason=stop_reason, stop_details=stop_details),
         usage=MessageDeltaUsage(output_tokens=output_tokens),
     )
 
@@ -810,6 +863,10 @@ def _msg_stop() -> RawMessageStopEvent:
 class TestAnthropicStreamConverter:
     def _run(self, events: list[Any]) -> list[Any]:
         return asyncio.run(_collect_events(events))
+
+    def _completed(self, llm_events: list[Any]) -> Response:
+        [completed] = [e for e in llm_events if isinstance(e, ResponseCompleted)]
+        return completed.response
 
     def test_text_stream(self):
         """Basic text streaming: message_start → text block → deltas → stop."""
@@ -1158,6 +1215,37 @@ class TestAnthropicStreamConverter:
         added_events = [e for e in llm_events if isinstance(e, OutputItemAdded)]
         output_indices = [e.output_index for e in added_events]
         assert output_indices == [0, 1, 2]
+
+    def test_refusal_before_any_output(self):
+        events = [
+            _msg_start_event(),
+            _msg_delta(stop_reason="refusal", stop_details=_BLOCKED),
+            _msg_stop(),
+        ]
+        response = self._completed(self._run(events))
+
+        assert response.incomplete_details is not None
+        assert response.incomplete_details.reason == "content_filter"
+        assert response.refusal == _BLOCKED.explanation
+        assert response.provider_specific_fields == {"refusal_category": "cyber"}
+
+    def test_mid_stream_refusal_joins_the_streamed_message(self):
+        events = [
+            _msg_start_event(),
+            _block_start(0, TextBlock(type="text", text="")),
+            _block_delta(0, TextDelta(type="text_delta", text="Partial answer")),
+            _block_stop(0),
+            _msg_delta(stop_reason="refusal", stop_details=_BLOCKED),
+            _msg_stop(),
+        ]
+        response = self._completed(self._run(events))
+
+        # Same single-message shape as the non-streaming converter.
+        assert len(response.message_items) == 1
+        item = response.message_items[0]
+        assert item.status == "incomplete"
+        assert item.text == "Partial answer"
+        assert item.refusal == _BLOCKED.explanation
 
 
 # ==== Web search: extraction + round-trip + streaming ====

--- a/tests/llm/test_llm_validation.py
+++ b/tests/llm/test_llm_validation.py
@@ -31,7 +31,10 @@ from grasp_agents.types.items import (
     InputMessageItem,
     OutputMessageItem,
 )
-from grasp_agents.types.llm_errors import LlmInternalServerError
+from grasp_agents.types.llm_errors import (
+    LlmContentFilterError,
+    LlmInternalServerError,
+)
 from grasp_agents.types.llm_events import (
     LlmEvent,
     OutputItemAdded,
@@ -40,7 +43,7 @@ from grasp_agents.types.llm_events import (
     ResponseCreated,
     ResponseRetrying,
 )
-from grasp_agents.types.response import Response
+from grasp_agents.types.response import REFUSAL_CATEGORY_KEY, Response
 
 # ---------- Mocks ----------
 
@@ -76,14 +79,20 @@ def _refusal_response(text: str = "I can't help with that.") -> Response:
     )
 
 
-def _content_filter_response() -> Response:
+def _content_filter_response(
+    explanation: str | None = None, category: str | None = None
+) -> Response:
+    content: list[Any] = [OutputMessageText(text="")]
+    if explanation is not None:
+        content = [OutputMessageRefusal(refusal=explanation)]
     return Response(
         model="mock",
         status="incomplete",
         incomplete_details=IncompleteDetails(reason="content_filter"),
-        output=[
-            OutputMessageItem(content=[OutputMessageText(text="")], status="incomplete")
-        ],
+        output=[OutputMessageItem(content=content, status="incomplete")],
+        provider_specific_fields=(
+            {REFUSAL_CATEGORY_KEY: category} if category else None
+        ),
     )
 
 
@@ -258,7 +267,10 @@ class TestValidationErrorTypes:
 
 
 class TestRefusalAndContentFilter:
-    """Refusals / content filters log a warning; the response flows through."""
+    """
+    A refusal the model wrote logs a warning and flows through; a content
+    filter that blocked the response raises instead.
+    """
 
     @pytest.mark.asyncio
     async def test_refusal_returns_response_and_warns(
@@ -271,15 +283,49 @@ class TestRefusalAndContentFilter:
         assert any("refusal" in r.getMessage() for r in caplog.records)
 
     @pytest.mark.asyncio
-    async def test_content_filter_returns_response_and_warns(
-        self, caplog: pytest.LogCaptureFixture
-    ):
+    async def test_content_filter_raises(self):
+        llm = MockLLM(
+            model_name="mock",
+            responses=[_content_filter_response("Blocked: cyber harm.", "cyber")],
+        )
+        with pytest.raises(LlmContentFilterError) as exc_info:
+            await llm.generate_response(_USER_MSG)
+        # The provider's own explanation and category reach the caller.
+        assert "Blocked: cyber harm." in str(exc_info.value)
+        assert exc_info.value.code == "cyber"
+
+    @pytest.mark.asyncio
+    async def test_content_filter_is_not_retried(self):
+        """The same request is blocked again — resampling only burns tokens."""
+        llm = MockLLM(
+            model_name="mock",
+            responses=[_content_filter_response(), _text_response("ok")],
+            retry_policy=RetryPolicy(api_retries=3, validation_retries=3),
+        )
+        with pytest.raises(LlmContentFilterError):
+            await llm.generate_response(_USER_MSG)
+        assert llm.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_content_filter_beats_schema_validation(self):
+        """
+        A blocked response has no output; reporting it as a schema mismatch
+        would blame the model for the filter's decision.
+        """
+
+        class M(BaseModel):
+            v: int
+
         llm = MockLLM(model_name="mock", responses=[_content_filter_response()])
-        with caplog.at_level(logging.WARNING, logger="grasp_agents.llm.llm"):
-            response = await llm.generate_response(_USER_MSG)
-        assert response.incomplete_details is not None
-        assert response.incomplete_details.reason == "content_filter"
-        assert any("content_filter" in r.getMessage() for r in caplog.records)
+        with pytest.raises(LlmContentFilterError):
+            await llm.generate_response(_USER_MSG, output_schema=M)
+
+    @pytest.mark.asyncio
+    async def test_content_filter_raises_when_streaming(self):
+        llm = MockLLM(model_name="mock", responses=[_content_filter_response()])
+        with pytest.raises(LlmContentFilterError):
+            async for _ in llm.generate_response_stream(_USER_MSG):
+                pass
 
     @pytest.mark.asyncio
     async def test_refusal_with_output_schema_is_resampled(self):

--- a/tests/llm/test_resilience.py
+++ b/tests/llm/test_resilience.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, patch
 import httpx
 import openai
 import pytest
+from openai.types.responses.response import IncompleteDetails
 from pydantic import BaseModel
 
 from grasp_agents.llm.cloud_llm import ApiCallParams, CloudLLM
@@ -27,7 +28,7 @@ from grasp_agents.llm_providers.openai_completions.error_mapping import (
     map_api_error as openai_map_api_error,
 )
 from grasp_agents.tools.base import BaseTool
-from grasp_agents.types.content import OutputMessageText
+from grasp_agents.types.content import OutputMessageRefusal, OutputMessageText
 from grasp_agents.types.errors import (
     LLMResponseValidationError,
     LLMToolCallValidationError,
@@ -35,6 +36,7 @@ from grasp_agents.types.errors import (
 from grasp_agents.types.items import InputItem, InputMessageItem, OutputMessageItem
 from grasp_agents.types.llm_errors import (
     LlmAuthenticationError,
+    LlmContentFilterError,
     LlmContextWindowError,
     LlmError,
     LlmInternalServerError,
@@ -71,6 +73,21 @@ def _text_response(text: str, model: str = "mock") -> Response:
             OutputMessageItem(
                 content=[OutputMessageText(text=text)],
                 status="completed",
+            )
+        ],
+    )
+
+
+def _content_filter_response(model: str = "mock") -> Response:
+    """A provider's policy block: a 200 response with nothing usable in it."""
+    return Response(
+        model=model,
+        status="incomplete",
+        incomplete_details=IncompleteDetails(reason="content_filter"),
+        output=[
+            OutputMessageItem(
+                content=[OutputMessageRefusal(refusal="Blocked by policy.")],
+                status="incomplete",
             )
         ],
     )
@@ -731,6 +748,72 @@ class TestFallbackMemberRetries:
 
         with pytest.raises(ValueError, match="member"):
             FallbackLLM(primary=primary, litellm_provider="openai")
+
+
+class TestFallbackContentFilter:
+    """
+    A policy block is the case fallback exists for: another model usually
+    answers. It must reach the cascade whatever shape it arrived in, and
+    must not burn the member's retry budget on the way.
+    """
+
+    @pytest.mark.asyncio
+    @patch("grasp_agents.llm.llm.asyncio.sleep", new_callable=AsyncMock)
+    async def test_blocked_response_fails_over_without_retries(
+        self, mock_sleep: AsyncMock
+    ) -> None:
+        # Arrives as a 200 response, not an exception — the shape that used
+        # to reach the caller as an output-less "success".
+        primary = StubLLM(
+            model_name="primary",
+            response=_content_filter_response(),
+            retry_policy=RetryPolicy(api_retries=3, validation_retries=3),
+        )
+        fallback = StubLLM(model_name="fallback", response=_text_response("rescued"))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
+
+        result = await llm.generate_response(_USER_MSG)
+
+        assert result.output_text == "rescued"
+        assert primary.call_count == 1
+        assert mock_sleep.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_blocked_error_fails_over(self) -> None:
+        # The other shape: the provider raised instead of responding.
+        primary = ErrorLLM(
+            model_name="primary",
+            error_to_raise=LlmContentFilterError("flagged for cyber risk"),
+        )
+        fallback = StubLLM(model_name="fallback", response=_text_response("rescued"))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
+
+        assert (await llm.generate_response(_USER_MSG)).output_text == "rescued"
+
+    @pytest.mark.asyncio
+    async def test_every_member_blocked_raises_a_block(self) -> None:
+        """Not a transport error: the caller must see why nothing answered."""
+        primary = StubLLM(model_name="primary", response=_content_filter_response())
+        fallback = StubLLM(model_name="fallback", response=_content_filter_response())
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
+
+        with pytest.raises(LlmContentFilterError):
+            await llm.generate_response(_USER_MSG)
+        assert fallback.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_blocked_stream_fails_over(self) -> None:
+        primary = StubLLM(model_name="primary", response=_content_filter_response())
+        fallback = StubLLM(model_name="fallback", response=_text_response("rescued"))
+        llm = FallbackLLM(primary=primary, fallbacks=(fallback,))
+
+        events = [e async for e in llm.generate_response_stream(_USER_MSG)]
+
+        assert [
+            e.fallback_model for e in events if isinstance(e, ResponseFallback)
+        ] == ["fallback"]
+        completed = [e for e in events if isinstance(e, ResponseCompleted)]
+        assert completed[-1].response.output_text == "rescued"
 
 
 class TestFallbackValidationRetries:

--- a/tests/openai_completions/test_error_mapping.py
+++ b/tests/openai_completions/test_error_mapping.py
@@ -147,3 +147,68 @@ class TestOpenAIQuotaDetection:
         )
         assert isinstance(mapped, LlmRateLimitError)
         assert not isinstance(mapped, LlmQuotaExceededError)
+
+
+class TestOpenAIContentFilterDetection:
+    """
+    One policy block reaches the SDK in several shapes. All of them must
+    map to the same type, or the same block behaves differently depending
+    on whether the call was streamed.
+    """
+
+    def test_streamed_block_maps_to_content_filter(self) -> None:
+        # An error frame inside a 200 SSE stream: no status, and the body
+        # carries no code — only the message identifies the block.
+        err = openai.APIError(
+            message=(
+                "This content was flagged for possible cybersecurity risk. "
+                "If this seems wrong, try rephrasing your request."
+            ),
+            request=_REQUEST,
+            body=None,
+        )
+        mapped = map_api_error(err)
+        assert isinstance(mapped, LlmContentFilterError)
+        assert not isinstance(mapped, LlmApiError)
+
+    def test_invalid_prompt_status_maps_to_content_filter(self) -> None:
+        # The non-streamed shape of the same block: a 400 that the generic
+        # mapping would bury as a programmer bug.
+        mapped = map_api_error(
+            _status_error(400, body={"code": "invalid_prompt", "type": None})
+        )
+        assert isinstance(mapped, LlmContentFilterError)
+        assert mapped.code == "invalid_prompt"
+
+    def test_azure_content_management_policy_maps(self) -> None:
+        response = httpx.Response(400, request=_REQUEST)
+        err = openai.APIStatusError(
+            "The response was filtered due to the prompt triggering Azure "
+            "OpenAI's content management policy.",
+            response=response,
+            body=None,
+        )
+        assert isinstance(map_api_error(err), LlmContentFilterError)
+
+    def test_block_message_carries_the_provider_explanation(self) -> None:
+        err = openai.APIError(
+            message="This content was flagged. Join the cyber program.",
+            request=_REQUEST,
+            body=None,
+        )
+        assert "Join the cyber program." in str(map_api_error(err))
+
+    def test_rate_limit_quoting_a_policy_is_not_a_block(self) -> None:
+        # The message is only trusted on codes a block can arrive under.
+        mapped = map_api_error(
+            openai.APIStatusError(
+                "Rate limit reached; see our usage policy.",
+                response=httpx.Response(429, request=_REQUEST),
+                body=None,
+            )
+        )
+        assert isinstance(mapped, LlmRateLimitError)
+        assert not isinstance(mapped, LlmContentFilterError)
+
+    def test_plain_bad_request_is_not_a_block(self) -> None:
+        assert not isinstance(map_api_error(_status_error(400)), LlmContentFilterError)

--- a/tests/test_utils_validation.py
+++ b/tests/test_utils_validation.py
@@ -1,0 +1,93 @@
+"""Parsing LLM output into JSON/Python values, and the fence handling."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+
+from grasp_agents.types.errors import (
+    JSONSchemaValidationError,
+    PyJSONStringParsingError,
+)
+from grasp_agents.utils.validation import (
+    parse_json_or_py_string,
+    validate_obj_from_json_or_py_string,
+)
+
+
+class TestFenceStripping:
+    """
+    Only a fence wrapping the whole payload is markup; one anywhere else is
+    content, and removing it rewrites the model's answer.
+    """
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            '```json\n{"a": 1}\n```',
+            "```\n{'a': 1}\n```",  # no language tag
+            '  \n```json\n{"a": 1}\n```  \n',  # padded
+            '```json\n{"a": 1}```',  # close on the content line
+            '```json\r\n{"a": 1}\r\n```',  # CRLF
+            '```json   \n{"a": 1}\n   ```',  # padding around the fences
+        ],
+    )
+    def test_wrapping_fence_is_stripped(self, raw: str) -> None:
+        assert parse_json_or_py_string(raw) == {"a": 1}
+
+    def test_fence_inside_a_string_value_survives(self) -> None:
+        """The regression: this used to parse, one code block lighter."""
+        raw = '{"code": "```python\\nprint(1)\\n```"}'
+
+        assert parse_json_or_py_string(raw) == {"code": "```python\nprint(1)\n```"}
+
+    def test_wrapping_fence_stripped_without_touching_an_inner_one(self) -> None:
+        raw = '```json\n{"code": "```py\\nx\\n```"}\n```'
+
+        assert parse_json_or_py_string(raw) == {"code": "```py\nx\n```"}
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            'Here you go:\n```json\n{"a": 1}\n```',
+            '```json\n{"a": 1}\n```\nHope that helps!',
+        ],
+    )
+    def test_fence_amid_prose_is_left_alone(self, raw: str) -> None:
+        """Neither half is parseable on its own — fail rather than guess."""
+        with pytest.raises(PyJSONStringParsingError):
+            parse_json_or_py_string(raw)
+
+    def test_prose_around_a_fence_still_parses_from_a_substring(self) -> None:
+        raw = 'Here you go:\n```json\n{"a": 1}\n```'
+
+        assert parse_json_or_py_string(raw, from_substring=True) == {"a": 1}
+
+    def test_stripping_can_be_disabled(self) -> None:
+        with pytest.raises(PyJSONStringParsingError):
+            parse_json_or_py_string(
+                '```json\n{"a": 1}\n```', strip_language_markdown=False
+            )
+
+
+class TestValidateFromString:
+    def test_fenced_output_validates_against_a_schema(self) -> None:
+        class M(BaseModel):
+            a: int
+
+        assert validate_obj_from_json_or_py_string(
+            '```json\n{"a": 1}\n```', schema=M
+        ) == M(a=1)
+
+    def test_str_schema_keeps_the_payload_verbatim(self) -> None:
+        """A str output is the answer, not a container — fences are content."""
+        raw = '```json\n{"a": 1}\n```'
+
+        assert validate_obj_from_json_or_py_string(raw, schema=str) == raw
+
+    def test_unparseable_output_raises_schema_error(self) -> None:
+        class M(BaseModel):
+            a: int
+
+        with pytest.raises(JSONSchemaValidationError):
+            validate_obj_from_json_or_py_string("not json at all", schema=M)

--- a/tests/test_utils_validation.py
+++ b/tests/test_utils_validation.py
@@ -63,6 +63,27 @@ class TestFenceStripping:
 
         assert parse_json_or_py_string(raw, from_substring=True) == {"a": 1}
 
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "```python x=1``` ```java y=5```",  # no newline after the tag
+            "```python\nx=1\n```\n```java\ny=5\n```",
+            '```json\n{"a": 1}\n```\n```json\n{"b": 2}\n```',
+        ],
+    )
+    def test_several_sibling_blocks_fail_loudly_quoting_the_original(
+        self, raw: str
+    ) -> None:
+        """
+        Sibling blocks are not one payload, so nothing here is parseable.
+        What matters is that the caller is shown what the model actually
+        said rather than a half-stripped rewrite of it.
+        """
+        with pytest.raises(PyJSONStringParsingError) as exc_info:
+            parse_json_or_py_string(raw)
+
+        assert raw in str(exc_info.value)
+
     def test_stripping_can_be_disabled(self) -> None:
         with pytest.raises(PyJSONStringParsingError):
             parse_json_or_py_string(

--- a/uv.lock
+++ b/uv.lock
@@ -1181,7 +1181,7 @@ wheels = [
 
 [[package]]
 name = "grasp-agents"
-version = "1.0.27"
+version = "1.0.28"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
# Content-filter error handling + code-fence stripping

Two related fixes to how provider content filters and fenced model output are
handled.

## Content-filter blocks are now one typed error

A policy block reached the framework in four shapes, each behaving differently:
a `400 invalid_prompt` (deterministic, failed over at once), an error frame
inside a 200 SSE stream (classified *transient*, so retried with backoff
first), the SDK's `.parse()` finish-reason error, and — on Anthropic — no
error at all. The same block therefore behaved differently depending on
whether the call was streamed.

All of them now map to `LlmContentFilterError`, which carries the provider's
own explanation and, where one is given, its code or policy category
(`invalid_prompt`, `cyber`, …). It is never retried — the same request is
blocked again — but it does advance a `FallbackLLM` to the next model, which
is the recovery both OpenAI and Anthropic recommend. Detection is shared
across the OpenAI (Responses and Completions), Anthropic, Gemini and LiteLLM
mappings.

### Breaking

A response normalized to `incomplete_details.reason == "content_filter"` now
**raises** instead of being returned.

Previously an Anthropic refusal (`stop_reason: "refusal"`, delivered as HTTP
200 with empty `content`) returned a response with no output items. The turn
added nothing to the transcript, so the next request was byte-identical and
the agent looped until `max_turns`; with an output schema it instead failed
schema validation, reporting the filter's decision as the model returning
malformed output.

A refusal the model *wrote* is unchanged — it carries text the agent can read
and correct course from, so it still logs a warning and flows through.

Anthropic's `stop_details` is now normalized: the explanation becomes an
`OutputMessageRefusal` part on the message the classifier interrupted (one
assistant message per turn, matching the other providers), and the policy
category lands in `Response.provider_specific_fields["refusal_category"]`.

## Fences are stripped only when they wrap the whole payload

Output validation stripped **every** ` ``` ` in the string. A structured answer
whose string values contained a code block was silently rewritten:

```
{"code": "```python\nprint(1)\n```"}   ->   {"code": "print(1)\n"}
```

The result still parses, so the corruption was invisible. Stripping is now
anchored to a fence wrapping the entire payload; a fence mid-message is
content and is left alone. This also fixes two inputs the old pattern mangled
outright — CRLF line endings, and a space after the language tag, both of
which left a stray `json` in the payload and made the response unparseable.

Tool-call arguments now go through the same rule, so validation and execution
no longer disagree about the same string.

## Also

- A response carrying no output items logs a warning; that state is otherwise
  invisible from the outside and looks like the agent silently looping.

## Tests

2821 passing. New coverage for the per-provider error-shape mapping, Anthropic
refusal conversion (before any output and mid-stream, on both the streaming
and non-streaming paths), fallback-cascade behavior on a block, and fence
stripping including sibling code blocks.

